### PR TITLE
Fix verifier build paths for contest 85

### DIFF
--- a/0-999/0-99/80-89/85/verifierA.go
+++ b/0-999/0-99/80-89/85/verifierA.go
@@ -12,7 +12,7 @@ import (
 
 func buildOracle() (string, error) {
 	exe := "oracleA"
-	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/85/85A.go")
+	cmd := exec.Command("go", "build", "-o", exe, "85A.go")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
 	}

--- a/0-999/0-99/80-89/85/verifierB.go
+++ b/0-999/0-99/80-89/85/verifierB.go
@@ -12,7 +12,7 @@ import (
 
 func buildOracle() (string, error) {
 	exe := "oracleB"
-	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/85/85B.go")
+	cmd := exec.Command("go", "build", "-o", exe, "85B.go")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
 	}

--- a/0-999/0-99/80-89/85/verifierC.go
+++ b/0-999/0-99/80-89/85/verifierC.go
@@ -125,7 +125,7 @@ func generateCase(rng *rand.Rand) string {
 
 func buildOracle() (string, error) {
 	exe := "oracleC"
-	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/85/85C.go")
+	cmd := exec.Command("go", "build", "-o", exe, "85C.go")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
 	}

--- a/0-999/0-99/80-89/85/verifierD.go
+++ b/0-999/0-99/80-89/85/verifierD.go
@@ -12,7 +12,7 @@ import (
 
 func buildOracle() (string, error) {
 	exe := "oracleD"
-	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/85/85D.go")
+	cmd := exec.Command("go", "build", "-o", exe, "85D.go")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
 	}

--- a/0-999/0-99/80-89/85/verifierE.go
+++ b/0-999/0-99/80-89/85/verifierE.go
@@ -12,7 +12,7 @@ import (
 
 func buildOracle() (string, error) {
 	exe := "oracleE"
-	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/85/85E.go")
+	cmd := exec.Command("go", "build", "-o", exe, "85E.go")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
 	}


### PR DESCRIPTION
## Summary
- use local Go file names when building oracles for contest 85

## Testing
- `go build 0-999/0-99/80-89/85/verifierB.go && echo "build success"`
- `go build 0-999/0-99/80-89/85/verifierA.go && echo ok`


------
https://chatgpt.com/codex/tasks/task_e_6885db82bd148324b59961654e757791