### PR TITLE
Add Go verifiers for contest 1348

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1348/verifierA.go
+++ b/1000-1999/1300-1399/1340-1349/1348/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct{ n int }
+
+func (t Test) Input() string {
+	return fmt.Sprintf("1\n%d\n", t.n)
+}
+
+func expected(t Test) string {
+	n := t.n
+	sum1 := 1 << n
+	for i := 1; i <= n/2-1; i++ {
+		sum1 += 1 << i
+	}
+	sum2 := 0
+	for i := n / 2; i <= n-1; i++ {
+		sum2 += 1 << i
+	}
+	return fmt.Sprintf("%d", sum1-sum2)
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(15)*2 + 2
+	return Test{n}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1300-1399/1340-1349/1348/verifierB.go
+++ b/1000-1999/1300-1399/1340-1349/1348/verifierB.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n   int
+	k   int
+	arr []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.k))
+	for i, v := range t.arr {
+		if i+1 == len(t.arr) {
+			sb.WriteString(fmt.Sprintf("%d\n", v))
+		} else {
+			sb.WriteString(fmt.Sprintf("%d ", v))
+		}
+	}
+	return sb.String()
+}
+
+func expected(t Test) string {
+	distinct := make(map[int]bool)
+	beauty := []int{}
+	for _, v := range t.arr {
+		if !distinct[v] {
+			distinct[v] = true
+			beauty = append(beauty, v)
+		}
+	}
+	if len(beauty) > t.k {
+		return "-1"
+	}
+	for i := 1; i <= t.n && len(beauty) < t.k; i++ {
+		if !distinct[i] {
+			distinct[i] = true
+			beauty = append(beauty, i)
+		}
+	}
+	total := t.n * len(beauty)
+	seq := make([]string, 0, total)
+	for i := 0; i < t.n; i++ {
+		for _, v := range beauty {
+			seq = append(seq, strconv.Itoa(v))
+		}
+	}
+	return fmt.Sprintf("%d\n%s", total, strings.Join(seq, " "))
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n) + 1
+	}
+	return Test{n: n, k: k, arr: arr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1300-1399/1340-1349/1348/verifierC.go
+++ b/1000-1999/1300-1399/1340-1349/1348/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	k int
+	s string
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("1\n%d %d\n%s\n", t.n, t.k, t.s)
+}
+
+func expected(t Test) string {
+	bytesArr := []byte(t.s)
+	sort.Slice(bytesArr, func(i, j int) bool { return bytesArr[i] < bytesArr[j] })
+	if bytesArr[0] != bytesArr[t.k-1] {
+		return string(bytesArr[t.k-1])
+	}
+	res := []byte{bytesArr[0]}
+	if t.k < t.n {
+		if bytesArr[t.k] != bytesArr[t.n-1] {
+			res = append(res, bytesArr[t.k:]...)
+		} else {
+			cnt := (t.n - t.k + t.k - 1) / t.k
+			res = append(res, []byte(strings.Repeat(string(bytesArr[t.k]), cnt))...)
+		}
+	}
+	return string(res)
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	letters := make([]byte, n)
+	for i := range letters {
+		letters[i] = byte('a' + rng.Intn(26))
+	}
+	return Test{n: n, k: k, s: string(letters)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1300-1399/1340-1349/1348/verifierD.go
+++ b/1000-1999/1300-1399/1340-1349/1348/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct{ n int64 }
+
+func (t Test) Input() string {
+	return fmt.Sprintf("1\n%d\n", t.n)
+}
+
+func expected(t Test) string {
+	n := t.n
+	days := 0
+	for (1<<days)-1 < int(n) {
+		days++
+	}
+	days--
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", days))
+	rem := n - 1
+	last := int64(1)
+	for i := days; i >= 1; i-- {
+		low := last
+		high := last * 2
+		ans := high
+		for low <= high {
+			mid := (low + high) / 2
+			mn := int64(i) * mid
+			mx := int64((1<<i)-1) * mid
+			if mn > rem {
+				high = mid - 1
+			} else if mx < rem {
+				low = mid + 1
+			} else {
+				ans = mid
+				break
+			}
+		}
+		sb.WriteString(fmt.Sprintf("%d", ans-last))
+		if i > 1 {
+			sb.WriteString(" ")
+		}
+		rem -= ans
+		last = ans
+	}
+	if days >= 1 {
+		sb.WriteString("\n")
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Int63n(1_000_000_000-2) + 2
+	return Test{n}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1300-1399/1340-1349/1348/verifierE.go
+++ b/1000-1999/1300-1399/1340-1349/1348/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	k int
+	a []int
+	b []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.k))
+	for i := 0; i < t.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.a[i], t.b[i]))
+	}
+	return sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expected(t Test) string {
+	n, k := t.n, t.k
+	sumR := 0
+	sumB := 0
+	for i := 0; i < n; i++ {
+		sumR += t.a[i]
+		sumB += t.b[i]
+	}
+	dp := make([]bool, k)
+	dp[0] = true
+	for i := 0; i < n; i++ {
+		ndp := make([]bool, k)
+		for r := 0; r < k; r++ {
+			if !dp[r] {
+				continue
+			}
+			maxx := min(t.a[i], k-1)
+			for x := 0; x <= maxx; x++ {
+				y := (k - ((r + x) % k)) % k
+				if y <= t.b[i] && x+y <= t.a[i]+t.b[i] {
+					ndp[(r+x)%k] = true
+				}
+			}
+		}
+		dp = ndp
+	}
+	total := sumR + sumB
+	res := total / k
+	if !dp[sumR%k] {
+		res--
+	}
+	if res < 0 {
+		res = 0
+	}
+	return fmt.Sprintf("%d", res)
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(10) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(10)
+		b[i] = rng.Intn(10)
+	}
+	return Test{n: n, k: k, a: a, b: b}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1300-1399/1340-1349/1348/verifierF.go
+++ b/1000-1999/1300-1399/1340-1349/1348/verifierF.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	a []int
+	b []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.n))
+	for i := 0; i < t.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.a[i], t.b[i]))
+	}
+	return sb.String()
+}
+
+type Person struct {
+	id  int
+	a   int
+	b   int
+	ans int
+}
+
+type Item struct {
+	b   int
+	idx int
+}
+
+type PQ []Item
+
+func (pq PQ) Len() int { return len(pq) }
+func (pq PQ) Less(i, j int) bool {
+	if pq[i].b == pq[j].b {
+		return pq[i].idx < pq[j].idx
+	}
+	return pq[i].b < pq[j].b
+}
+func (pq PQ) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PQ) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	x := old[n-1]
+	*pq = old[:n-1]
+	return x
+}
+
+type Pair struct {
+	b  int
+	id int
+}
+
+func pairMax(x, y Pair) Pair {
+	if x.b > y.b {
+		return x
+	} else if x.b < y.b {
+		return y
+	}
+	if x.id > y.id {
+		return x
+	}
+	return y
+}
+
+func expected(t Test) string {
+	n := t.n
+	p := make([]Person, n)
+	for i := 0; i < n; i++ {
+		p[i] = Person{id: i + 1, a: t.a[i], b: t.b[i]}
+	}
+	sort.Slice(p, func(i, j int) bool { return p[i].a < p[j].a })
+	pq := &PQ{}
+	heap.Init(pq)
+	j := 0
+	for i := 1; i <= n; i++ {
+		for j < n && p[j].a <= i {
+			heap.Push(pq, Item{b: p[j].b, idx: j})
+			j++
+		}
+		item := heap.Pop(pq).(Item)
+		p[item.idx].ans = i
+	}
+	sort.Slice(p, func(i, j int) bool { return p[i].ans < p[j].ans })
+	ft := make([]Pair, n+2)
+	update := func(u, b, id int) {
+		for u > 0 {
+			if pairMax(ft[u], Pair{b, id}) != ft[u] {
+				ft[u] = pairMax(ft[u], Pair{b, id})
+			}
+			u -= u & -u
+		}
+	}
+	get := func(u int) Pair {
+		res := Pair{0, 0}
+		for u <= n {
+			res = pairMax(res, ft[u])
+			u += u & -u
+		}
+		return res
+	}
+	resU, resV := 0, 0
+	for i := 0; i < n; i++ {
+		mx := get(p[i].a)
+		if mx.b >= p[i].ans {
+			resU = p[i].id
+			resV = mx.id
+			break
+		}
+		update(p[i].ans, p[i].b, p[i].id)
+	}
+	sort.Slice(p, func(i, j int) bool { return p[i].id < p[j].id })
+	var sb strings.Builder
+	if resU != 0 {
+		sb.WriteString("NO\n")
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d", p[i].ans))
+			if i+1 == n {
+				sb.WriteString("\n")
+			} else {
+				sb.WriteString(" ")
+			}
+		}
+		for i := range p {
+			if p[i].id == resU {
+				for j := range p {
+					if p[j].id == resV {
+						p[i].ans, p[j].ans = p[j].ans, p[i].ans
+						break
+					}
+				}
+				break
+			}
+		}
+	} else {
+		sb.WriteString("YES\n")
+	}
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", p[i].ans))
+		if i+1 == n {
+			sb.WriteString("\n")
+		} else {
+			sb.WriteString(" ")
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(10) + 1
+	perm := rng.Perm(n)
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		val := perm[i] + 1
+		a[i] = rng.Intn(val) + 1
+		b[i] = val + rng.Intn(n-val+1)
+	}
+	return Test{n: n, a: a, b: b}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 1348 (problems A–F)
- each verifier generates at least 100 random test cases and checks an external binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6885dbb61eac8324b5aed86607148e15