### PR TITLE
Add Go verifiers for contest 1325

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1325/verifierA.go
+++ b/1000-1999/1300-1399/1320-1329/1325/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int64) int64 {
+	return a / gcd(a, b) * b
+}
+
+func verifyCase(bin string, x int64) error {
+	input := fmt.Sprintf("1\n%d\n", x)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	if len(fields) != 2 {
+		return fmt.Errorf("expected two numbers, got %q", out)
+	}
+	a, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid number %q", fields[0])
+	}
+	b, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid number %q", fields[1])
+	}
+	if gcd(a, b)+lcm(a, b) != x {
+		return fmt.Errorf("GCD+LCM != x for x=%d a=%d b=%d", x, a, b)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		x := rng.Int63n(1_000_000_000-1) + 2
+		if err := verifyCase(bin, x); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1325/verifierB.go
+++ b/1000-1999/1300-1399/1320-1329/1325/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyCase(bin string, arr []int) error {
+	n := len(arr)
+	input := fmt.Sprintf("1\n%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			input += " "
+		}
+		input += strconv.Itoa(v)
+	}
+	input += "\n"
+
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("invalid output %q", out)
+	}
+	m := make(map[int]struct{})
+	for _, v := range arr {
+		m[v] = struct{}{}
+	}
+	if got != len(m) {
+		return fmt.Errorf("expected %d got %d", len(m), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(1000) + 1
+		}
+		if err := verifyCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1325/verifierC.go
+++ b/1000-1999/1300-1399/1320-1329/1325/verifierC.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(n int, edges []edge) []int {
+	inDeg := make([]int, n+1)
+	for _, e := range edges {
+		inDeg[e.u]++
+		inDeg[e.v]++
+	}
+	node := 0
+	for i := 1; i <= n; i++ {
+		if inDeg[i] >= 3 {
+			node = i
+			break
+		}
+	}
+	labels := make([]int, len(edges))
+	for i := range labels {
+		labels[i] = -1
+	}
+	cnt := 0
+	if node != 0 {
+		for i, e := range edges {
+			if e.u == node || e.v == node {
+				labels[i] = cnt
+				cnt++
+			}
+		}
+	}
+	for i := range labels {
+		if labels[i] == -1 {
+			labels[i] = cnt
+			cnt++
+		}
+	}
+	return labels
+}
+
+func verifyCase(bin string, n int, edges []edge) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	outFields := strings.Fields(out)
+	if len(outFields) != n-1 {
+		return fmt.Errorf("expected %d numbers, got %d", n-1, len(outFields))
+	}
+	got := make([]int, n-1)
+	for i, f := range outFields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("invalid number %q", f)
+		}
+		got[i] = v
+	}
+	expect := solveC(n, edges)
+	for i := range expect {
+		if got[i] != expect[i] {
+			return fmt.Errorf("expected %v got %v", expect, got)
+		}
+	}
+	return nil
+}
+
+func genTree(rng *rand.Rand, n int) []edge {
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, edge{p, i})
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 2
+		edges := genTree(rng, n)
+		if err := verifyCase(bin, n, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1325/verifierD.go
+++ b/1000-1999/1300-1399/1320-1329/1325/verifierD.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(u, v int64) []int64 {
+	diff := v - u
+	if diff < 0 || diff&1 == 1 {
+		return []int64{-1}
+	}
+	if diff == 0 {
+		if u == 0 {
+			return []int64{0}
+		}
+		return []int64{1, u}
+	}
+	diff >>= 1
+	if diff&u == 0 {
+		return []int64{2, diff, diff ^ u}
+	}
+	return []int64{3, diff, diff, u}
+}
+
+func verifyCase(bin string, u, v int64) error {
+	input := fmt.Sprintf("%d %d\n", u, v)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	expected := solveD(u, v)
+	if int64(len(fields)) != int64(len(expected)) {
+		return fmt.Errorf("expected %d numbers got %d", len(expected), len(fields))
+	}
+	for i, f := range fields {
+		got, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid number %q", f)
+		}
+		if got != expected[i] {
+			return fmt.Errorf("expected %v got %v", expected, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		u := rng.Int63n(1_000_000_000)
+		diff := rng.Int63n(1_000_000_000)
+		v := u + diff
+		if err := verifyCase(bin, u, v); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1325/verifierE.go
+++ b/1000-1999/1300-1399/1320-1329/1325/verifierE.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyCase(bin string, arr []int) error {
+	n := len(arr)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected, err := run("1325E.go", input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(1000) + 1
+		}
+		if err := verifyCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1325/verifierF.go
+++ b/1000-1999/1300-1399/1320-1329/1325/verifierF.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyCase(bin string, n int, edges [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	input := sb.String()
+	expected, err := run("1325F.go", input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func genGraph(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	mExtra := rng.Intn(n)
+	for i := 0; i < mExtra; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			i--
+			continue
+		}
+		edges = append(edges, [2]int{u, v})
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(15) + 2
+		edges := genGraph(rng, n)
+		if err := verifyCase(bin, n, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add random-test verifiers for problems A–F in contest 1325
- each verifier runs 100 cases and checks output

## Testing
- `go build 1000-1999/1300-1399/1320-1329/1325/verifierA.go`
- `go build 1000-1999/1300-1399/1320-1329/1325/verifierB.go`
- `go build 1000-1999/1300-1399/1320-1329/1325/verifierC.go`
- `go build 1000-1999/1300-1399/1320-1329/1325/verifierD.go`
- `go build 1000-1999/1300-1399/1320-1329/1325/verifierE.go`
- `go build 1000-1999/1300-1399/1320-1329/1325/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885cf2039848324b7bdeb4c5225ce5f