### PR TITLE
Add verifiers for contest 1316

### DIFF
--- a/1000-1999/1300-1399/1310-1319/1316/verifierA.go
+++ b/1000-1999/1300-1399/1310-1319/1316/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, m int64, arr []int64) int64 {
+	var sum int64
+	for _, v := range arr {
+		sum += v
+	}
+	if sum < m {
+		return sum
+	}
+	return m
+}
+
+func generateCase(rng *rand.Rand) (string, int, int64, []int64) {
+	n := rng.Intn(20) + 1
+	m := rng.Int63n(100000) + 1
+	arr := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Int63n(m + 1)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), n, m, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, n, m, arr := generateCase(rng)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 0 {
+			fmt.Fprintf(os.Stderr, "case %d failed: no output\ninput:%s", t+1, input)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output\ninput:%soutput:%s\n", t+1, input, out)
+			os.Exit(1)
+		}
+		exp := expected(n, m, arr)
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:%s", t+1, exp, val, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1316/verifierB.go
+++ b/1000-1999/1300-1399/1310-1319/1316/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return fmt.Sprintf("1\n%d\n%s\n", n, string(b))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refB")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1316B.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d candidate error: %v\ninput:%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d reference error: %v\ninput:%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1316/verifierC.go
+++ b/1000-1999/1300-1399/1310-1319/1316/verifierC.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func firstNotDivisible(arr []int64, p int64) int {
+	for i, v := range arr {
+		if v%p != 0 {
+			return i
+		}
+	}
+	return len(arr) - 1
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	primes := []int64{2, 3, 5, 7, 11, 13}
+	p := primes[rng.Intn(len(primes))]
+	fa := make([]int64, n)
+	fb := make([]int64, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, p))
+	good := false
+	for i := 0; i < n; i++ {
+		fa[i] = int64(rng.Intn(20) + 1)
+		if fa[i]%p != 0 {
+			good = true
+		}
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(fa[i]))
+	}
+	if !good {
+		fa[0]++
+		sb.Reset()
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, p))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(fa[i]))
+		}
+	}
+	sb.WriteByte('\n')
+	good = false
+	for i := 0; i < m; i++ {
+		fb[i] = int64(rng.Intn(20) + 1)
+		if fb[i]%p != 0 {
+			good = true
+		}
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(fb[i]))
+	}
+	if !good {
+		fb[0]++
+		sb.Reset()
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, p))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(fa[i]))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(fb[i]))
+		}
+	}
+	sb.WriteByte('\n')
+	expect := firstNotDivisible(fa, p) + firstNotDivisible(fb, p)
+	input := "1\n" + sb.String()
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := generateCase(rng)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 0 {
+			fmt.Fprintf(os.Stderr, "case %d failed: no output\ninput:%s", t+1, input)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(fields[0])
+		if err != nil || val != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", t+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1316/verifierD.go
+++ b/1000-1999/1300-1399/1310-1319/1316/verifierD.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ x, y int }
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateBoard(rng *rand.Rand, n int) [][]byte {
+	board := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		board[i] = make([]byte, n)
+		for j := 0; j < n; j++ {
+			opts := []byte{'X'}
+			if i > 0 {
+				opts = append(opts, 'U')
+			}
+			if i+1 < n {
+				opts = append(opts, 'D')
+			}
+			if j > 0 {
+				opts = append(opts, 'L')
+			}
+			if j+1 < n {
+				opts = append(opts, 'R')
+			}
+			board[i][j] = opts[rng.Intn(len(opts))]
+		}
+	}
+	board[rng.Intn(n)][rng.Intn(n)] = 'X'
+	return board
+}
+
+func follow(board [][]byte, r, c int) pair {
+	n := len(board)
+	visited := make(map[pair]bool)
+	for step := 0; step < n*n+5; step++ {
+		if board[r][c] == 'X' {
+			return pair{r + 1, c + 1}
+		}
+		p := pair{r, c}
+		if visited[p] {
+			return pair{-1, -1}
+		}
+		visited[p] = true
+		switch board[r][c] {
+		case 'U':
+			r--
+		case 'D':
+			r++
+		case 'L':
+			c--
+		case 'R':
+			c++
+		}
+	}
+	return pair{-1, -1}
+}
+
+func computePairs(board [][]byte) [][]pair {
+	n := len(board)
+	res := make([][]pair, n)
+	for i := 0; i < n; i++ {
+		res[i] = make([]pair, n)
+		for j := 0; j < n; j++ {
+			res[i][j] = follow(board, i, j)
+		}
+	}
+	return res
+}
+
+func pairsToInput(p [][]pair) string {
+	n := len(p)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d %d", p[i][j].x, p[i][j].y))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func parseBoard(out string, n int) ([][]byte, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < n+1 {
+		return nil, fmt.Errorf("not enough lines")
+	}
+	if strings.TrimSpace(lines[0]) != "VALID" {
+		return nil, fmt.Errorf("expected VALID")
+	}
+	board := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := strings.TrimSpace(lines[i+1])
+		if len(row) != n {
+			return nil, fmt.Errorf("row %d length", i)
+		}
+		for j := 0; j < n; j++ {
+			ch := row[j]
+			switch ch {
+			case 'U', 'D', 'L', 'R', 'X':
+			default:
+				return nil, fmt.Errorf("invalid char")
+			}
+		}
+		board[i] = []byte(row)
+	}
+	return board, nil
+}
+
+func check(candidate string, input string, expected [][]pair) error {
+	out, err := runBinary(candidate, input)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	if strings.TrimSpace(lines[0]) != "VALID" {
+		return fmt.Errorf("candidate says INVALID")
+	}
+	n := len(expected)
+	board, err := parseBoard(out, n)
+	if err != nil {
+		return err
+	}
+	pairs := computePairs(board)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if pairs[i][j] != expected[i][j] {
+				return fmt.Errorf("mismatch at %d %d", i, j)
+			}
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, [][]pair) {
+	n := rng.Intn(3) + 1
+	board := generateBoard(rng, n)
+	pairs := computePairs(board)
+	input := pairsToInput(pairs)
+	return input, pairs
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, pairs := generateCase(rng)
+		if err := check(bin, input, pairs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1316/verifierE.go
+++ b/1000-1999/1300-1399/1310-1319/1316/verifierE.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	p := rng.Intn(3) + 1
+	if p > 7 {
+		p = 7
+	}
+	if p >= n {
+		p = n - 1
+	}
+	k := rng.Intn(n-p) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, p, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(20) + 1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		for j := 0; j < p; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(rng.Intn(20) + 1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refE")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1316E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d candidate error: %v\ninput:%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d reference error: %v\ninput:%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1310-1319/1316/verifierF.go
+++ b/1000-1999/1300-1399/1310-1319/1316/verifierF.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(20) + 1))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		idx := rng.Intn(n) + 1
+		val := rng.Intn(20) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", idx, val))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refF")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1316F.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d candidate error: %v\ninput:%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d reference error: %v\ninput:%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for all problems in contest 1316
- each verifier generates 100 random tests and checks a candidate binary
- some verifiers rely on the existing solution as reference

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6885ca3345cc8324958f752f49ee40cf