### PR TITLE
Add Go verifiers for contest 1328

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1328/verifierA.go
+++ b/1000-1999/1300-1399/1320-1329/1328/verifierA.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(a, b int64) int64 {
+	rem := a % b
+	if rem == 0 {
+		return 0
+	}
+	return b - rem
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		a := rand.Int63n(1_000_000_000) + 1
+		b := rand.Int63n(1_000_000_000) + 1
+		input := fmt.Sprintf("1\n%d %d\n", a, b)
+		expect := fmt.Sprintf("%d", solve(a, b))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n%s", t, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\ninput:\n%s", t, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1328/verifierB.go
+++ b/1000-1999/1300-1399/1320-1329/1328/verifierB.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveB(n int, k int) string {
+	s := make([]byte, n)
+	for i := 0; i < n; i++ {
+		s[i] = 'a'
+	}
+	for i := n - 2; i >= 0; i-- {
+		cnt := n - i - 1
+		if k > cnt {
+			k -= cnt
+		} else {
+			s[i] = 'b'
+			s[n-k] = 'b'
+			break
+		}
+	}
+	return string(s)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(50) + 3
+		maxK := n * (n - 1) / 2
+		k := rand.Intn(maxK) + 1
+		input := fmt.Sprintf("1\n%d %d\n", n, k)
+		expect := solveB(n, k)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n%s", t, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\ninput:\n%s", t, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1328/verifierC.go
+++ b/1000-1999/1300-1399/1320-1329/1328/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveC(x string) (string, string) {
+	n := len(x)
+	a := make([]byte, n)
+	b := make([]byte, n)
+	a[0], b[0] = '1', '1'
+	broken := false
+	for i := 1; i < n; i++ {
+		switch x[i] {
+		case '0':
+			a[i], b[i] = '0', '0'
+		case '1':
+			if !broken {
+				a[i], b[i] = '1', '0'
+				broken = true
+			} else {
+				a[i], b[i] = '0', '1'
+			}
+		case '2':
+			if !broken {
+				a[i], b[i] = '1', '1'
+			} else {
+				a[i], b[i] = '0', '2'
+			}
+		}
+	}
+	return string(a), string(b)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(30) + 1
+		sb := make([]byte, n)
+		sb[0] = '2'
+		for i := 1; i < n; i++ {
+			sb[i] = byte('0' + rand.Intn(3))
+		}
+		x := string(sb)
+		input := fmt.Sprintf("1\n%d\n%s\n", n, x)
+		a, b := solveC(x)
+		expect := strings.TrimSpace(a + "\n" + b)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n%s", t, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected\n%s\ngot\n%s\ninput:\n%s", t, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1328/verifierD.go
+++ b/1000-1999/1300-1399/1320-1329/1328/verifierD.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveD(a []int) (int, []int) {
+	n := len(a)
+	tag := true
+	flag := false
+	for i := 1; i < n; i++ {
+		if a[i] != a[i-1] {
+			tag = false
+		} else {
+			flag = true
+		}
+	}
+	if a[0] == a[n-1] {
+		flag = true
+	}
+	k := 0
+	colors := make([]int, n)
+	if tag {
+		k = 1
+		for i := 0; i < n; i++ {
+			colors[i] = 1
+		}
+	} else if flag {
+		k = 2
+		if n%2 == 0 {
+			for i := 0; i < n; i++ {
+				if i%2 == 0 {
+					colors[i] = 2
+				} else {
+					colors[i] = 1
+				}
+			}
+		} else {
+			op := 1
+			vis := false
+			colors[0] = op + 1
+			for i := 1; i < n; i++ {
+				if !vis && a[i] == a[i-1] {
+					vis = true
+				} else {
+					op ^= 1
+				}
+				colors[i] = op + 1
+			}
+		}
+	} else {
+		if n%2 == 0 {
+			k = 2
+			for i := 0; i < n; i++ {
+				if i%2 == 0 {
+					colors[i] = 2
+				} else {
+					colors[i] = 1
+				}
+			}
+		} else {
+			k = 3
+			op := 1
+			colors[0] = 2
+			for i := 1; i < n-1; i++ {
+				op ^= 1
+				colors[i] = op + 1
+			}
+			colors[n-1] = 3
+		}
+	}
+	return k, colors
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(20) + 3
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(5) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		sb.WriteByte('\n')
+		k, colors := solveD(arr)
+		expect := fmt.Sprintf("%d\n", k)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				expect += " "
+			}
+			expect += fmt.Sprintf("%d", colors[i])
+		}
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n%s", t, err, sb.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected\n%s\ngot\n%s\ninput:\n%s", t, expect, out, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1328/verifierE.go
+++ b/1000-1999/1300-1399/1320-1329/1328/verifierE.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveE(n int, edges [][2]int, queries [][]int) []string {
+	g := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	parent := make([]int, n+1)
+	depth := make([]int, n+1)
+	tin := make([]int, n+1)
+	tout := make([]int, n+1)
+	timer := 0
+	type frame struct{ v, p, idx int }
+	stack := []frame{{1, 0, -1}}
+	for len(stack) > 0 {
+		f := &stack[len(stack)-1]
+		if f.idx == -1 {
+			parent[f.v] = f.p
+			depth[f.v] = depth[f.p] + 1
+			timer++
+			tin[f.v] = timer
+			f.idx = 0
+		}
+		if f.idx < len(g[f.v]) {
+			to := g[f.v][f.idx]
+			f.idx++
+			if to == f.p {
+				continue
+			}
+			stack = append(stack, frame{to, f.v, -1})
+		} else {
+			timer++
+			tout[f.v] = timer
+			stack = stack[:len(stack)-1]
+		}
+	}
+	isAncestor := func(u, v int) bool {
+		return tin[u] <= tin[v] && tout[v] <= tout[u]
+	}
+	res := make([]string, len(queries))
+	for idx, q := range queries {
+		deepest := 1
+		nodes := make([]int, len(q))
+		for i, v := range q {
+			if v != 1 {
+				v = parent[v]
+			}
+			nodes[i] = v
+			if depth[v] > depth[deepest] {
+				deepest = v
+			}
+		}
+		ok := true
+		for _, v := range nodes {
+			if !isAncestor(v, deepest) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			res[idx] = "YES"
+		} else {
+			res[idx] = "NO"
+		}
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(8) + 2
+		edges := make([][2]int, n-1)
+		for i := 2; i <= n; i++ {
+			p := rand.Intn(i-1) + 1
+			edges[i-2] = [2]int{p, i}
+		}
+		m := rand.Intn(5) + 1
+		queries := make([][]int, m)
+		for i := 0; i < m; i++ {
+			k := rand.Intn(n) + 1
+			used := make(map[int]bool)
+			q := make([]int, k)
+			for j := 0; j < k; j++ {
+				v := rand.Intn(n) + 1
+				for used[v] {
+					v = rand.Intn(n) + 1
+				}
+				used[v] = true
+				q[j] = v
+			}
+			queries[i] = q
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		for _, q := range queries {
+			sb.WriteString(fmt.Sprintf("%d", len(q)))
+			for _, v := range q {
+				sb.WriteString(fmt.Sprintf(" %d", v))
+			}
+			sb.WriteByte('\n')
+		}
+		expectLines := solveE(n, edges, queries)
+		expect := strings.Join(expectLines, "\n")
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n%s", t, err, sb.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected\n%s\ngot\n%s\ninput:\n%s", t, expect, out, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1320-1329/1328/verifierF.go
+++ b/1000-1999/1300-1399/1320-1329/1328/verifierF.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func solveF(a []int, k int) int64 {
+	n := len(a)
+	sort.Ints(a)
+	prefix := make([]int64, n+1)
+	for i, v := range a {
+		prefix[i+1] = prefix[i] + int64(v)
+	}
+	ans := int64(1 << 62)
+	i := 0
+	for i < n {
+		j := i
+		for j < n && a[j] == a[i] {
+			j++
+		}
+		x := a[i]
+		cnt := j - i
+		if cnt >= k {
+			return 0
+		}
+		need := k - cnt
+		left := i
+		right := n - j
+		if left >= need {
+			cost := int64(x)*int64(need) - (prefix[left] - prefix[left-need])
+			if cost < ans {
+				ans = cost
+			}
+		}
+		if right >= need {
+			cost := (prefix[j+need] - prefix[j]) - int64(x)*int64(need)
+			if cost < ans {
+				ans = cost
+			}
+		}
+		if left+right >= need {
+			if left < need {
+				leftCost := int64(x)*int64(left) - prefix[left]
+				rightTake := need - left
+				rightCost := (prefix[j+rightTake] - prefix[j]) - int64(x)*int64(rightTake)
+				if leftCost+rightCost < ans {
+					ans = leftCost + rightCost
+				}
+			}
+			if right < need {
+				rightCost := prefix[n] - prefix[j] - int64(x)*int64(right)
+				leftTake := need - right
+				leftCost := int64(x)*int64(leftTake) - (prefix[left] - prefix[left-leftTake])
+				if leftCost+rightCost < ans {
+					ans = leftCost + rightCost
+				}
+			}
+		}
+		i = j
+	}
+	if ans < 0 {
+		ans = 0
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(6)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(n) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(50) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		sb.WriteByte('\n')
+		expect := fmt.Sprintf("%d", solveF(append([]int(nil), arr...), k))
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n%s", t, err, sb.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\ninput:\n%s", t, expect, out, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces contest 1328 problems A–F
- each verifier generates 100+ tests and checks a supplied binary

## Testing
- `go build 1000-1999/1300-1399/1320-1329/1328/verifierA.go`
- `go build 1000-1999/1300-1399/1320-1329/1328/verifierB.go`
- `go build 1000-1999/1300-1399/1320-1329/1328/verifierC.go`
- `go build 1000-1999/1300-1399/1320-1329/1328/verifierD.go`
- `go build 1000-1999/1300-1399/1320-1329/1328/verifierE.go`
- `go build 1000-1999/1300-1399/1320-1329/1328/verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6885d0c4862c8324b718030059b34481