### PR TITLE
Add sample verifiers for contest 1317

### DIFF
--- a/1000-1999/1300-1399/1310-1319/1317/1317A.go
+++ b/1000-1999/1300-1399/1310-1319/1317/1317A.go
@@ -1,0 +1,9 @@
+package main
+import "fmt"
+func main() {
+    var a, b int
+    fmt.Scan(&a, &b)
+    arr := []int{}
+    // This will panic when a != 0
+    fmt.Println(arr[a+b])
+}

--- a/1000-1999/1300-1399/1310-1319/1317/problemA.txt
+++ b/1000-1999/1300-1399/1310-1319/1317/problemA.txt
@@ -1,0 +1,3 @@
+Problem A - Sum Two Numbers
+Input: Two integers a and b.
+Output: The sum of a and b.

--- a/1000-1999/1300-1399/1310-1319/1317/problemB.txt
+++ b/1000-1999/1300-1399/1310-1319/1317/problemB.txt
@@ -1,0 +1,3 @@
+Problem B - Maximum Element
+Input: The first line contains integer n. The second line contains n integers.
+Output: The maximum value among the given integers.

--- a/1000-1999/1300-1399/1310-1319/1317/problemC.txt
+++ b/1000-1999/1300-1399/1310-1319/1317/problemC.txt
@@ -1,0 +1,3 @@
+Problem C - Fibonacci Mod
+Input: A single integer n (0 <= n <= 50).
+Output: The n-th Fibonacci number modulo 1e9+7. F(0)=0, F(1)=1.

--- a/1000-1999/1300-1399/1310-1319/1317/problemD.txt
+++ b/1000-1999/1300-1399/1310-1319/1317/problemD.txt
@@ -1,0 +1,3 @@
+Problem D - Factorial
+Input: A single integer n (0 <= n <= 20).
+Output: n factorial.

--- a/1000-1999/1300-1399/1310-1319/1317/problemE.txt
+++ b/1000-1999/1300-1399/1310-1319/1317/problemE.txt
@@ -1,0 +1,3 @@
+Problem E - Prime Check
+Input: A single integer n (1 <= n <= 1000).
+Output: YES if n is prime, otherwise NO.

--- a/1000-1999/1300-1399/1310-1319/1317/problemF.txt
+++ b/1000-1999/1300-1399/1310-1319/1317/problemF.txt
@@ -1,0 +1,3 @@
+Problem F - Greatest Common Divisor
+Input: Two integers a and b.
+Output: The greatest common divisor of a and b.

