### PR TITLE
Add verifiers for CF 1340

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1340/verifierA.go
+++ b/1000-1999/1300-1399/1340-1349/1340/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase() string {
+	n := rand.Intn(5) + 1
+	p := rand.Perm(n)
+	for i := range p {
+		p[i]++
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", p[i]))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		exp, err := runBinary("1340A.go", input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed running official solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1340-1349/1340/verifierB.go
+++ b/1000-1999/1300-1399/1340-1349/1340/verifierB.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase() string {
+	n := rand.Intn(3) + 1
+	k := rand.Intn(7*n + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		for j := 0; j < 7; j++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		exp, err := runBinary("1340B.go", input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed running official solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1340-1349/1340/verifierC.go
+++ b/1000-1999/1300-1399/1340-1349/1340/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase() string {
+	n := rand.Intn(30) + 1
+	maxm := n + 1
+	if maxm > 8 {
+		maxm = 8
+	}
+	m := rand.Intn(maxm-1) + 2 // at least 2 including 0 and n
+	set := map[int]bool{0: true, n: true}
+	for len(set) < m {
+		v := rand.Intn(n-1) + 1
+		set[v] = true
+	}
+	arr := make([]int, 0, len(set))
+	for v := range set {
+		arr = append(arr, v)
+	}
+	sort.Ints(arr)
+	g := rand.Intn(10) + 1
+	r := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", g, r))
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		exp, err := runBinary("1340C.go", input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed running official solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1340-1349/1340/verifierD.go
+++ b/1000-1999/1300-1399/1340-1349/1340/verifierD.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase() (string, int, []edge) {
+	n := rand.Intn(4) + 2
+	edges := make([]edge, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges[i-2] = edge{p, i}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String(), n, edges
+}
+
+func verify(n int, edges []edge, out string) error {
+	adj := make([]map[int]bool, n+1)
+	deg := 0
+	for i := 1; i <= n; i++ {
+		adj[i] = make(map[int]bool)
+	}
+	for _, e := range edges {
+		adj[e.u][e.v] = true
+		adj[e.v][e.u] = true
+	}
+	for i := 1; i <= n; i++ {
+		if len(adj[i]) > deg {
+			deg = len(adj[i])
+		}
+	}
+	scan := bufio.NewScanner(strings.NewReader(out))
+	scan.Split(bufio.ScanWords)
+	if !scan.Scan() {
+		return fmt.Errorf("missing k")
+	}
+	k, err := strconv.Atoi(scan.Text())
+	if err != nil || k <= 0 {
+		return fmt.Errorf("bad k")
+	}
+	type pair struct{ v, t int }
+	seq := make([]pair, 0, k)
+	for i := 0; i < k; i++ {
+		if !scan.Scan() {
+			return fmt.Errorf("bad output")
+		}
+		v, _ := strconv.Atoi(scan.Text())
+		if !scan.Scan() {
+			return fmt.Errorf("bad output")
+		}
+		t, _ := strconv.Atoi(scan.Text())
+		seq = append(seq, pair{v, t})
+	}
+	if scan.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	if len(seq) != k {
+		return fmt.Errorf("wrong length")
+	}
+	if seq[0].v != 1 || seq[0].t != 0 {
+		return fmt.Errorf("must start at 1 0")
+	}
+	if seq[len(seq)-1].v != 1 {
+		return fmt.Errorf("must end at 1")
+	}
+	seenPair := make(map[[2]int]bool)
+	visited := make(map[int]bool)
+	maxT := 0
+	for i := 0; i < len(seq); i++ {
+		p := seq[i]
+		if seenPair[[2]int{p.v, p.t}] {
+			return fmt.Errorf("duplicate pair")
+		}
+		seenPair[[2]int{p.v, p.t}] = true
+		visited[p.v] = true
+		if p.t > maxT {
+			maxT = p.t
+		}
+		if i > 0 {
+			prev := seq[i-1]
+			if p.v == prev.v {
+				if p.t >= prev.t {
+					return fmt.Errorf("time must decrease when staying")
+				}
+			} else {
+				if p.t != prev.t+1 {
+					return fmt.Errorf("wrong time increment")
+				}
+				if !adj[prev.v][p.v] {
+					return fmt.Errorf("edge %d-%d doesn't exist", prev.v, p.v)
+				}
+			}
+		}
+	}
+	if len(visited) != n {
+		return fmt.Errorf("not all nodes visited")
+	}
+	if maxT != deg {
+		return fmt.Errorf("max time %d != expected %d", maxT, deg)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input, n, edges := generateCase()
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verify(n, edges, out); err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%soutput:\n%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1340-1349/1340/verifierE.go
+++ b/1000-1999/1300-1399/1340-1349/1340/verifierE.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase() string {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(n*(n-1)/2 + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	edges := make(map[[2]int]bool)
+	for len(edges) < m {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		if edges[[2]int{u, v}] {
+			continue
+		}
+		edges[[2]int{u, v}] = true
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		exp, err := runBinary("1340E.go", input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed running official solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1300-1399/1340-1349/1340/verifierF.go
+++ b/1000-1999/1300-1399/1340-1349/1340/verifierF.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase() string {
+	n := rand.Intn(5) + 1
+	k := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		v := rand.Intn(7) - 3
+		if v == 0 {
+			v = 1
+		}
+		sb.WriteString(fmt.Sprintf("%d ", v))
+	}
+	sb.WriteByte('\n')
+	q := rand.Intn(5) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		typ := rand.Intn(2) + 1
+		if typ == 1 {
+			idx := rand.Intn(n) + 1
+			val := rand.Intn(7) - 3
+			if val == 0 {
+				val = 1
+			}
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", idx, val))
+		} else {
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", l, r))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		exp, err := runBinary("1340F.go", input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed running official solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1340 problems A–F
- each verifier generates 100 random tests and runs the provided binary against the official solution
- problem D verifier additionally validates the route constraints

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885d755891883249eb61cc115b88210