### PR TITLE
Add Go verifiers for Codeforces contest 1327

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1327/verifierA.go
+++ b/1000-1999/1300-1399/1320-1329/1327/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(n, k int) string {
+	if n >= k*k && n%2 == k%2 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	t := 100
+	cases := make([][2]int, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(1000000) + 1
+		k := rand.Intn(1000) + 1
+		cases[i] = [2]int{n, k}
+	}
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", t))
+	for _, c := range cases {
+		input.WriteString(fmt.Sprintf("%d %d\n", c[0], c[1]))
+	}
+	in := input.String()
+
+	var expectedOut strings.Builder
+	for _, c := range cases {
+		expectedOut.WriteString(expected(c[0], c[1]))
+		expectedOut.WriteByte('\n')
+	}
+	want := strings.TrimSpace(expectedOut.String())
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Runtime error: %v\n%s", err, out.String())
+		os.Exit(1)
+	}
+
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	wantLines := strings.Split(want, "\n")
+	if len(gotLines) != len(wantLines) {
+		fmt.Println("Wrong answer: line count mismatch")
+		fmt.Println("Expected:")
+		fmt.Println(want)
+		fmt.Println("Got:")
+		fmt.Println(out.String())
+		os.Exit(1)
+	}
+	for i := range wantLines {
+		if strings.TrimSpace(gotLines[i]) != strings.TrimSpace(wantLines[i]) {
+			fmt.Printf("Wrong answer on case %d: expected %s got %s\n", i+1, wantLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1320-1329/1327/verifierB.go
+++ b/1000-1999/1300-1399/1320-1329/1327/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func solveCase(n int, lists [][]int) (bool, int, int) {
+	used := make([]bool, n+1)
+	unmatched := 0
+	for i := 1; i <= n; i++ {
+		matched := false
+		for _, p := range lists[i-1] {
+			if !used[p] {
+				used[p] = true
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			unmatched = i
+		}
+	}
+	if unmatched == 0 {
+		return false, 0, 0
+	}
+	prince := 0
+	for j := 1; j <= n; j++ {
+		if !used[j] {
+			prince = j
+			break
+		}
+	}
+	return true, unmatched, prince
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(2)
+	t := 100
+	cases := make([][][]int, t)
+	ns := make([]int, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 1
+		ns[i] = n
+		lists := make([][]int, n)
+		for d := 0; d < n; d++ {
+			k := rand.Intn(n + 1)
+			perm := rand.Perm(n)
+			lst := perm[:k]
+			for idx := range lst {
+				lst[idx]++
+			}
+			sort.Ints(lst)
+			lists[d] = append([]int(nil), lst...)
+		}
+		cases[i] = lists
+	}
+
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", t))
+	for idx := 0; idx < t; idx++ {
+		n := ns[idx]
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		lists := cases[idx]
+		for _, lst := range lists {
+			input.WriteString(fmt.Sprintf("%d", len(lst)))
+			for _, v := range lst {
+				input.WriteString(fmt.Sprintf(" %d", v))
+			}
+			input.WriteByte('\n')
+		}
+	}
+	in := input.String()
+
+	var expectedOut strings.Builder
+	for idx := 0; idx < t; idx++ {
+		improve, girl, prince := solveCase(ns[idx], cases[idx])
+		if improve {
+			expectedOut.WriteString("IMPROVE\n")
+			expectedOut.WriteString(fmt.Sprintf("%d %d\n", girl, prince))
+		} else {
+			expectedOut.WriteString("OPTIMAL\n")
+		}
+	}
+	want := strings.TrimSpace(expectedOut.String())
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Runtime error: %v\n%s", err, out.String())
+		os.Exit(1)
+	}
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	wantLines := strings.Split(want, "\n")
+	if len(gotLines) != len(wantLines) {
+		fmt.Println("Wrong answer: line count mismatch")
+		os.Exit(1)
+	}
+	for i := range wantLines {
+		if strings.TrimSpace(gotLines[i]) != strings.TrimSpace(wantLines[i]) {
+			fmt.Printf("Wrong answer on line %d: expected %s got %s\n", i+1, wantLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1320-1329/1327/verifierC.go
+++ b/1000-1999/1300-1399/1320-1329/1327/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expectedPath(n, m int) string {
+	var sb strings.Builder
+	for i := 0; i < n-1; i++ {
+		sb.WriteByte('U')
+	}
+	for i := 0; i < m-1; i++ {
+		sb.WriteByte('L')
+	}
+	for i := 1; i <= n; i++ {
+		if i%2 == 1 {
+			for j := 0; j < m-1; j++ {
+				sb.WriteByte('R')
+			}
+		} else {
+			for j := 0; j < m-1; j++ {
+				sb.WriteByte('L')
+			}
+		}
+		sb.WriteByte('D')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(3)
+	t := 100
+	ns := make([]int, t)
+	ms := make([]int, t)
+	ks := make([]int, t)
+	starts := make([][][2]int, t)
+	ends := make([][][2]int, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(5) + 1
+		k := rand.Intn(5)
+		ns[i], ms[i], ks[i] = n, m, k
+		st := make([][2]int, k)
+		ed := make([][2]int, k)
+		for j := 0; j < k; j++ {
+			st[j] = [2]int{rand.Intn(n) + 1, rand.Intn(m) + 1}
+		}
+		for j := 0; j < k; j++ {
+			ed[j] = [2]int{rand.Intn(n) + 1, rand.Intn(m) + 1}
+		}
+		starts[i] = st
+		ends[i] = ed
+	}
+
+	for idx := 0; idx < t; idx++ {
+		n, m, k := ns[idx], ms[idx], ks[idx]
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for j := 0; j < k; j++ {
+			input.WriteString(fmt.Sprintf("%d %d\n", starts[idx][j][0], starts[idx][j][1]))
+		}
+		for j := 0; j < k; j++ {
+			input.WriteString(fmt.Sprintf("%d %d\n", ends[idx][j][0], ends[idx][j][1]))
+		}
+		in := input.String()
+		wantPath := expectedPath(n, m)
+		want := fmt.Sprintf("%d\n%s\n", len(wantPath), wantPath)
+
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(in)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Runtime error: %v\n%s", err, out.String())
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		want = strings.TrimSpace(want)
+		if got != want {
+			fmt.Printf("Wrong answer on test %d\nExpected:\n%s\nGot:\n%s\n", idx+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1320-1329/1327/verifierD.go
+++ b/1000-1999/1300-1399/1320-1329/1327/verifierD.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func divisors(n int) []int {
+	ds := []int{}
+	for i := 1; i*i <= n; i++ {
+		if n%i == 0 {
+			ds = append(ds, i)
+			if i != n/i {
+				ds = append(ds, n/i)
+			}
+		}
+	}
+	sort.Ints(ds)
+	return ds
+}
+
+func solve(n int, p []int, c []int) int {
+	visited := make([]bool, n)
+	ans := n
+
+	for i := 0; i < n; i++ {
+		if visited[i] {
+			continue
+		}
+		var cycle []int
+		j := i
+		for !visited[j] {
+			visited[j] = true
+			cycle = append(cycle, j)
+			j = p[j]
+		}
+		l := len(cycle)
+		ds := divisors(l)
+	NextCycle:
+		for _, d := range ds {
+			if d >= ans {
+				continue
+			}
+			for start := 0; start < d; start++ {
+				color := c[cycle[start]]
+				good := true
+				for pos := start; pos < l; pos += d {
+					if c[cycle[pos]] != color {
+						good = false
+						break
+					}
+				}
+				if good {
+					if d < ans {
+						ans = d
+					}
+					break NextCycle
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(4)
+	t := 100
+	ns := make([]int, t)
+	ps := make([][]int, t)
+	cs := make([][]int, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 1
+		ns[i] = n
+		perm := rand.Perm(n)
+		p := make([]int, n)
+		for j := 0; j < n; j++ {
+			p[j] = perm[j]
+		}
+		colors := make([]int, n)
+		for j := 0; j < n; j++ {
+			colors[j] = rand.Intn(n) + 1
+		}
+		ps[i] = p
+		cs[i] = colors
+	}
+
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := ns[i]
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", ps[i][j]+1))
+		}
+		input.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", cs[i][j]))
+		}
+		input.WriteByte('\n')
+	}
+	in := input.String()
+
+	var expectedOut strings.Builder
+	for i := 0; i < t; i++ {
+		res := solve(ns[i], ps[i], cs[i])
+		expectedOut.WriteString(fmt.Sprintf("%d\n", res))
+	}
+	want := strings.TrimSpace(expectedOut.String())
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Runtime error: %v\n%s", err, out.String())
+		os.Exit(1)
+	}
+
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	wantLines := strings.Split(want, "\n")
+	if len(gotLines) != len(wantLines) {
+		fmt.Println("Wrong answer: line count mismatch")
+		os.Exit(1)
+	}
+	for i := range wantLines {
+		if strings.TrimSpace(gotLines[i]) != strings.TrimSpace(wantLines[i]) {
+			fmt.Printf("Wrong answer on test %d: expected %s got %s\n", i+1, wantLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1320-1329/1327/verifierE.go
+++ b/1000-1999/1300-1399/1320-1329/1327/verifierE.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod int64 = 998244353
+
+func expected(n int) []int64 {
+	pow10 := make([]int64, n+1)
+	pow10[0] = 1
+	for i := 1; i <= n; i++ {
+		pow10[i] = pow10[i-1] * 10 % mod
+	}
+	res := make([]int64, n)
+	for i := 1; i <= n; i++ {
+		if i == n {
+			res[i-1] = 10
+		} else {
+			part1 := int64(2*10*9) * pow10[n-i-1] % mod
+			ans := part1
+			if n-i-1 > 0 {
+				part2 := int64(n-i-1) * 10 % mod
+				part2 = part2 * 9 % mod
+				part2 = part2 * 9 % mod
+				part2 = part2 * pow10[n-i-2] % mod
+				ans = (ans + part2) % mod
+			}
+			res[i-1] = ans
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(5)
+	t := 100
+	for idx := 0; idx < t; idx++ {
+		n := rand.Intn(50) + 1
+		wantArr := expected(n)
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input.String())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n%s", idx+1, err, out.String())
+			os.Exit(1)
+		}
+		gotLines := strings.Fields(strings.TrimSpace(out.String()))
+		if len(gotLines) != n {
+			fmt.Printf("Wrong answer on test %d: expected %d numbers got %d\n", idx+1, n, len(gotLines))
+			os.Exit(1)
+		}
+		for i := 0; i < n; i++ {
+			if gotLines[i] != fmt.Sprint(wantArr[i]) {
+				fmt.Printf("Wrong answer on test %d position %d: expected %d got %s\n", idx+1, i+1, wantArr[i], gotLines[i])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1320-1329/1327/verifierF.go
+++ b/1000-1999/1300-1399/1320-1329/1327/verifierF.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod int64 = 998244353
+
+func solve(n, k, m int, L, R, X []int) int64 {
+	ans := int64(1)
+	for bit := 0; bit < k; bit++ {
+		diff := make([]int, n+2)
+		left := make([]int, n+1)
+		zeroSegL := make([]int, 0)
+		zeroSegR := make([]int, 0)
+		for i := 0; i < m; i++ {
+			if (X[i]>>bit)&1 == 1 {
+				diff[L[i]]++
+				diff[R[i]+1]--
+			} else {
+				if left[R[i]] < L[i] {
+					left[R[i]] = L[i]
+				}
+				zeroSegL = append(zeroSegL, L[i])
+				zeroSegR = append(zeroSegR, R[i])
+			}
+		}
+		forced := make([]bool, n+1)
+		prefOnes := make([]int, n+1)
+		cur := 0
+		for i := 1; i <= n; i++ {
+			cur += diff[i]
+			if cur > 0 {
+				forced[i] = true
+				prefOnes[i] = prefOnes[i-1] + 1
+			} else {
+				prefOnes[i] = prefOnes[i-1]
+			}
+		}
+		valid := true
+		for idx := range zeroSegL {
+			l := zeroSegL[idx]
+			r := zeroSegR[idx]
+			if prefOnes[r]-prefOnes[l-1] == r-l+1 {
+				valid = false
+				break
+			}
+			if left[r] < l {
+				left[r] = l
+			}
+		}
+		if !valid {
+			ans = 0
+			break
+		}
+		dp := make([]int64, n+1)
+		dp[0] = 1
+		pointer := 0
+		sumValid := int64(1)
+		requirement := 0
+		for i := 1; i <= n; i++ {
+			validPrev := sumValid
+			if !forced[i] {
+				dp[i] = validPrev % mod
+			}
+			sumValid = (sumValid + dp[i]) % mod
+			if left[i] > requirement {
+				requirement = left[i]
+			}
+			for pointer < requirement {
+				sumValid -= dp[pointer]
+				sumValid %= mod
+				if sumValid < 0 {
+					sumValid += mod
+				}
+				pointer++
+			}
+		}
+		ans = ans * (sumValid % mod) % mod
+	}
+	return ans % mod
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(6)
+	t := 100
+	for idx := 0; idx < t; idx++ {
+		n := rand.Intn(6) + 1
+		k := rand.Intn(4) + 1
+		m := rand.Intn(6)
+		L := make([]int, m)
+		R := make([]int, m)
+		X := make([]int, m)
+		for i := 0; i < m; i++ {
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			L[i] = l
+			R[i] = r
+			X[i] = rand.Intn(1 << k)
+		}
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d %d\n", n, k, m))
+		for i := 0; i < m; i++ {
+			input.WriteString(fmt.Sprintf("%d %d %d\n", L[i], R[i], X[i]))
+		}
+		want := fmt.Sprintf("%d\n", solve(n, k, m, L, R, X))
+
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input.String())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n%s", idx+1, err, out.String())
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != strings.TrimSpace(want) {
+			fmt.Printf("Wrong answer on test %d\nExpected: %s\nGot: %s\n", idx+1, strings.TrimSpace(want), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1320-1329/1327/verifierG.go
+++ b/1000-1999/1300-1399/1320-1329/1327/verifierG.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const alphabet = 14
+
+type node struct {
+	next [alphabet]int
+	fail int
+	val  int64
+}
+
+func newNode() node {
+	n := node{fail: 0, val: 0}
+	for i := 0; i < alphabet; i++ {
+		n.next[i] = -1
+	}
+	return n
+}
+
+func insert(trie *[]node, s string, cost int64) {
+	cur := 0
+	for i := 0; i < len(s); i++ {
+		idx := int(s[i] - 'a')
+		if (*trie)[cur].next[idx] == -1 {
+			*trie = append(*trie, newNode())
+			(*trie)[cur].next[idx] = len(*trie) - 1
+		}
+		cur = (*trie)[cur].next[idx]
+	}
+	(*trie)[cur].val += cost
+}
+
+func build(trie []node) {
+	queue := make([]int, 0)
+	for c := 0; c < alphabet; c++ {
+		if trie[0].next[c] != -1 {
+			child := trie[0].next[c]
+			trie[child].fail = 0
+			queue = append(queue, child)
+		} else {
+			trie[0].next[c] = 0
+		}
+	}
+	for head := 0; head < len(queue); head++ {
+		v := queue[head]
+		f := trie[v].fail
+		trie[v].val += trie[f].val
+		for c := 0; c < alphabet; c++ {
+			if trie[v].next[c] != -1 {
+				child := trie[v].next[c]
+				trie[child].fail = trie[f].next[c]
+				queue = append(queue, child)
+			} else {
+				trie[v].next[c] = trie[f].next[c]
+			}
+		}
+	}
+}
+
+func segTransition(trie []node, seg string) ([]int, []int64) {
+	n := len(trie)
+	nxt := make([]int, n)
+	val := make([]int64, n)
+	for s := 0; s < n; s++ {
+		cur := s
+		sum := int64(0)
+		for i := 0; i < len(seg); i++ {
+			ch := int(seg[i] - 'a')
+			cur = trie[cur].next[ch]
+			sum += trie[cur].val
+		}
+		nxt[s] = cur
+		val[s] = sum
+	}
+	return nxt, val
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solve(k int, ts []string, cs []int64, S string) int64 {
+	trie := []node{newNode()}
+	for i := 0; i < k; i++ {
+		insert(&trie, ts[i], cs[i])
+	}
+	build(trie)
+	segments := make([]string, 0)
+	sb := make([]byte, 0, len(S))
+	qm := 0
+	for i := 0; i < len(S); i++ {
+		if S[i] == '?' {
+			segments = append(segments, string(sb))
+			sb = sb[:0]
+			qm++
+		} else {
+			sb = append(sb, S[i])
+		}
+	}
+	segments = append(segments, string(sb))
+	m := qm
+	nStates := len(trie)
+	segNext := make([][]int, len(segments))
+	segVal := make([][]int64, len(segments))
+	for i := 0; i < len(segments); i++ {
+		segNext[i], segVal[i] = segTransition(trie, segments[i])
+	}
+	startState := segNext[0][0]
+	startVal := segVal[0][0]
+	if m == 0 {
+		return startVal
+	}
+	masksByCnt := make([][]int, m+1)
+	for mask := 0; mask < (1 << alphabet); mask++ {
+		cnt := bits.OnesCount(uint(mask))
+		if cnt <= m {
+			masksByCnt[cnt] = append(masksByCnt[cnt], mask)
+		}
+	}
+	maskIdx := make([][]int, m+1)
+	for i := 0; i <= m; i++ {
+		maskIdx[i] = make([]int, 1<<alphabet)
+		for j := range maskIdx[i] {
+			maskIdx[i][j] = -1
+		}
+		for idx, mask := range masksByCnt[i] {
+			maskIdx[i][mask] = idx
+		}
+	}
+	negInf := int64(-1 << 60)
+	dpPrev := make([][]int64, len(masksByCnt[0]))
+	for idx := range dpPrev {
+		dpPrev[idx] = make([]int64, nStates)
+		for j := range dpPrev[idx] {
+			dpPrev[idx][j] = negInf
+		}
+	}
+	dpPrev[maskIdx[0][0]][startState] = startVal
+	for step := 1; step <= m; step++ {
+		dpNext := make([][]int64, len(masksByCnt[step]))
+		for idx := range dpNext {
+			dpNext[idx] = make([]int64, nStates)
+			for j := range dpNext[idx] {
+				dpNext[idx][j] = negInf
+			}
+		}
+		for pIdx, mask := range masksByCnt[step-1] {
+			arr := dpPrev[pIdx]
+			for s := 0; s < nStates; s++ {
+				val := arr[s]
+				if val == negInf {
+					continue
+				}
+				for l := 0; l < alphabet; l++ {
+					if mask&(1<<l) != 0 {
+						continue
+					}
+					newMask := mask | (1 << l)
+					nIdx := maskIdx[step][newMask]
+					if nIdx == -1 {
+						continue
+					}
+					s1 := trie[s].next[l]
+					v1 := val + trie[s1].val
+					s2 := segNext[step][s1]
+					v2 := v1 + segVal[step][s1]
+					if v2 > dpNext[nIdx][s2] {
+						dpNext[nIdx][s2] = v2
+					}
+				}
+			}
+		}
+		dpPrev = dpNext
+	}
+	ans := negInf
+	for _, arr := range dpPrev {
+		for s := 0; s < nStates; s++ {
+			ans = max64(ans, arr[s])
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(7)
+	t := 100
+	for idx := 0; idx < t; idx++ {
+		k := rand.Intn(3) + 1
+		ts := make([]string, k)
+		cs := make([]int64, k)
+		for i := 0; i < k; i++ {
+			length := rand.Intn(3) + 1
+			b := make([]byte, length)
+			for j := range b {
+				b[j] = byte('a' + rand.Intn(alphabet))
+			}
+			ts[i] = string(b)
+			cs[i] = int64(rand.Intn(21) - 10)
+		}
+		lengthS := rand.Intn(8) + 1
+		qm := rand.Intn(min(3, lengthS))
+		qmPositions := rand.Perm(lengthS)[:qm]
+		posMap := make(map[int]bool)
+		for _, p := range qmPositions {
+			posMap[p] = true
+		}
+		b := make([]byte, lengthS)
+		for j := 0; j < lengthS; j++ {
+			if posMap[j] {
+				b[j] = '?'
+			} else {
+				b[j] = byte('a' + rand.Intn(alphabet))
+			}
+		}
+		S := string(b)
+		want := fmt.Sprintf("%d\n", solve(k, ts, cs, S))
+
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", k))
+		for i := 0; i < k; i++ {
+			input.WriteString(fmt.Sprintf("%s %d\n", ts[i], cs[i]))
+		}
+		input.WriteString(fmt.Sprintf("%s\n", S))
+
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input.String())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n%s", idx+1, err, out.String())
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != strings.TrimSpace(want) {
+			fmt.Printf("Wrong answer on test %d\nExpected: %s\nGot: %s\n", idx+1, strings.TrimSpace(want), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Summary
- add verifierA.go through verifierG.go to validate solutions for contest 1327 problems A–G
- each verifier runs 100 randomized tests against a given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go run verifierA.go ./1327A_bin`
- `go run verifierB.go ./1327B_bin`
- `go run verifierC.go ./1327C_bin`
- `go run verifierD.go ./1327D_bin`
- `go run verifierE.go ./1327E_bin`
- `go run verifierF.go ./1327F_bin`
- `go run verifierG.go ./1327G_bin`


------
https://chatgpt.com/codex/tasks/task_e_6885d03867f48324abf439990618f024