### PR TITLE
Add Go verifiers for CF 1333

### DIFF
--- a/1000-1999/1300-1399/1330-1339/1333/verifierA.go
+++ b/1000-1999/1300-1399/1330-1339/1333/verifierA.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// testCase represents one input with potentially multiple testcases
+// t testcases with dimensions in ns and ms.
+type testCase struct {
+	input string
+	ns    []int
+	ms    []int
+}
+
+// randomCase generates a random test case with up to 3 individual boards of size up to 10x10.
+func randomCase(rng *rand.Rand) testCase {
+	t := rng.Intn(3) + 1
+	ns := make([]int, t)
+	ms := make([]int, t)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(9) + 2 // 2..10
+		m := rng.Intn(9) + 2
+		ns[i] = n
+		ms[i] = m
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	}
+	return testCase{input: sb.String(), ns: ns, ms: ms}
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// checkOutput validates candidate output for the provided test case.
+func checkOutput(tc testCase, output string) error {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	idx := 0
+	for caseNum := 0; caseNum < len(tc.ns); caseNum++ {
+		n, m := tc.ns[caseNum], tc.ms[caseNum]
+		if idx+n > len(lines) {
+			return fmt.Errorf("case %d: expected %d lines, got %d", caseNum+1, n, len(lines)-idx)
+		}
+		board := make([][]byte, n)
+		for i := 0; i < n; i++ {
+			line := strings.TrimSpace(lines[idx+i])
+			if len(line) != m {
+				return fmt.Errorf("case %d line %d: expected length %d", caseNum+1, i+1, m)
+			}
+			row := make([]byte, m)
+			for j := 0; j < m; j++ {
+				c := line[j]
+				if c != 'B' && c != 'W' {
+					return fmt.Errorf("case %d line %d: invalid char", caseNum+1, i+1)
+				}
+				row[j] = c
+			}
+			board[i] = row
+		}
+		idx += n
+		// compute B and W
+		B, W := 0, 0
+		dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				here := board[i][j]
+				for _, d := range dirs {
+					x, y := i+d[0], j+d[1]
+					if x >= 0 && x < n && y >= 0 && y < m {
+						if here == 'B' && board[x][y] == 'W' {
+							B++
+							break
+						}
+						if here == 'W' && board[x][y] == 'B' {
+							W++
+							break
+						}
+					}
+				}
+			}
+		}
+		if B != W+1 {
+			return fmt.Errorf("case %d: condition failed B=%d W=%d", caseNum+1, B, W)
+		}
+	}
+	for idx < len(lines) && strings.TrimSpace(lines[idx]) == "" {
+		idx++
+	}
+	if idx != len(lines) {
+		return fmt.Errorf("extra output lines")
+	}
+	return nil
+}
+
+func runCase(bin string, tc testCase) error {
+	out, err := run(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out)
+	}
+	return checkOutput(tc, out)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// deterministic simple cases
+	cases := []testCase{
+		{input: "1\n2 2\n", ns: []int{2}, ms: []int{2}},
+		{input: "1\n3 3\n", ns: []int{3}, ms: []int{3}},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1333/verifierB.go
+++ b/1000-1999/1300-1399/1330-1339/1333/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(a, b []int) string {
+	pos, neg := false, false
+	for i := range a {
+		if b[i] > a[i] && !pos {
+			return "NO\n"
+		}
+		if b[i] < a[i] && !neg {
+			return "NO\n"
+		}
+		if a[i] == 1 {
+			pos = true
+		}
+		if a[i] == -1 {
+			neg = true
+		}
+	}
+	return "YES\n"
+}
+
+func buildCase(a, b []int) testCase {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	n := len(a)
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: solveCase(a, b)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(3) - 1 // -1..1
+		b[i] = rng.Intn(7) - 3 // -3..3
+	}
+	return buildCase(a, b)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(tc.expected) {
+		return fmt.Errorf("expected %q got %q", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase([]int{0}, []int{0}),
+		buildCase([]int{1, -1}, []int{1, -2}),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1333/verifierC.go
+++ b/1000-1999/1300-1399/1330-1339/1333/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(a []int64) string {
+	prefix := make(map[int64]int)
+	prefixSum := int64(0)
+	prefix[0] = 0
+	left := 0
+	var res int64
+	for i := 1; i <= len(a); i++ {
+		prefixSum += a[i-1]
+		if idx, ok := prefix[prefixSum]; ok && idx >= left {
+			left = idx + 1
+		}
+		prefix[prefixSum] = i
+		res += int64(i - left)
+	}
+	return fmt.Sprintf("%d\n", res)
+}
+
+func buildCase(a []int64) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(a)))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: solveCase(a)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = int64(rng.Intn(11) - 5)
+	}
+	return buildCase(a)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(tc.expected) {
+		return fmt.Errorf("expected %q got %q", tc.expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase([]int64{1, 2, -3}),
+		buildCase([]int64{0, 0, 0}),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1333/verifierD.go
+++ b/1000-1999/1300-1399/1330-1339/1333/verifierD.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	n, k     int
+	initial  string
+	possible bool
+}
+
+// computeMoves replicates the reference algorithm to determine minimal and total swaps.
+func computeMoves(n int, s string) ([][]int, int) {
+	b := []byte(s)
+	moves := make([][]int, 0)
+	total := 0
+	for {
+		cur := 0
+		mn := n + 1
+		v := make([]int, 0)
+		for i := 1; i < n; i++ {
+			if b[i] == 'L' {
+				cur++
+			} else {
+				cur--
+			}
+			if b[i] == 'L' && b[i-1] == 'R' {
+				if cur < mn {
+					mn = cur
+					v = v[:0]
+					v = append(v, i)
+				} else if cur == mn {
+					v = append(v, i)
+				}
+			}
+		}
+		if len(v) == 0 {
+			break
+		}
+		for _, x := range v {
+			b[x-1], b[x] = b[x], b[x-1]
+		}
+		total += len(v)
+		cp := append([]int(nil), v...)
+		moves = append(moves, cp)
+	}
+	return moves, total
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 2 // 2..6
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = 'L'
+		} else {
+			b[i] = 'R'
+		}
+	}
+	s := string(b)
+	moves, tot := computeMoves(n, s)
+	kmin := len(moves)
+	kmax := tot
+	if kmax == 0 {
+		kmin = 0
+	}
+	var k int
+	possible := true
+	if kmax == 0 {
+		if rng.Intn(2) == 0 {
+			k = 0
+		} else {
+			k = rng.Intn(3) + 1
+			possible = false
+		}
+	} else {
+		if rng.Intn(2) == 0 {
+			k = kmin + rng.Intn(kmax-kmin+1)
+			possible = true
+		} else {
+			if rng.Intn(2) == 0 {
+				k = rng.Intn(kmin)
+			} else {
+				k = kmax + 1 + rng.Intn(3)
+			}
+			possible = false
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n%s\n", n, k, s))
+	return testCase{input: sb.String(), n: n, k: k, initial: s, possible: possible}
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func validate(tc testCase, output string) error {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	tok := scanner.Text()
+	if tok == "-1" {
+		if tc.possible {
+			if scanner.Scan() {
+				return fmt.Errorf("unexpected extra output after -1")
+			}
+			return fmt.Errorf("solution exists but candidate printed -1")
+		}
+		if scanner.Scan() {
+			return fmt.Errorf("unexpected extra output after -1")
+		}
+		return nil
+	}
+	if !tc.possible {
+		return fmt.Errorf("expected -1 but got answer")
+	}
+	// tok is first n_i
+	b := []byte(tc.initial)
+	step := 0
+	for {
+		if step == tc.k {
+			return fmt.Errorf("too many moves")
+		}
+		n_i, err := strconv.Atoi(tok)
+		if err != nil {
+			return fmt.Errorf("bad integer %q", tok)
+		}
+		if n_i <= 0 || n_i > tc.n/2 {
+			return fmt.Errorf("invalid count at step %d", step+1)
+		}
+		moves := make([]int, n_i)
+		for j := 0; j < n_i; j++ {
+			if !scanner.Scan() {
+				return fmt.Errorf("not enough numbers for step %d", step+1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				return fmt.Errorf("bad number at step %d", step+1)
+			}
+			moves[j] = val
+		}
+		used := make(map[int]bool)
+		for _, x := range moves {
+			if x <= 0 || x >= tc.n {
+				return fmt.Errorf("bad index %d at step %d", x, step+1)
+			}
+			if used[x] {
+				return fmt.Errorf("duplicate index %d at step %d", x, step+1)
+			}
+			used[x] = true
+			if b[x-1] != 'R' || b[x] != 'L' {
+				return fmt.Errorf("invalid pair at step %d index %d", step+1, x)
+			}
+		}
+		for _, x := range moves {
+			b[x-1], b[x] = b[x], b[x-1]
+		}
+		step++
+		if step == tc.k {
+			break
+		}
+		if !scanner.Scan() {
+			return fmt.Errorf("not enough steps")
+		}
+		tok = scanner.Text()
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	if strings.Contains(string(b), "RL") {
+		return fmt.Errorf("process not finished")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{}
+	// simple deterministic cases
+	cases = append(cases, testCase{input: "2 1\nRL\n", n: 2, k: 1, initial: "RL", possible: true})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if err := validate(tc, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, tc.input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1333/verifierE.go
+++ b/1000-1999/1300-1399/1330-1339/1333/verifierE.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	n      int
+	hasSol bool
+}
+
+func canRookMove(x1, y1, x2, y2 int) bool {
+	return x1 == x2 || y1 == y2
+}
+
+func canQueenMove(x1, y1, x2, y2 int) bool {
+	if x1 == x2 || y1 == y2 {
+		return true
+	}
+	return abs(x1-x2) == abs(y1-y2)
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func computeFee(board [][]int, canMove func(int, int, int, int) bool) int {
+	n := len(board)
+	pos := make(map[int][2]int, n*n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			pos[board[i][j]] = [2]int{i, j}
+		}
+	}
+	visited := make([]bool, n*n+1)
+	cur := 1
+	visited[1] = true
+	fee := 0
+	visitedCount := 1
+	for visitedCount < n*n {
+		x, y := pos[cur][0], pos[cur][1]
+		next := 0
+		best := n*n + 1
+		for v := 1; v <= n*n; v++ {
+			if visited[v] {
+				continue
+			}
+			px, py := pos[v][0], pos[v][1]
+			if canMove(x, y, px, py) {
+				if v < best {
+					best = v
+					next = v
+				}
+			}
+		}
+		if next == 0 {
+			for v := 1; v <= n*n; v++ {
+				if !visited[v] {
+					next = v
+					break
+				}
+			}
+			fee++
+		}
+		visited[next] = true
+		visitedCount++
+		cur = next
+	}
+	return fee
+}
+
+func parseBoard(n int, lines []string) ([][]int, error) {
+	board := make([][]int, n)
+	used := make([]bool, n*n+1)
+	for i := 0; i < n; i++ {
+		fields := strings.Fields(strings.TrimSpace(lines[i]))
+		if len(fields) != n {
+			return nil, fmt.Errorf("line %d: expected %d numbers", i+1, n)
+		}
+		row := make([]int, n)
+		for j, f := range fields {
+			val, err := strconv.Atoi(f)
+			if err != nil || val < 1 || val > n*n || used[val] {
+				return nil, fmt.Errorf("invalid number at line %d", i+1)
+			}
+			used[val] = true
+			row[j] = val
+		}
+		board[i] = row
+	}
+	for v := 1; v <= n*n; v++ {
+		if !used[v] {
+			return nil, fmt.Errorf("missing number %d", v)
+		}
+	}
+	return board, nil
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr == "-1" {
+		if tc.hasSol {
+			return fmt.Errorf("solution exists but -1 returned")
+		}
+		return nil
+	}
+	lines := strings.Split(outStr, "\n")
+	if len(lines) != tc.n {
+		return fmt.Errorf("expected %d lines got %d", tc.n, len(lines))
+	}
+	board, err := parseBoard(tc.n, lines)
+	if err != nil {
+		return err
+	}
+	rFee := computeFee(board, canRookMove)
+	qFee := computeFee(board, canQueenMove)
+	if rFee >= qFee {
+		return fmt.Errorf("rook fee %d not less than queen %d", rFee, qFee)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(3) + 1 // 1..3
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	has := n >= 3
+	return testCase{input: sb.String(), n: n, hasSol: has}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{input: "1\n", n: 1, hasSol: false},
+		{input: "2\n", n: 2, hasSol: false},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1330-1339/1333/verifierF.go
+++ b/1000-1999/1300-1399/1330-1339/1333/verifierF.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(n int) string {
+	spf := make([]int, n+1)
+	primes := make([]int, 0)
+	for i := 2; i <= n; i++ {
+		if spf[i] == 0 {
+			spf[i] = i
+			primes = append(primes, i)
+		}
+		for _, p := range primes {
+			if p > spf[i] || i*p > n {
+				break
+			}
+			spf[i*p] = p
+		}
+	}
+	mpf := make([]int, n+1)
+	mpf[1] = 1
+	for i := 2; i <= n; i++ {
+		p := spf[i]
+		mpf[i] = p
+		if i/p > 1 {
+			if mpf[i/p] > mpf[i] {
+				mpf[i] = mpf[i/p]
+			}
+		}
+	}
+	freq := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		freq[mpf[i]]++
+	}
+	prefix := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		prefix[i] = prefix[i-1] + freq[i]
+	}
+	primePre := make([]int, n+1)
+	cnt := 0
+	isPrime := make([]bool, n+1)
+	for _, p := range primes {
+		isPrime[p] = true
+	}
+	for i := 1; i <= n; i++ {
+		if isPrime[i] {
+			cnt++
+		}
+		primePre[i] = cnt
+	}
+	piN := cnt
+	M := make([]int, n+1)
+	for g := 1; g <= n; g++ {
+		M[g] = prefix[g] + (piN - primePre[g])
+	}
+	res := make([]int, n+1)
+	g := 1
+	for k := 2; k <= n; k++ {
+		for g <= n && M[g] < k {
+			g++
+		}
+		if g > n {
+			res[k] = n
+		} else {
+			res[k] = g
+		}
+	}
+	var sb strings.Builder
+	for k := 2; k <= n; k++ {
+		if k > 2 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(res[k]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildCase(n int) testCase {
+	return testCase{input: fmt.Sprintf("%d\n", n), expected: solveCase(n)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 2
+	return buildCase(n)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(tc.expected) {
+		return fmt.Errorf("expected %q got %q", tc.expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase(2),
+		buildCase(3),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to validate board coloring for problem A
- add verifierB.go for transformation checks of arrays
- add verifierC.go to validate good subarray counts
- add verifierD.go to simulate swaps for given `k`
- add verifierE.go to check rook vs queen fees
- add verifierF.go for minimal imperfection outputs

## Testing
- `go build 1000-1999/1300-1399/1330-1339/1333/verifierA.go`
- `go build 1000-1999/1300-1399/1330-1339/1333/verifierB.go`
- `go build 1000-1999/1300-1399/1330-1339/1333/verifierC.go`
- `go build 1000-1999/1300-1399/1330-1339/1333/verifierD.go`
- `go build 1000-1999/1300-1399/1330-1339/1333/verifierE.go`
- `go build 1000-1999/1300-1399/1330-1339/1333/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885d380f0808324b0e2e100564bf8ab