### PR TITLE
Add Go solution for 1566B

### DIFF
--- a/1000-1999/1500-1599/1560-1569/1566/1566B.go
+++ b/1000-1999/1500-1599/1560-1569/1566/1566B.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		zeroGroups := 0
+		prev := byte('1')
+		for i := 0; i < len(s); i++ {
+			if s[i] == '0' && prev != '0' {
+				zeroGroups++
+			}
+			prev = s[i]
+		}
+		if zeroGroups > 2 {
+			zeroGroups = 2
+		}
+		fmt.Fprintln(writer, zeroGroups)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1566B

## Testing
- `go build 1000-1999/1500-1599/1560-1569/1566/1566B.go`
- `echo -e "3\n01\n1111\n01100\n" | go run 1000-1999/1500-1599/1560-1569/1566/1566B.go`

------
https://chatgpt.com/codex/tasks/task_e_6885d2aee56883249bfb693b27c893ce