### PR TITLE
Add placeholder solution for 1331F

### DIFF
--- a/1000-1999/1300-1399/1330-1339/1331/1331F.go
+++ b/1000-1999/1300-1399/1330-1339/1331/1331F.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// TODO: implement the actual algorithm for Codeforces problem 1331F as
+// described in problemF.txt. The statement is missing in this repository,
+// so this placeholder just reads the input string and prints "NO" so the
+// file compiles and the repository builds.
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var s string
+	fmt.Fscan(reader, &s)
+	fmt.Println("NO")
+}


### PR DESCRIPTION
## Summary
- add missing file `1331F.go`
- provide placeholder implementation for problem F to ensure repository builds

## Testing
- `go build 1000-1999/1300-1399/1330-1339/1331/1331F.go`

------
https://chatgpt.com/codex/tasks/task_e_6885cca9a40c8324aa9e678b4025bd3b