### PR TITLE
Add verifiers for Codeforces 1324

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1324/verifierA.go
+++ b/1000-1999/1300-1399/1320-1329/1324/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(in, &t)
+	var sb strings.Builder
+	for i := 0; i < t; i++ {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Fscan(in, &arr[j])
+		}
+		parity := arr[0] % 2
+		ok := true
+		for _, v := range arr[1:] {
+			if v%2 != parity {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			sb.WriteString("YES")
+		} else {
+			sb.WriteString("NO")
+		}
+		if i+1 < t {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(rng.Intn(100)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solve(in)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1324/verifierB.go
+++ b/1000-1999/1300-1399/1320-1329/1324/verifierB.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(in, &t)
+	var sb strings.Builder
+	for caseIdx := 0; caseIdx < t; caseIdx++ {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		for i := range arr {
+			fmt.Fscan(in, &arr[i])
+		}
+		seen := make(map[int]int)
+		found := false
+		for i, v := range arr {
+			if idx, ok := seen[v]; ok {
+				if i-idx >= 2 {
+					found = true
+					break
+				}
+			} else {
+				seen[v] = i
+			}
+		}
+		if found {
+			sb.WriteString("YES")
+		} else {
+			sb.WriteString("NO")
+		}
+		if caseIdx+1 < t {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(8) + 3
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(rng.Intn(n) + 1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solve(in)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1324/verifierC.go
+++ b/1000-1999/1300-1399/1320-1329/1324/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(in, &t)
+	var sb strings.Builder
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(in, &s)
+		pos := []int{0}
+		for i, ch := range s {
+			if ch == 'R' {
+				pos = append(pos, i+1)
+			}
+		}
+		pos = append(pos, len(s)+1)
+		maxGap := 0
+		for i := 1; i < len(pos); i++ {
+			gap := pos[i] - pos[i-1]
+			if gap > maxGap {
+				maxGap = gap
+			}
+		}
+		sb.WriteString(fmt.Sprintf("%d", maxGap))
+		if t > 1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	letters := []byte{'L', 'R'}
+	for i := 0; i < t; i++ {
+		n := rng.Intn(20) + 1
+		for j := 0; j < n; j++ {
+			sb.WriteByte(letters[rng.Intn(2)])
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solve(in)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1324/verifierD.go
+++ b/1000-1999/1300-1399/1320-1329/1324/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(in, &n)
+	a := make([]int, n)
+	b := make([]int, n)
+	diff := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &b[i])
+		diff[i] = a[i] - b[i]
+	}
+	sort.Ints(diff)
+	var ans int64
+	for i := 0; i < n; i++ {
+		target := -diff[i]
+		j := sort.Search(n, func(k int) bool { return diff[k] > target })
+		if j < i+1 {
+			j = i + 1
+		}
+		ans += int64(n - j)
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(100) + 1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(100) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solve(in)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1324/verifierE.go
+++ b/1000-1999/1300-1399/1320-1329/1324/verifierE.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, h, l, r int
+	fmt.Fscan(in, &n, &h, &l, &r)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	const negInf = -1 << 60
+	dp := make([][]int, n+1)
+	for i := range dp {
+		dp[i] = make([]int, h)
+		for j := range dp[i] {
+			dp[i][j] = negInf
+		}
+	}
+	dp[0][0] = 0
+	for i := 1; i <= n; i++ {
+		ai := a[i-1]
+		for t := 0; t < h; t++ {
+			if dp[i-1][t] == negInf {
+				continue
+			}
+			nt := (t + ai) % h
+			val := dp[i-1][t]
+			if l <= nt && nt <= r {
+				val++
+			}
+			if val > dp[i][nt] {
+				dp[i][nt] = val
+			}
+			nt = (t + ai - 1) % h
+			val = dp[i-1][t]
+			if l <= nt && nt <= r {
+				val++
+			}
+			if val > dp[i][nt] {
+				dp[i][nt] = val
+			}
+		}
+	}
+	ans := 0
+	for t := 0; t < h; t++ {
+		if dp[n][t] > ans {
+			ans = dp[n][t]
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	h := rng.Intn(10) + 3
+	l := rng.Intn(h)
+	r := l + rng.Intn(h-l)
+	if r < l {
+		r = l
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", n, h, l, r)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(h-1) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solve(in)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1324/verifierF.go
+++ b/1000-1999/1300-1399/1320-1329/1324/verifierF.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(in, &n)
+	val := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		var x int
+		fmt.Fscan(in, &x)
+		if x == 1 {
+			val[i] = 1
+		} else {
+			val[i] = -1
+		}
+	}
+	adj := make([][]int, n+1)
+	for i := 0; i < n-1; i++ {
+		var u, v int
+		fmt.Fscan(in, &u, &v)
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	parent := make([]int, n+1)
+	order := make([]int, 0, n)
+	stack := []int{1}
+	parent[1] = 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, v)
+		for _, u := range adj[v] {
+			if u == parent[v] {
+				continue
+			}
+			parent[u] = v
+			stack = append(stack, u)
+		}
+	}
+	dp := make([]int, n+1)
+	for i := len(order) - 1; i >= 0; i-- {
+		v := order[i]
+		dp[v] = val[v]
+		for _, u := range adj[v] {
+			if u == parent[v] {
+				continue
+			}
+			if dp[u] > 0 {
+				dp[v] += dp[u]
+			}
+		}
+	}
+	up := make([]int, n+1)
+	res := make([]int, n+1)
+	stack = []int{1}
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		res[v] = dp[v] + up[v]
+		for _, u := range adj[v] {
+			if u == parent[v] {
+				continue
+			}
+			tmp := up[v] + dp[v]
+			if dp[u] > 0 {
+				tmp -= dp[u]
+			}
+			if tmp < 0 {
+				tmp = 0
+			}
+			up[u] = tmp
+			stack = append(stack, u)
+		}
+	}
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(res[i]))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(2)))
+	}
+	sb.WriteByte('\n')
+	for i := 2; i <= n; i++ {
+		u := rng.Intn(i-1) + 1
+		fmt.Fprintf(&sb, "%d %d\n", u, i)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solve(in)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 1324 problems A–F
- each verifier runs 100 random tests against a given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885ce93eef483249215b46bc0a52e58