### PR TITLE
Add Go verifiers for contest 1334

### DIFF
--- a/1000-1999/1300-1399/1330-1339/1334/verifierA.go
+++ b/1000-1999/1300-1399/1330-1339/1334/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(pairs [][2]int) string {
+	prevP, prevC := 0, 0
+	for _, pc := range pairs {
+		p, c := pc[0], pc[1]
+		if p < c || p < prevP || c < prevC || p-prevP < c-prevC {
+			return "NO"
+		}
+		prevP = p
+		prevC = c
+	}
+	return "YES"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		pairs := make([][2]int, n)
+		for j := 0; j < n; j++ {
+			pairs[j][0] = rng.Intn(20)
+			pairs[j][1] = rng.Intn(20)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, pc := range pairs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", pc[0], pc[1]))
+		}
+		input := sb.String()
+		exp := expected(pairs)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1334/verifierB.go
+++ b/1000-1999/1300-1399/1330-1339/1334/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(arr []int64, x int64) string {
+	sort.Slice(arr, func(i, j int) bool { return arr[i] > arr[j] })
+	var sum int64
+	ans := 0
+	for i, v := range arr {
+		sum += v
+		if sum >= x*int64(i+1) {
+			ans = i + 1
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 1
+		x := int64(rng.Intn(20) + 1)
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = int64(rng.Intn(30))
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(append([]int64(nil), arr...), x)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1334/verifierC.go
+++ b/1000-1999/1300-1399/1330-1339/1334/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a, b []int64) string {
+	n := len(a)
+	extra := make([]int64, n)
+	var sum int64
+	for i := 0; i < n; i++ {
+		prev := (i + n - 1) % n
+		if a[i] > b[prev] {
+			extra[i] = a[i] - b[prev]
+		} else {
+			extra[i] = 0
+		}
+		sum += extra[i]
+	}
+	ans := sum + a[0] - extra[0]
+	for i := 1; i < n; i++ {
+		cand := sum + a[i] - extra[i]
+		if cand < ans {
+			ans = cand
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		a := make([]int64, n)
+		bArr := make([]int64, n)
+		for j := 0; j < n; j++ {
+			a[j] = int64(rng.Intn(20) + 1)
+			bArr[j] = int64(rng.Intn(20) + 1)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", a[j], bArr[j]))
+		}
+		input := sb.String()
+		exp := expected(append([]int64(nil), a...), append([]int64(nil), bArr...))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1334/verifierD.go
+++ b/1000-1999/1300-1399/1330-1339/1334/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, l, r int64) []int64 {
+	result := make([]int64, 0, r-l+1)
+	var pos int64 = 1
+	for i := int64(1); i < n && pos <= r; i++ {
+		blockLen := 2 * (n - i)
+		if l > pos+blockLen-1 {
+			pos += blockLen
+			continue
+		}
+		for j := i + 1; j <= n && pos <= r; j++ {
+			if pos >= l {
+				result = append(result, i)
+			}
+			pos++
+			if pos > r {
+				break
+			}
+			if pos >= l {
+				result = append(result, j)
+			}
+			pos++
+		}
+	}
+	if pos <= r {
+		if pos >= l {
+			result = append(result, 1)
+		}
+	}
+	return result
+}
+
+func expected(n, l, r int64) string {
+	res := solve(n, l, r)
+	var sb strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := int64(rng.Intn(5) + 2)
+		totalLen := n*(n-1) + 1
+		l := int64(rng.Intn(int(totalLen)) + 1)
+		maxRange := int(totalLen - l + 1)
+		if maxRange > 20 {
+			maxRange = 20
+		}
+		r := l + int64(rng.Intn(maxRange))
+		input := fmt.Sprintf("1\n%d %d %d\n", n, l, r)
+		exp := expected(n, l, r)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1334/verifierE.go
+++ b/1000-1999/1300-1399/1330-1339/1334/verifierE.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func modPow(a, e, m int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % m
+		}
+		a = a * a % m
+		e >>= 1
+	}
+	return res
+}
+
+func computeAnswers(D int64, queries [][2]int64) []int64 {
+	primes := make([]int64, 0)
+	exps := make([]int, 0)
+	n := D
+	for p := int64(2); p*p <= n; p++ {
+		if n%p == 0 {
+			cnt := 0
+			for n%p == 0 {
+				n /= p
+				cnt++
+			}
+			primes = append(primes, p)
+			exps = append(exps, cnt)
+		}
+	}
+	if n > 1 {
+		primes = append(primes, n)
+		exps = append(exps, 1)
+	}
+	maxExp := 0
+	for _, e := range exps {
+		maxExp += e
+	}
+	fact := make([]int64, maxExp+1)
+	invFact := make([]int64, maxExp+1)
+	fact[0] = 1
+	for i := 1; i <= maxExp; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[maxExp] = modPow(fact[maxExp], mod-2, mod)
+	for i := maxExp; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+
+	ans := make([]int64, len(queries))
+	for idx, qu := range queries {
+		v := qu[0]
+		u := qu[1]
+		diffV := make([]int, len(primes))
+		diffU := make([]int, len(primes))
+		sumV, sumU := 0, 0
+		tempV := v
+		tempU := u
+		for i, p := range primes {
+			cv, cu := 0, 0
+			for tempV%p == 0 {
+				tempV /= p
+				cv++
+			}
+			for tempU%p == 0 {
+				tempU /= p
+				cu++
+			}
+			g := cv
+			if cu < g {
+				g = cu
+			}
+			diffV[i] = cv - g
+			diffU[i] = cu - g
+			sumV += diffV[i]
+			sumU += diffU[i]
+		}
+		res := fact[sumV]
+		for _, x := range diffV {
+			res = res * invFact[x] % mod
+		}
+		res2 := fact[sumU]
+		for _, x := range diffU {
+			res2 = res2 * invFact[x] % mod
+		}
+		ans[idx] = res * res2 % mod
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomDivisors(D int64, rng *rand.Rand) int64 {
+	divisors := []int64{}
+	for i := int64(1); i*i <= D; i++ {
+		if D%i == 0 {
+			divisors = append(divisors, i)
+			if i*i != D {
+				divisors = append(divisors, D/i)
+			}
+		}
+	}
+	return divisors[rng.Intn(len(divisors))]
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		D := int64(rng.Intn(1000)+1) * int64(rng.Intn(5)+1)
+		q := rng.Intn(3) + 1
+		queries := make([][2]int64, q)
+		for i := 0; i < q; i++ {
+			v := randomDivisors(D, rng)
+			u := randomDivisors(D, rng)
+			queries[i] = [2]int64{v, u}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", D))
+		sb.WriteString(fmt.Sprintf("%d\n", q))
+		for _, qu := range queries {
+			sb.WriteString(fmt.Sprintf("%d %d\n", qu[0], qu[1]))
+		}
+		input := sb.String()
+		answers := computeAnswers(D, queries)
+		var expSB strings.Builder
+		for i, v := range answers {
+			if i > 0 {
+				expSB.WriteByte('\n')
+			}
+			expSB.WriteString(fmt.Sprintf("%d", v))
+		}
+		exp := expSB.String()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1334/verifierF.go
+++ b/1000-1999/1300-1399/1330-1339/1334/verifierF.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const INF int64 = 1 << 60
+
+type Fenwick struct {
+	n    int
+	tree []int64
+}
+
+func NewFenwick(n int) *Fenwick {
+	return &Fenwick{n: n, tree: make([]int64, n+2)}
+}
+
+func (f *Fenwick) add(idx int, val int64) {
+	for idx <= f.n+1 {
+		f.tree[idx] += val
+		idx += idx & -idx
+	}
+}
+
+func (f *Fenwick) rangeAdd(l, r int, val int64) {
+	if l > r {
+		return
+	}
+	f.add(l+1, val)
+	f.add(r+2, -val)
+}
+
+func (f *Fenwick) sum(idx int) int64 {
+	res := int64(0)
+	for idx > 0 {
+		res += f.tree[idx]
+		idx -= idx & -idx
+	}
+	return res
+}
+
+func (f *Fenwick) pointQuery(i int) int64 {
+	return f.sum(i + 1)
+}
+
+func expected(a []int, p []int, b []int) string {
+	m := len(b)
+	dpBase := make([]int64, m+1)
+	for i := 1; i <= m; i++ {
+		dpBase[i] = INF
+	}
+	bit := NewFenwick(m + 1)
+
+	query := func(idx int) int64 { return dpBase[idx] + bit.pointQuery(idx) }
+	setVal := func(idx int, val int64) { dpBase[idx] = val - bit.pointQuery(idx) }
+	rangeAdd := func(l, r int, val int64) { bit.rangeAdd(l, r, val) }
+
+	for i := 0; i < len(a); i++ {
+		x := a[i]
+		cost := int64(p[i])
+		pos := sort.Search(len(b), func(j int) bool { return b[j] >= x })
+		if pos == m {
+			rangeAdd(0, m, cost)
+			continue
+		}
+		old := query(pos)
+		if pos > 0 {
+			rangeAdd(0, pos-1, cost)
+		}
+		addVal := cost
+		if addVal > 0 {
+			addVal = 0
+		}
+		rangeAdd(pos, m, addVal)
+		if b[pos] == x {
+			cur := query(pos + 1)
+			if old < cur {
+				setVal(pos+1, old)
+			}
+		}
+	}
+
+	ans := query(m)
+	if ans >= INF/2 {
+		return "NO"
+	}
+	return fmt.Sprintf("YES\n%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(5) + 1
+		a := make([]int, n)
+		pArr := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(10) + 1
+			pArr[i] = rng.Intn(11) - 5
+		}
+		m := rng.Intn(n) + 1
+		b := make([]int, m)
+		used := map[int]bool{}
+		for i := 0; i < m; i++ {
+			val := rng.Intn(10) + 1
+			for used[val] {
+				val = rng.Intn(10) + 1
+			}
+			used[val] = true
+			b[i] = val
+		}
+		sort.Ints(b)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteString("\n")
+		for i, v := range pArr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteString("\n")
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for i, v := range b {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteString("\n")
+		input := sb.String()
+		exp := expected(append([]int(nil), a...), append([]int(nil), pArr...), append([]int(nil), b...))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1334/verifierG.go
+++ b/1000-1999/1300-1399/1330-1339/1334/verifierG.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(p []int, s, t string) string {
+	n := len(t)
+	m := len(s)
+	bitsets := make([]*big.Int, 26)
+	for i := 0; i < 26; i++ {
+		bitsets[i] = new(big.Int)
+	}
+	for i := 0; i < n; i++ {
+		c := int(t[i] - 'a')
+		bitsets[c].SetBit(bitsets[c], i, 1)
+	}
+	idx0 := int(s[0] - 'a')
+	res := new(big.Int).Or(new(big.Int).Set(bitsets[idx0]), bitsets[p[idx0]])
+	for k := 1; k < m; k++ {
+		idx := int(s[k] - 'a')
+		tmp := new(big.Int).Or(new(big.Int).Set(bitsets[idx]), bitsets[p[idx]])
+		tmp.Rsh(tmp, uint(k))
+		res.And(res, tmp)
+	}
+	limit := n - m + 1
+	var sb strings.Builder
+	for i := 0; i < limit; i++ {
+		if res.Bit(i) == 1 {
+			sb.WriteByte('1')
+		} else {
+			sb.WriteByte('0')
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		// permutation p
+		perm := rng.Perm(26)
+		sLen := rng.Intn(6) + 1
+		tLen := rng.Intn(10) + sLen
+		s := randString(rng, sLen)
+		t := randString(rng, tLen)
+		var sb strings.Builder
+		for i, v := range perm {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v+1))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+		sb.WriteString(t)
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(perm, s, t)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement standalone verifiers for problems A–G of contest 1334
- each verifier generates 100 random tests and checks any binary
- verifiers replicate the official solutions to compute expected answers

## Testing
- `go run verifierA.go ./progA`
- `go run verifierB.go ./progB`
- `go run verifierC.go ./progC`
- `go run verifierD.go ./progD`
- `go run verifierE.go ./progE`
- `go run verifierF.go ./progF`
- `go run verifierG.go ./progG`


------
https://chatgpt.com/codex/tasks/task_e_6885d40cf7a48324951d3cffd6c8b609