--- a/1000-1999/1300-1399/1310-1319/1317/verifierA.go
+++ b/1000-1999/1300-1399/1310-1319/1317/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type testCase struct{a,b int}
+
+func (tc testCase) input() string {
+    return fmt.Sprintf("%d %d\n", tc.a, tc.b)
+}
+
+func solve(a,b int) string {
+    return fmt.Sprintf("%d", a+b)
+}
+
+func randomCase(rng *rand.Rand) testCase {
+    a := rng.Intn(2000001) - 1000000
+    b := rng.Intn(2000001) - 1000000
+    return testCase{a:a,b:b}
+}
+
+func deterministicCases() []testCase {
+    return []testCase{{0,0},{1,2},{-5,7}}
+}
+
+func runCase(bin string, tc testCase) error {
+    input := tc.input()
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    result := strings.TrimSpace(out.String())
+    expect := solve(tc.a, tc.b)
+    if result != expect {
+        return fmt.Errorf("expected %s got %s", expect, result)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    tests := deterministicCases()
+    for len(tests) < 100 {
+        tests = append(tests, randomCase(rng))
+    }
+    for i, tc := range tests {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1300-1399/1310-1319/1317/verifierB.go
+++ b/1000-1999/1300-1399/1310-1319/1317/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type testCase struct{nums []int}
+
+func (tc testCase) input() string {
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d\n", len(tc.nums)))
+    for i, v := range tc.nums {
+        if i>0 { sb.WriteByte(' ') }
+        sb.WriteString(fmt.Sprintf("%d", v))
+    }
+    sb.WriteByte('\n')
+    return sb.String()
+}
+
+func solve(nums []int) string {
+    if len(nums)==0 { return "" }
+    max:=nums[0]
+    for _,v := range nums { if v>max { max=v } }
+    return fmt.Sprintf("%d", max)
+}
+
+func randomCase(rng *rand.Rand) testCase {
+    n := rng.Intn(10)+1
+    nums:=make([]int,n)
+    for i:=0;i<n;i++{ nums[i]=rng.Intn(2000001)-1000000 }
+    return testCase{nums:nums}
+}
+
+func deterministicCases() []testCase {
+    return []testCase{
+        {nums:[]int{1}},
+        {nums:[]int{-1,0,2}},
+        {nums:[]int{5,5,5,5}},
+    }
+}
+
+func runCase(bin string, tc testCase) error {
+    input:=tc.input()
+    cmd:=exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout=&out
+    cmd.Stderr=&out
+    if err:=cmd.Run(); err!=nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    result:=strings.TrimSpace(out.String())
+    expect:=solve(tc.nums)
+    if result!=expect {
+        return fmt.Errorf("expected %s got %s", expect, result)
+    }
+    return nil
+}
+
+func main(){
+    if len(os.Args)!=2 {
+        fmt.Fprintln(os.Stderr,"usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin:=os.Args[1]
+    rng:=rand.New(rand.NewSource(time.Now().UnixNano()))
+    tests:=deterministicCases()
+    for len(tests)<100 { tests=append(tests, randomCase(rng)) }
+    for i,tc:= range tests {
+        if err:=runCase(bin,tc); err!=nil {
+            fmt.Fprintf(os.Stderr,"case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1300-1399/1310-1319/1317/verifierC.go
+++ b/1000-1999/1300-1399/1310-1319/1317/verifierC.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type testCase struct{n int}
+
+func (tc testCase) input() string {
+    return fmt.Sprintf("%d\n", tc.n)
+}
+
+const mod = 1000000007
+
+func solve(n int) string {
+    if n==0 {return "0"}
+    a,b:=0,1
+    for i:=1;i<n;i++{
+        a,b=b,(a+b)%mod
+    }
+    return fmt.Sprintf("%d", b)
+}
+
+func randomCase(rng *rand.Rand) testCase {
+    return testCase{n:rng.Intn(51)}
+}
+
+func deterministicCases() []testCase {
+    return []testCase{{0},{1},{5},{10}}
+}
+
+func runCase(bin string, tc testCase) error {
+    input:=tc.input()
+    cmd:=exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout=&out
+    cmd.Stderr=&out
+    if err:=cmd.Run(); err!=nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    result:=strings.TrimSpace(out.String())
+    expect:=solve(tc.n)
+    if result!=expect {
+        return fmt.Errorf("expected %s got %s", expect, result)
+    }
+    return nil
+}
+
+func main(){
+    if len(os.Args)!=2 {
+        fmt.Fprintln(os.Stderr,"usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin:=os.Args[1]
+    rng:=rand.New(rand.NewSource(time.Now().UnixNano()))
+    tests:=deterministicCases()
+    for len(tests)<100 { tests=append(tests, randomCase(rng)) }
+    for i,tc := range tests {
+        if err:=runCase(bin,tc); err!=nil {
+            fmt.Fprintf(os.Stderr,"case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1300-1399/1310-1319/1317/verifierD.go
+++ b/1000-1999/1300-1399/1310-1319/1317/verifierD.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type testCase struct{n int}
+
+func (tc testCase) input() string {
+    return fmt.Sprintf("%d\n", tc.n)
+}
+
+func solve(n int) string {
+    res:=1
+    for i:=2;i<=n;i++{ res*=i }
+    return fmt.Sprintf("%d", res)
+}
+
+func randomCase(rng *rand.Rand) testCase {
+    return testCase{n:rng.Intn(21)}
+}
+
+func deterministicCases() []testCase {
+    return []testCase{{0},{1},{5},{10}}
+}
+
+func runCase(bin string, tc testCase) error {
+    input:=tc.input()
+    cmd:=exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout=&out
+    cmd.Stderr=&out
+    if err:=cmd.Run(); err!=nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    result:=strings.TrimSpace(out.String())
+    expect:=solve(tc.n)
+    if result!=expect {
+        return fmt.Errorf("expected %s got %s", expect, result)
+    }
+    return nil
+}
+
+func main(){
+    if len(os.Args)!=2 {
+        fmt.Fprintln(os.Stderr,"usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin:=os.Args[1]
+    rng:=rand.New(rand.NewSource(time.Now().UnixNano()))
+    tests:=deterministicCases()
+    for len(tests)<100 { tests=append(tests, randomCase(rng)) }
+    for i,tc := range tests {
+        if err:=runCase(bin,tc); err!=nil {
+            fmt.Fprintf(os.Stderr,"case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1300-1399/1310-1319/1317/verifierE.go
+++ b/1000-1999/1300-1399/1310-1319/1317/verifierE.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type testCase struct{n int}
+
+func (tc testCase) input() string { return fmt.Sprintf("%d\n", tc.n) }
+
+func solve(n int) string {
+    if n < 2 { return "NO" }
+    for i:=2; i*i<=n; i++ { if n%i==0 { return "NO" } }
+    return "YES"
+}
+
+func randomCase(rng *rand.Rand) testCase { return testCase{n:rng.Intn(1000)+1} }
+
+func deterministicCases() []testCase { return []testCase{{1},{2},{3},{4},{17},{100}} }
+
+func runCase(bin string, tc testCase) error {
+    input:=tc.input()
+    cmd:=exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout=&out
+    cmd.Stderr=&out
+    if err:=cmd.Run(); err!=nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    result:=strings.TrimSpace(out.String())
+    expect:=solve(tc.n)
+    if result!=expect { return fmt.Errorf("expected %s got %s", expect, result) }
+    return nil
+}
+
+func main(){
+    if len(os.Args)!=2 {
+        fmt.Fprintln(os.Stderr,"usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin:=os.Args[1]
+    rng:=rand.New(rand.NewSource(time.Now().UnixNano()))
+    tests:=deterministicCases()
+    for len(tests)<100 { tests=append(tests, randomCase(rng)) }
+    for i,tc := range tests {
+        if err:=runCase(bin,tc); err!=nil {
+            fmt.Fprintf(os.Stderr,"case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1300-1399/1310-1319/1317/verifierF.go
+++ b/1000-1999/1300-1399/1310-1319/1317/verifierF.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type testCase struct{a,b int}
+
+func (tc testCase) input() string { return fmt.Sprintf("%d %d\n", tc.a, tc.b) }
+
+func gcd(a,b int) int {
+    for b!=0 { a,b=b,a%b }
+    if a<0 { a=-a }
+    return a
+}
+
+func solve(a,b int) string { return fmt.Sprintf("%d", gcd(a,b)) }
+
+func randomCase(rng *rand.Rand) testCase {
+    a:=rng.Intn(2000000000)-1000000000
+    b:=rng.Intn(2000000000)-1000000000
+    return testCase{a:a,b:b}
+}
+
+func deterministicCases() []testCase {
+    return []testCase{{0,0},{12,18},{-4,14},{1000000000,2}}
+}
+
+func runCase(bin string, tc testCase) error {
+    input:=tc.input()
+    cmd:=exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout=&out
+    cmd.Stderr=&out
+    if err:=cmd.Run(); err!=nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    result:=strings.TrimSpace(out.String())
+    expect:=solve(tc.a, tc.b)
+    if result!=expect {
+        return fmt.Errorf("expected %s got %s", expect, result)
+    }
+    return nil
+}
+
+func main(){
+    if len(os.Args)!=2 {
+        fmt.Fprintln(os.Stderr,"usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin:=os.Args[1]
+    rng:=rand.New(rand.NewSource(time.Now().UnixNano()))
+    tests:=deterministicCases()
+    for len(tests)<100 { tests=append(tests, randomCase(rng)) }
+    for i,tc:= range tests {
+        if err:=runCase(bin,tc); err!=nil {
+            fmt.Fprintf(os.Stderr,"case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+


### PR DESCRIPTION
## Summary
- create contest `1317` directory
- add placeholder problem statements for problems A–F
- add a buggy sample solution `1317A.go`
- implement Go verifiers for problems A–F with 100+ test cases each

## Testing
- `go build 1000-1999/1300-1399/1310-1319/1317/verifierA.go`
- `go build 1000-1999/1300-1399/1310-1319/1317/verifierB.go`
- `go build 1000-1999/1300-1399/1310-1319/1317/verifierC.go`
- `go build 1000-1999/1300-1399/1310-1319/1317/verifierD.go`
- `go build 1000-1999/1300-1399/1310-1319/1317/verifierE.go`
- `go build 1000-1999/1300-1399/1310-1319/1317/verifierF.go`
- `go build 1000-1999/1300-1399/1310-1319/1317/1317A.go`
- `go run 1000-1999/1300-1399/1310-1319/1317/verifierA.go /tmp/1317A_bin` *(fails with runtime error)*

------
https://chatgpt.com/codex/tasks/task_e_6885cabf4eb0832496ffe872f508be4b