### PR TITLE
Add solution verifiers for CF 1345

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1345/verifierA.go
+++ b/1000-1999/1300-1399/1340-1349/1345/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct{n,m int}
+
+func solve(n,m int) string {
+    if n==1 || m==1 || (n==2 && m==2) {
+        return "YES"
+    }
+    return "NO"
+}
+
+func main(){
+    if len(os.Args) != 2 {
+        fmt.Println("Usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := make([]test,0)
+    // generate 120 test cases
+    for i:=1;i<=20;i++{
+        for j:=1;j<=6;j++{
+            tests = append(tests,test{i,j})
+        }
+    }
+    // add some larger cases
+    large := []test{{100,100},{1,1000},{1000,1},{20000,20000}}
+    tests = append(tests, large...)
+    input := fmt.Sprintf("%d\n", len(tests))
+    expected := make([]string,0,len(tests))
+    for _,t := range tests{
+        input += fmt.Sprintf("%d %d\n", t.n,t.m)
+        expected = append(expected, solve(t.n,t.m))
+    }
+    out,err := run(bin,input)
+    if err != nil {
+        fmt.Printf("error executing %s: %v\nOutput:\n%s", bin, err, out)
+        os.Exit(1)
+    }
+    lines := strings.Fields(strings.TrimSpace(out))
+    if len(lines)!=len(expected){
+        fmt.Printf("expected %d lines, got %d\n", len(expected), len(lines))
+        os.Exit(1)
+    }
+    for i,exp := range expected{
+        if strings.ToUpper(lines[i]) != exp {
+            fmt.Printf("mismatch on test %d: expected %s got %s\n", i+1, exp, lines[i])
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed!")
+}
+
+func run(bin,stringInput string)(string,error){
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(stringInput)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return out.String(), err
+}

--- a/1000-1999/1300-1399/1340-1349/1345/verifierB.go
+++ b/1000-1999/1300-1399/1340-1349/1345/verifierB.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func solve(n int) int {
+    cards := make([]int,0)
+    for h:=1;;h++{
+        val := (3*h*h + h)/2
+        if val>1e9{break}
+        cards = append(cards,val)
+    }
+    cnt := 0
+    for n >= 2 {
+        best := -1
+        for _,v := range cards{
+            if v<=n{best=v}else{break}
+        }
+        if best==-1 {break}
+        n-=best
+        cnt++
+    }
+    return cnt
+}
+
+func main(){
+    if len(os.Args) != 2 {
+        fmt.Println("Usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := make([]int,0)
+    for i:=1;i<=100;i++{
+        tests = append(tests,i)
+    }
+    extra := []int{150,200,300,500,1000,5000,10000,50000,100000,1000000}
+    tests = append(tests, extra...)
+    input := fmt.Sprintf("%d\n", len(tests))
+    expected := make([]int,0,len(tests))
+    for _,n := range tests{
+        input += fmt.Sprintf("%d\n", n)
+        expected = append(expected, solve(n))
+    }
+    out,err := run(bin,input)
+    if err != nil {
+        fmt.Printf("error executing %s: %v\nOutput:\n%s", bin, err, out)
+        os.Exit(1)
+    }
+    lines := strings.Fields(strings.TrimSpace(out))
+    if len(lines)!=len(expected){
+        fmt.Printf("expected %d lines, got %d\n", len(expected), len(lines))
+        os.Exit(1)
+    }
+    for i,exp := range expected{
+        if lines[i] != fmt.Sprint(exp) {
+            fmt.Printf("mismatch on test %d: expected %d got %s\n", i+1, exp, lines[i])
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed!")
+}
+
+func run(bin, input string)(string,error){
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return out.String(), err
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 1345
- each verifier executes a solution binary and checks it against more than 100 internal test cases

## Testing
- `go run verifierA.go ./1345A`
- `go build 1345B.go`
- `go run verifierB.go ./1345B`


------
https://chatgpt.com/codex/tasks/task_e_6885da11d9fc8324b8661a1c9f2aa2d3