### PR TITLE
Add Go solution for 1567B

### DIFF
--- a/1000-1999/1500-1599/1560-1569/1567/1567B.go
+++ b/1000-1999/1500-1599/1560-1569/1567/1567B.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func prefixXor(n int) int {
+	switch n & 3 {
+	case 0:
+		return n
+	case 1:
+		return 1
+	case 2:
+		return n + 1
+	default:
+		return 0
+	}
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b int
+		fmt.Fscan(reader, &a, &b)
+
+		x := prefixXor(a - 1)
+		if x == b {
+			fmt.Fprintln(writer, a)
+		} else if (x ^ b) == a {
+			fmt.Fprintln(writer, a+2)
+		} else {
+			fmt.Fprintln(writer, a+1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1567B (MEXor Mixup)

## Testing
- `gofmt -w 1000-1999/1500-1599/1560-1569/1567/1567B.go`


------
https://chatgpt.com/codex/tasks/task_e_6885dda0480c83249f4ee2c37f62eaeb