### PR TITLE
Add verifiers for contest 1315

### DIFF
--- a/1000-1999/1300-1399/1310-1319/1315/verifierA.go
+++ b/1000-1999/1300-1399/1310-1319/1315/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedA(a, b, x, y int) int {
+	left := x * b
+	right := (a - x - 1) * b
+	top := y * a
+	bottom := (b - y - 1) * a
+	ans := left
+	if right > ans {
+		ans = right
+	}
+	if top > ans {
+		ans = top
+	}
+	if bottom > ans {
+		ans = bottom
+	}
+	return ans
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		a := rand.Intn(10000) + 1
+		b := rand.Intn(10000) + 1
+		if a+b <= 2 {
+			a = 2
+			b = 1
+		}
+		x := rand.Intn(a)
+		y := rand.Intn(b)
+		input := fmt.Sprintf("1\n%d %d %d %d\n", a, b, x, y)
+		expect := expectedA(a, b, x, y)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != fmt.Sprint(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1315/verifierB.go
+++ b/1000-1999/1300-1399/1310-1319/1315/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedB(aCost, bCost, p int64, s string) int {
+	n := len(s)
+	var cost int64
+	var last byte
+	ans := 1
+	for i := n - 2; i >= 0; i-- {
+		if s[i] != last {
+			if s[i] == 'A' {
+				cost += aCost
+			} else {
+				cost += bCost
+			}
+			last = s[i]
+		}
+		if cost > p {
+			ans = i + 2
+			break
+		}
+	}
+	if cost <= p {
+		ans = 1
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	letters := []byte{'A', 'B'}
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(18) + 2
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteByte(letters[rand.Intn(2)])
+		}
+		s := sb.String()
+		a := rand.Intn(10) + 1
+		b := rand.Intn(10) + 1
+		p := rand.Intn(20) + 1
+		input := fmt.Sprintf("1\n%d %d %d\n%s\n", a, b, p, s)
+		expect := expectedB(int64(a), int64(b), int64(p), s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != fmt.Sprint(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1315/verifierC.go
+++ b/1000-1999/1300-1399/1310-1319/1315/verifierC.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedC(b []int) string {
+	n := len(b)
+	used := make([]bool, 2*n+1)
+	for _, v := range b {
+		if v >= 1 && v <= 2*n {
+			used[v] = true
+		}
+	}
+	rem := make([]int, 0, 2*n)
+	for v := 1; v <= 2*n; v++ {
+		if !used[v] {
+			rem = append(rem, v)
+		}
+	}
+	a := make([]int, 2*n)
+	for i := 0; i < n; i++ {
+		a[2*i] = b[i]
+		idx := -1
+		for j, rv := range rem {
+			if rv > b[i] {
+				idx = j
+				break
+			}
+		}
+		if idx == -1 {
+			return "-1"
+		}
+		a[2*i+1] = rem[idx]
+		rem = append(rem[:idx], rem[idx+1:]...)
+	}
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(5) + 1
+		used := make(map[int]bool)
+		b := make([]int, n)
+		for j := 0; j < n; j++ {
+			for {
+				v := rand.Intn(2*n) + 1
+				if !used[v] {
+					used[v] = true
+					b[j] = v
+					break
+				}
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+		for j, v := range b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := expectedC(b)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add random-test solution verifiers for contest 1315 problems A, B, and C

## Testing
- `go build 1000-1999/1300-1399/1310-1319/1315/verifierA.go`
- `go build 1000-1999/1300-1399/1310-1319/1315/verifierB.go`
- `go build 1000-1999/1300-1399/1310-1319/1315/verifierC.go`


------
https://chatgpt.com/codex/tasks/task_e_6885c9a731448324a9081844d0216499