### PR TITLE
Add Go solution verifiers for Codeforces contest 1326

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1326/verifierA.go
+++ b/1000-1999/1300-1399/1320-1329/1326/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1326A.go")
+	bin := filepath.Join(os.TempDir(), "oracle1326A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1\n",
+		"1\n2\n",
+		"2\n1\n3\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(20) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := runCandidate(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := runCandidate(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1300-1399/1320-1329/1326/verifierB.go
+++ b/1000-1999/1300-1399/1320-1329/1326/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1326B.go")
+	bin := filepath.Join(os.TempDir(), "oracle1326B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1\n0\n",
+		"1\n3\n1 -2 3\n",
+		"1\n5\n0 0 0 0 0\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(201)-100)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := runCandidate(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := runCandidate(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1300-1399/1320-1329/1326/verifierC.go
+++ b/1000-1999/1300-1399/1320-1329/1326/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1326C.go")
+	bin := filepath.Join(os.TempDir(), "oracle1326C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"3 1\n1 2 3\n",
+		"5 2\n2 5 1 4 3\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	perm := rand.Perm(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := runCandidate(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := runCandidate(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1300-1399/1320-1329/1326/verifierD1.go
+++ b/1000-1999/1300-1399/1320-1329/1326/verifierD1.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1326D1.go")
+	bin := filepath.Join(os.TempDir(), "oracle1326D1.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\na\n",
+		"1\nabc\n",
+		"1\nabba\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		length := rng.Intn(20) + 1
+		for j := 0; j < length; j++ {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := runCandidate(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := runCandidate(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1300-1399/1320-1329/1326/verifierD2.go
+++ b/1000-1999/1300-1399/1320-1329/1326/verifierD2.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1326D2.go")
+	bin := filepath.Join(os.TempDir(), "oracle1326D2.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\na\n",
+		"1\nabc\n",
+		"1\nabcba\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		length := rng.Intn(50) + 1
+		for j := 0; j < length; j++ {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := runCandidate(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := runCandidate(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1300-1399/1320-1329/1326/verifierE.go
+++ b/1000-1999/1300-1399/1320-1329/1326/verifierE.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1326E.go")
+	bin := filepath.Join(os.TempDir(), "oracle1326E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"3\n1 2 3\n3 2 1\n",
+		"2\n2 1\n1 2\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	p := rand.Perm(n)
+	q := rand.Perm(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	for i, v := range q {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := runCandidate(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := runCandidate(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1300-1399/1320-1329/1326/verifierF1.go
+++ b/1000-1999/1300-1399/1320-1329/1326/verifierF1.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1326F1.go")
+	bin := filepath.Join(os.TempDir(), "oracle1326F1.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"2\n01\n10\n",
+		"3\n011\n101\n110\n",
+	}
+}
+
+func genMatrix(rng *rand.Rand, n int) []string {
+	mat := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if i == j {
+				b[j] = '0'
+			} else {
+				if rng.Intn(2) == 0 {
+					b[j] = '0'
+				} else {
+					b[j] = '1'
+				}
+			}
+		}
+		mat[i] = string(b)
+	}
+	// ensure symmetry
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if mat[i][j] != mat[j][i] {
+				if rng.Intn(2) == 0 {
+					b := []byte(mat[i])
+					b[j] = mat[j][i]
+					mat[i] = string(b)
+				} else {
+					b := []byte(mat[j])
+					b[i] = mat[i][j]
+					mat[j] = string(b)
+				}
+			}
+		}
+	}
+	return mat
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	mat := genMatrix(rng, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		sb.WriteString(mat[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := runCandidate(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := runCandidate(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1300-1399/1320-1329/1326/verifierF2.go
+++ b/1000-1999/1300-1399/1320-1329/1326/verifierF2.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1326F2.go")
+	bin := filepath.Join(os.TempDir(), "oracle1326F2.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"2\n01\n10\n",
+		"3\n011\n101\n110\n",
+	}
+}
+
+func genMatrix(rng *rand.Rand, n int) []string {
+	mat := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if i == j {
+				b[j] = '0'
+			} else if rng.Intn(2) == 0 {
+				b[j] = '0'
+			} else {
+				b[j] = '1'
+			}
+		}
+		mat[i] = string(b)
+	}
+	// ensure symmetry
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if mat[i][j] != mat[j][i] {
+				if rng.Intn(2) == 0 {
+					b := []byte(mat[i])
+					b[j] = mat[j][i]
+					mat[i] = string(b)
+				} else {
+					b := []byte(mat[j])
+					b[i] = mat[i][j]
+					mat[j] = string(b)
+				}
+			}
+		}
+	}
+	return mat
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	mat := genMatrix(rng, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		sb.WriteString(mat[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := runCandidate(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := runCandidate(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1300-1399/1320-1329/1326/verifierG.go
+++ b/1000-1999/1300-1399/1320-1329/1326/verifierG.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1326G.go")
+	bin := filepath.Join(os.TempDir(), "oracle1326G.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n0 0\n",
+		"2\n0 0\n1 1\n1 2\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	coords := make([][2]int, n)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(20)
+		y := rng.Intn(20)
+		coords[i] = [2]int{x, y}
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	for i := 1; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", i, i+1)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := runCandidate(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := runCandidate(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for all problems of contest 1326
- verifiers compile the provided reference solutions and compare them with the candidate binary
- each verifier generates at least 100 test cases (deterministic + random)

## Testing
- `go build 1000-1999/1300-1399/1320-1329/1326/verifierA.go`
- `go build 1000-1999/1300-1399/1320-1329/1326/verifierB.go`
- `go build 1000-1999/1300-1399/1320-1329/1326/verifierC.go`
- `go build 1000-1999/1300-1399/1320-1329/1326/verifierD1.go`
- `go build 1000-1999/1300-1399/1320-1329/1326/verifierD2.go`
- `go build 1000-1999/1300-1399/1320-1329/1326/verifierE.go`
- `go build 1000-1999/1300-1399/1320-1329/1326/verifierF1.go`
- `go build 1000-1999/1300-1399/1320-1329/1326/verifierF2.go`
- `go build 1000-1999/1300-1399/1320-1329/1326/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6885cfac4b8883248a95a81570707390