### PR TITLE
Add verifiers for contest 1343

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1343/verifierA.go
+++ b/1000-1999/1300-1399/1340-1349/1343/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedX(n int64) int64 {
+	for k := int64(2); ; k++ {
+		denom := (int64(1) << k) - 1
+		if n%denom == 0 {
+			return n / denom
+		}
+	}
+}
+
+func genCase(rng *rand.Rand) int64 {
+	k := rng.Intn(28) + 2 // 2..29
+	denom := int64(1<<k) - 1
+	maxX := int64(1e9) / denom
+	if maxX < 1 {
+		maxX = 1
+	}
+	x := rng.Int63n(maxX) + 1
+	return x * denom
+}
+
+func runCase(bin string, n int64) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	got, err := runProg(bin, input)
+	if err != nil {
+		return err
+	}
+	x, err := strconv.ParseInt(strings.TrimSpace(got), 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	exp := expectedX(n)
+	if x != exp {
+		return fmt.Errorf("expected %d got %d", exp, x)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := genCase(rng)
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1343/verifierB.go
+++ b/1000-1999/1300-1399/1340-1349/1343/verifierB.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) int {
+	return 2 * (rng.Intn(100) + 1) // even between 2 and 200
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	out, err := runProg(bin, input)
+	if err != nil {
+		return err
+	}
+	tokens := strings.Fields(out)
+	if len(tokens) == 0 {
+		return fmt.Errorf("no output")
+	}
+	needNO := (n/2)%2 == 1
+	ans := strings.ToUpper(tokens[0])
+	if needNO {
+		if ans != "NO" {
+			return fmt.Errorf("expected NO for n=%d", n)
+		}
+		return nil
+	}
+	if ans != "YES" {
+		return fmt.Errorf("expected YES for n=%d", n)
+	}
+	if len(tokens)-1 != n {
+		return fmt.Errorf("expected %d numbers got %d", n, len(tokens)-1)
+	}
+	seen := make(map[int]bool)
+	sumEven := 0
+	sumOdd := 0
+	for i := 0; i < n; i++ {
+		v, err := strconv.Atoi(tokens[i+1])
+		if err != nil {
+			return fmt.Errorf("invalid number: %v", err)
+		}
+		if v <= 0 {
+			return fmt.Errorf("non positive value %d", v)
+		}
+		if seen[v] {
+			return fmt.Errorf("duplicate value %d", v)
+		}
+		seen[v] = true
+		if i < n/2 {
+			if v%2 != 0 {
+				return fmt.Errorf("first half not even")
+			}
+			sumEven += v
+		} else {
+			if v%2 == 0 {
+				return fmt.Errorf("second half not odd")
+			}
+			sumOdd += v
+		}
+	}
+	if sumEven != sumOdd {
+		return fmt.Errorf("sum mismatch %d vs %d", sumEven, sumOdd)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := genCase(rng)
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1343/verifierC.go
+++ b/1000-1999/1300-1399/1340-1349/1343/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) []int64 {
+	n := rng.Intn(50) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		v := rng.Int63n(200) - 100
+		if v == 0 {
+			v = 1
+		}
+		arr[i] = v
+	}
+	return arr
+}
+
+func expected(arr []int64) int64 {
+	if len(arr) == 0 {
+		return 0
+	}
+	currMax := arr[0]
+	ans := int64(0)
+	currSign := arr[0] > 0
+	for i := 1; i < len(arr); i++ {
+		sign := arr[i] > 0
+		if sign == currSign {
+			if arr[i] > currMax {
+				currMax = arr[i]
+			}
+		} else {
+			ans += currMax
+			currMax = arr[i]
+			currSign = sign
+		}
+	}
+	ans += currMax
+	return ans
+}
+
+func runCase(bin string, arr []int64) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	out, err := runProg(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	exp := expected(arr)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := genCase(rng)
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1343/verifierD.go
+++ b/1000-1999/1300-1399/1340-1349/1343/verifierD.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1343D.go")
+	return runProg(ref, input)
+}
+
+func genCase(rng *rand.Rand) (int, int, []int) {
+	n := 2 * (rng.Intn(50) + 1) // even 2..100
+	k := rng.Intn(50) + 2       // 2..51
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(k) + 1
+	}
+	return n, k, arr
+}
+
+func runCase(bin string, n, k int, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	expect, err := runRef(sb.String())
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %s got %s", strings.TrimSpace(expect), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, arr := genCase(rng)
+		if err := runCase(bin, n, k, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1343/verifierE.go
+++ b/1000-1999/1300-1399/1340-1349/1343/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1343E.go")
+	return runProg(ref, input)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 2 // 2..7
+	maxM := n * (n - 1) / 2
+	m := rng.Intn(maxM-(n-1)+1) + (n - 1)
+	a := rng.Intn(n) + 1
+	b := rng.Intn(n) + 1
+	c := rng.Intn(n) + 1
+	edges := make([][2]int, 0, m)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{i, p})
+	}
+	has := func(x, y int) bool {
+		for _, e := range edges {
+			if (e[0] == x && e[1] == y) || (e[0] == y && e[1] == x) {
+				return true
+			}
+		}
+		return false
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v || has(u, v) {
+			continue
+		}
+		edges = append(edges, [2]int{u, v})
+	}
+	prices := make([]int, m)
+	for i := range prices {
+		prices[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d %d %d %d\n", n, m, a, b, c)
+	for i, v := range prices {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	return sb.String()
+}
+
+func runCase(bin string, input string) error {
+	expect, err := runRef(input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %s got %s", strings.TrimSpace(expect), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1343/verifierF.go
+++ b/1000-1999/1300-1399/1340-1349/1343/verifierF.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verify(perm []int, segs [][]int) bool {
+	n := len(perm)
+	counter := make(map[string]int)
+	for _, s := range segs {
+		key := fmt.Sprint(s)
+		counter[key]++
+	}
+	for r := 2; r <= n; r++ {
+		found := false
+		for l := 1; l < r; l++ {
+			sub := append([]int(nil), perm[l-1:r]...)
+			sort.Ints(sub)
+			key := fmt.Sprint(sub)
+			if counter[key] > 0 {
+				counter[key]--
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func genCase(rng *rand.Rand) (string, [][]int, int) {
+	n := rng.Intn(8) + 2 // 2..9
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	segs := make([][]int, n-1)
+	idx := 0
+	for r := 2; r <= n; r++ {
+		l := rng.Intn(r-1) + 1
+		seg := append([]int(nil), perm[l-1:r]...)
+		sort.Ints(seg)
+		segs[idx] = seg
+		idx++
+	}
+	rng.Shuffle(len(segs), func(i, j int) { segs[i], segs[j] = segs[j], segs[i] })
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, seg := range segs {
+		sb.WriteString(fmt.Sprintf("%d", len(seg)))
+		for _, v := range seg {
+			sb.WriteByte(' ')
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), segs, n
+}
+
+func runCase(bin string, input string, segs [][]int, n int) error {
+	out, err := runProg(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	if len(fields) != n {
+		return fmt.Errorf("expected %d numbers got %d", n, len(fields))
+	}
+	perm := make([]int, n)
+	seen := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		v, err := strconv.Atoi(fields[i])
+		if err != nil {
+			return fmt.Errorf("invalid number: %v", err)
+		}
+		if v < 1 || v > n {
+			return fmt.Errorf("value %d out of range", v)
+		}
+		if seen[v] {
+			return fmt.Errorf("duplicate value %d", v)
+		}
+		seen[v] = true
+		perm[i] = v
+	}
+	if !verify(perm, segs) {
+		return fmt.Errorf("output does not satisfy segments")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, segs, n := genCase(rng)
+		if err := runCase(bin, input, segs, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1343
- each verifier generates 100 random tests and checks candidate outputs
- reference solutions are used where appropriate to compute expected results

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885d8f9c0208324ba9a5ad4cd1c7fee