### PR TITLE
Add Go verifiers for contest 1310

### DIFF
--- a/1000-1999/1300-1399/1310-1319/1310/verifierA.go
+++ b/1000-1999/1300-1399/1310-1319/1310/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refA")
+	cmd := exec.Command("go", "build", "-o", tmp, "1310A.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	a := make([]int, n)
+	t := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(5) + 1
+		t[i] = rng.Intn(5) + 1
+	}
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, n)
+	for i, v := range a {
+		if i > 0 {
+			fmt.Fprint(&buf, " ")
+		}
+		fmt.Fprint(&buf, v)
+	}
+	fmt.Fprintln(&buf)
+	for i, v := range t {
+		if i > 0 {
+			fmt.Fprint(&buf, " ")
+		}
+		fmt.Fprint(&buf, v)
+	}
+	fmt.Fprintln(&buf)
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/bin")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err1 := runProg(ref, test)
+		if err1 != nil {
+			fmt.Fprintln(os.Stderr, "reference run error:", err1)
+			os.Exit(1)
+		}
+		got, err2 := runProg(target, test)
+		if err2 != nil {
+			fmt.Fprintf(os.Stderr, "test %d: execution error: %v\n", i+1, err2)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1310/verifierB.go
+++ b/1000-1999/1300-1399/1310-1319/1310/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refB")
+	cmd := exec.Command("go", "build", "-o", tmp, "1310B.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	tot := 1 << n
+	k := rng.Intn(tot + 1)
+	fav := rng.Perm(tot)[:k]
+	sort.Ints(fav)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d\n", n, k)
+	for i, v := range fav {
+		if i > 0 {
+			fmt.Fprint(&buf, " ")
+		}
+		fmt.Fprint(&buf, v+1)
+	}
+	fmt.Fprintln(&buf)
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/bin")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1310/verifierC.go
+++ b/1000-1999/1300-1399/1310-1319/1310/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refC")
+	cmd := exec.Command("go", "build", "-o", tmp, "1310C.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(n) + 1
+	k := rng.Intn(5) + 1
+	s := randString(rng, n)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d %d\n%s\n", n, m, k, s)
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/bin")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1310/verifierD.go
+++ b/1000-1999/1300-1399/1310-1319/1310/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refD")
+	cmd := exec.Command("go", "build", "-o", tmp, "1310D.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(3) + 2
+	k := 2 * (rng.Intn(3) + 1)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				fmt.Fprint(&buf, " ")
+			}
+			fmt.Fprint(&buf, rng.Intn(10)+1)
+		}
+		fmt.Fprintln(&buf)
+	}
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/bin")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1310/verifierE.go
+++ b/1000-1999/1300-1399/1310-1319/1310/verifierE.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refE")
+	cmd := exec.Command("go", "build", "-o", tmp, "1310E.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d\n", n, k)
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/bin")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1310/verifierF.go
+++ b/1000-1999/1300-1399/1310-1319/1310/verifierF.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refF")
+	cmd := exec.Command("go", "build", "-o", tmp, "1310F.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	t := rng.Intn(4) + 1
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		a := rng.Uint64()%100 + 1
+		b := rng.Uint64()%100 + 1
+		fmt.Fprintf(&buf, "%d %d\n", a, b)
+	}
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/bin")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go, verifierB.go, verifierC.go, verifierD.go, verifierE.go and verifierF.go
- each verifier compiles the official solution, generates 100 random test cases and compares outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885c6eac6988324b5357eeb9f56631f