### PR TITLE
Add Go solution for 1560B

### DIFF
--- a/1000-1999/1500-1599/1560-1569/1560/1560B.go
+++ b/1000-1999/1500-1599/1560-1569/1560/1560B.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b, c int
+		fmt.Fscan(reader, &a, &b, &c)
+		diff := abs(a - b)
+		n := diff * 2
+		if diff == 0 || max(a, b, c) > n {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		half := diff
+		var d int
+		if c > half {
+			d = c - half
+		} else {
+			d = c + half
+		}
+		fmt.Fprintln(writer, d)
+	}
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func max(nums ...int) int {
+	m := nums[0]
+	for _, v := range nums[1:] {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1560B

## Testing
- `go run 1000-1999/1500-1599/1560-1569/1560/1560B.go <<EOF
1
1 5 3
EOF`
- `printf "3\n4 7 5\n2 3 2\n2 4 10\n" | go run 1000-1999/1500-1599/1560-1569/1560/1560B.go`

------
https://chatgpt.com/codex/tasks/task_e_6885db70309483249d17d14e4be7915d