### PR TITLE
Add verifiers for contest 1332

### DIFF
--- a/1000-1999/1300-1399/1330-1339/1332/verifierA.go
+++ b/1000-1999/1300-1399/1330-1339/1332/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	a, b, c, d int64
+	x, y       int64
+	x1, y1     int64
+	x2, y2     int64
+}
+
+func solveCase(tc testCase) string {
+	if tc.x1 == tc.x2 && (tc.a > 0 || tc.b > 0) {
+		return "NO"
+	}
+	if tc.y1 == tc.y2 && (tc.c > 0 || tc.d > 0) {
+		return "NO"
+	}
+	nx := tc.x + tc.b - tc.a
+	ny := tc.y + tc.d - tc.c
+	if nx < tc.x1 || nx > tc.x2 || ny < tc.y1 || ny > tc.y2 {
+		return "NO"
+	}
+	return "YES"
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	// coordinate range [-10,10]
+	x1 := int64(rng.Intn(21) - 10)
+	x2 := x1 + int64(rng.Intn(21))
+	y1 := int64(rng.Intn(21) - 10)
+	y2 := y1 + int64(rng.Intn(21))
+	x := x1 + int64(rng.Intn(int(x2-x1+1)))
+	y := y1 + int64(rng.Intn(int(y2-y1+1)))
+	a := int64(rng.Intn(5))
+	b := int64(rng.Intn(5))
+	c := int64(rng.Intn(5))
+	d := int64(rng.Intn(5))
+	return testCase{a, b, c, d, x, y, x1, y1, x2, y2}
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("1\n%d %d %d %d\n%d %d %d %d %d %d\n", tc.a, tc.b, tc.c, tc.d, tc.x, tc.y, tc.x1, tc.y1, tc.x2, tc.y2)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := solveCase(tc)
+	if !strings.EqualFold(got, expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			fmt.Fprintf(os.Stderr, "input:\n1\n%d %d %d %d\n%d %d %d %d %d %d\n", tc.a, tc.b, tc.c, tc.d, tc.x, tc.y, tc.x1, tc.y1, tc.x2, tc.y2)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1332/verifierB.go
+++ b/1000-1999/1300-1399/1330-1339/1332/verifierB.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func spfSieve(maxN int) []int {
+	spf := make([]int, maxN+1)
+	for i := 0; i <= maxN; i++ {
+		spf[i] = i
+	}
+	for i := 2; i*i <= maxN; i++ {
+		for j := i * 2; j <= maxN; j += i {
+			if spf[j] > i {
+				spf[j] = i
+			}
+		}
+	}
+	return spf
+}
+
+func solveCase(arr []int, spf []int) (int, []int) {
+	mp := map[int]int{}
+	id := 1
+	colors := make([]int, len(arr))
+	for i, v := range arr {
+		p := spf[v]
+		if mp[p] == 0 {
+			mp[p] = id
+			id++
+		}
+		colors[i] = mp[p]
+	}
+	return len(mp), colors
+}
+
+func generateCase(rng *rand.Rand) []int {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(999) + 2
+	}
+	return arr
+}
+
+func runCase(bin string, arr []int, spf []int) error {
+	var input strings.Builder
+	input.WriteString("1\n")
+	input.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(strconv.Itoa(v))
+	}
+	input.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) < 2 {
+		return fmt.Errorf("expected at least 2 lines got %d", len(lines))
+	}
+	expectedCnt, expectedColors := solveCase(arr, spf)
+	if strings.TrimSpace(lines[0]) != strconv.Itoa(expectedCnt) {
+		return fmt.Errorf("expected %d got %s", expectedCnt, lines[0])
+	}
+	cols := strings.Fields(lines[1])
+	if len(cols) != len(arr) {
+		return fmt.Errorf("expected %d colors got %d", len(arr), len(cols))
+	}
+	for i, c := range cols {
+		v, err := strconv.Atoi(c)
+		if err != nil {
+			return fmt.Errorf("bad color %q", c)
+		}
+		if v != expectedColors[i] {
+			return fmt.Errorf("colors mismatch")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	spf := spfSieve(1000)
+	for i := 0; i < 100; i++ {
+		arr := generateCase(rng)
+		if err := runCase(bin, arr, spf); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\narr: %v\n", i+1, err, arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1332/verifierC.go
+++ b/1000-1999/1300-1399/1330-1339/1332/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveCase(n, k int, s string) int {
+	freq := make([][26]int, k)
+	for i := 0; i < n; i++ {
+		c := s[i] - 'a'
+		idx := i % k
+		freq[idx][c]++
+	}
+	m := n / k
+	ans := 0
+	for i := 0; i <= (k-1)/2; i++ {
+		j := k - 1 - i
+		counts := [26]int{}
+		groupSize := m
+		if i != j {
+			groupSize = 2 * m
+			for ch := 0; ch < 26; ch++ {
+				counts[ch] = freq[i][ch] + freq[j][ch]
+			}
+		} else {
+			for ch := 0; ch < 26; ch++ {
+				counts[ch] = freq[i][ch]
+			}
+		}
+		maxFreq := 0
+		for ch := 0; ch < 26; ch++ {
+			if counts[ch] > maxFreq {
+				maxFreq = counts[ch]
+			}
+		}
+		ans += groupSize - maxFreq
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (int, int, string) {
+	k := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	n := k * m
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return n, k, string(b)
+}
+
+func runCase(bin string, n, k int, s string) error {
+	var input strings.Builder
+	input.WriteString("1\n")
+	input.WriteString(fmt.Sprintf("%d %d\n%s\n", n, k, s))
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := solveCase(n, k, s)
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(gotStr)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, s := generateCase(rng)
+		if err := runCase(bin, n, k, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d\n%s\n", i+1, err, n, k, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1332/verifierD.go
+++ b/1000-1999/1300-1399/1330-1339/1332/verifierD.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(k int64) string {
+	add := int64(1 << 17)
+	return fmt.Sprintf("3 3\n%d %d %d\n%d %d %d\n0 0 %d\n", k+add, k+add, k, add, add, k+add, k)
+}
+
+func generateCase(rng *rand.Rand) int64 {
+	return rng.Int63n(1 << 30) // random non-negative
+}
+
+func runCase(bin string, k int64) error {
+	input := fmt.Sprintf("%d\n", k)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := strings.TrimSpace(solveCase(k))
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		k := generateCase(rng)
+		if err := runCase(bin, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1332/verifierE.go
+++ b/1000-1999/1300-1399/1330-1339/1332/verifierE.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func modPow(a, b int64) int64 {
+	a %= mod
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func solveCase(n, m, L, R int64) int64 {
+	N := n * m
+	total := R - L + 1
+	if N%2 == 1 {
+		return modPow(total%mod, N)
+	}
+	even := R/2 - (L-1)/2
+	odd := total - even
+	diff := (even - odd) % mod
+	if diff < 0 {
+		diff += mod
+	}
+	a := modPow(total%mod, N)
+	b := modPow(diff, N)
+	ans := (a + b) % mod
+	ans = ans * ((mod + 1) / 2) % mod
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (int64, int64, int64, int64) {
+	n := int64(rng.Intn(4) + 1)
+	m := int64(rng.Intn(4) + 1)
+	L := int64(rng.Intn(10))
+	R := L + int64(rng.Intn(10))
+	return n, m, L, R
+}
+
+func runCase(bin string, n, m, L, R int64) error {
+	input := fmt.Sprintf("%d %d %d %d\n", n, m, L, R)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := solveCase(n, m, L, R)
+	gotStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(gotStr, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, L, R := generateCase(rng)
+		if err := runCase(bin, n, m, L, R); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1332/verifierF.go
+++ b/1000-1999/1300-1399/1330-1339/1332/verifierF.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 998244353
+
+type edge struct{ u, v int }
+
+func solveCase(n int, edges []edge) int64 {
+	m := len(edges)
+	// adjacency matrix
+	adj := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		adj[i] = make([]bool, n)
+	}
+	for _, e := range edges {
+		adj[e.u][e.v] = true
+		adj[e.v][e.u] = true
+	}
+	var sum int64
+	// iterate over non-empty subsets of edges
+	for mask := 1; mask < (1 << m); mask++ {
+		involvedMask := 0
+		for i, e := range edges {
+			if mask>>i&1 == 1 {
+				involvedMask |= 1 << e.u
+				involvedMask |= 1 << e.v
+			}
+		}
+		// get list of vertices
+		vertIndices := []int{}
+		for v := 0; v < n; v++ {
+			if involvedMask>>v&1 == 1 {
+				vertIndices = append(vertIndices, v)
+			}
+		}
+		k := len(vertIndices)
+		var cnt int64
+		for sub := 0; sub < (1 << k); sub++ {
+			ok := true
+			for i := 0; i < k && ok; i++ {
+				if sub>>i&1 == 1 {
+					vi := vertIndices[i]
+					for j := i + 1; j < k; j++ {
+						if sub>>j&1 == 1 {
+							vj := vertIndices[j]
+							if adj[vi][vj] {
+								ok = false
+								break
+							}
+						}
+					}
+				}
+			}
+			if ok {
+				cnt++
+			}
+		}
+		sum = (sum + cnt) % MOD
+	}
+	return sum
+}
+
+func generateCase(rng *rand.Rand) (int, []edge) {
+	n := rng.Intn(5) + 2 // 2..6
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, edge{p - 1, i - 1})
+	}
+	return n, edges
+}
+
+func runCase(bin string, n int, edges []edge) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		input.WriteString(fmt.Sprintf("%d %d\n", e.u+1, e.v+1))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := solveCase(n, edges)
+	outStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(outStr, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got%MOD != expected%MOD {
+		return fmt.Errorf("expected %d got %d", expected%MOD, got%MOD)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, edges := generateCase(rng)
+		if err := runCase(bin, n, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1332/verifierG.go
+++ b/1000-1999/1300-1399/1330-1339/1332/verifierG.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	a []int
+	L int
+	R int
+}
+
+func isMonotoneTriple(a, b, c int) bool {
+	return (a <= b && b <= c) || (a >= b && b >= c)
+}
+
+func checkSubsequence(vals []int, idxs []int) bool {
+	m := len(idxs)
+	for i := 0; i < m; i++ {
+		for j := i + 1; j < m; j++ {
+			for k := j + 1; k < m; k++ {
+				if isMonotoneTriple(vals[idxs[i]], vals[idxs[j]], vals[idxs[k]]) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func solveCase(tc testCase) (int, []int) {
+	vals := tc.a[tc.L : tc.R+1]
+	n := len(vals)
+	// search length 4 then 3
+	for l := 4; l >= 3; l-- {
+		idxs := make([]int, l)
+		var dfs func(pos, last int) []int
+		dfs = func(pos, last int) []int {
+			if pos == l {
+				if checkSubsequence(vals, idxs) {
+					res := make([]int, l)
+					for i, v := range idxs {
+						res[i] = v + tc.L + 1
+					}
+					return res
+				}
+				return nil
+			}
+			for i := last; i < n; i++ {
+				idxs[pos] = i
+				if r := dfs(pos+1, i+1); r != nil {
+					return r
+				}
+			}
+			return nil
+		}
+		if res := dfs(0, 0); res != nil {
+			return l, res
+		}
+	}
+	return 0, nil
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 3 // 3..8
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(21) - 10
+	}
+	L := rng.Intn(n - 2)
+	R := L + 2 + rng.Intn(n-L-2)
+	return testCase{a, L, R}
+}
+
+func runCase(bin string, tc testCase) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d\n", len(tc.a), 1))
+	for i, v := range tc.a {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprintf("%d", v))
+	}
+	input.WriteString(fmt.Sprintf("\n%d %d\n", tc.L+1, tc.R+1))
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	k, idxs := solveCase(tc)
+	outFields := strings.Fields(strings.TrimSpace(out.String()))
+	if k == 0 {
+		if len(outFields) != 1 || outFields[0] != "0" {
+			return fmt.Errorf("expected 0 got %v", outFields)
+		}
+		return nil
+	}
+	if len(outFields) != k+1 {
+		return fmt.Errorf("expected %d numbers got %d", k+1, len(outFields))
+	}
+	if outFields[0] != fmt.Sprintf("%d", k) {
+		return fmt.Errorf("expected length %d got %s", k, outFields[0])
+	}
+	for i := 0; i < k; i++ {
+		var v int
+		if _, err := fmt.Sscan(outFields[i+1], &v); err != nil {
+			return fmt.Errorf("bad index")
+		}
+		if v != idxs[i] {
+			return fmt.Errorf("expected %v got %v", idxs, outFields[1:])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G of contest 1332
- each verifier runs 100 random test cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6885d2f4f7048324901062cff5901f59