### PR TITLE
Add Go solution for Codeforces 1560C

### DIFF
--- a/1000-1999/1500-1599/1560-1569/1560/1560C.go
+++ b/1000-1999/1500-1599/1560-1569/1560/1560C.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var k int64
+		fmt.Fscan(reader, &k)
+		r, c := position(k)
+		fmt.Fprintf(writer, "%d %d\n", r, c)
+	}
+}
+
+func position(k int64) (int64, int64) {
+	root := int64(math.Sqrt(float64(k)))
+	if root*root < k {
+		root++
+	}
+	prev := (root - 1) * (root - 1)
+	diff := k - prev
+	if diff <= root {
+		return diff, root
+	}
+	return root, root*2 - diff
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problem 1560C (Infinity Table)

## Testing
- `gofmt -w 1000-1999/1500-1599/1560-1569/1560/1560C.go`


------
https://chatgpt.com/codex/tasks/task_e_6885dae40a3483248194f14d06ecaa49