### PR TITLE
Add Go verifiers for contest 1349

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1349/verifierA.go
+++ b/1000-1999/1300-1399/1340-1349/1349/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refA-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1349A.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(9) + 2 // 2..10
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(200000)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nGot: %s\ninput:\n%s", t+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1349/verifierB.go
+++ b/1000-1999/1300-1399/1340-1349/1349/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refB-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1349B.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(4) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(8) + 1
+		k := rng.Intn(20) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(20)+1)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", tcase+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nGot: %s\ninput:\n%s", tcase+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1349/verifierC.go
+++ b/1000-1999/1300-1399/1340-1349/1349/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refC-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1349C.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	t := rng.Intn(4) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, t)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 1 {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('0')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < t; i++ {
+		ii := rng.Intn(n) + 1
+		jj := rng.Intn(m) + 1
+		p := rng.Intn(10)
+		fmt.Fprintf(&sb, "%d %d %d\n", ii, jj, p)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", tcase+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nGot: %s\ninput:\n%s", tcase+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1349/verifierD.go
+++ b/1000-1999/1300-1399/1340-1349/1349/verifierD.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	a %= mod
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func solveTwo(a, b int) int64 {
+	S := a + b
+	if S <= 1 {
+		return 0
+	}
+	n := S - 1
+	A := make([][]*big.Rat, n)
+	B := make([]*big.Rat, n)
+	for i := 0; i < n; i++ {
+		A[i] = make([]*big.Rat, n)
+		B[i] = new(big.Rat).SetInt64(1)
+	}
+	for k := 1; k < S; k++ {
+		row := k - 1
+		A[row][row] = new(big.Rat).SetInt64(1)
+		if k-1 >= 1 {
+			A[row][row-1] = new(big.Rat).SetFrac(big.NewInt(int64(-k)), big.NewInt(int64(S)))
+		}
+		if k+1 <= S-1 {
+			A[row][row+1] = new(big.Rat).SetFrac(big.NewInt(int64(k-S)), big.NewInt(int64(S)))
+		}
+	}
+	// Gaussian elimination
+	for i := 0; i < n; i++ {
+		pivot := i
+		for pivot < n && (A[pivot][i] == nil || A[pivot][i].Sign() == 0) {
+			pivot++
+		}
+		if pivot == n {
+			continue
+		}
+		if pivot != i {
+			A[i], A[pivot] = A[pivot], A[i]
+			B[i], B[pivot] = B[pivot], B[i]
+		}
+		pv := new(big.Rat).Set(A[i][i])
+		for j := i; j < n; j++ {
+			if A[i][j] == nil {
+				A[i][j] = new(big.Rat)
+			}
+			A[i][j].Quo(A[i][j], pv)
+		}
+		B[i].Quo(B[i], pv)
+		for r := 0; r < n; r++ {
+			if r == i {
+				continue
+			}
+			if A[r][i] == nil || A[r][i].Sign() == 0 {
+				continue
+			}
+			factor := new(big.Rat).Set(A[r][i])
+			for j := i; j < n; j++ {
+				if A[r][j] == nil {
+					A[r][j] = new(big.Rat)
+				}
+				tmp := new(big.Rat).Mul(factor, A[i][j])
+				A[r][j].Sub(A[r][j], tmp)
+			}
+			tmp := new(big.Rat).Mul(factor, B[i])
+			B[r].Sub(B[r], tmp)
+		}
+	}
+	res := B[a-1]
+	num := new(big.Int).Mod(res.Num(), big.NewInt(mod))
+	den := new(big.Int).Mod(res.Denom(), big.NewInt(mod))
+	inv := modPow(den.Int64(), mod-2)
+	return num.Int64() * inv % mod
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	a := rng.Intn(4) + 1
+	b := rng.Intn(4) + 1
+	return fmt.Sprintf("2\n%d %d\n", a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		input := genCase(rng)
+		var a, b int
+		fmt.Sscanf(input, "2\n%d %d\n", &a, &b)
+		exp := solveTwo(a, b)
+		gotStr, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		var got int64
+		fmt.Sscan(gotStr, &got)
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %d\nGot: %d\ninput:\n%s", tcase+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1349/verifierE.go
+++ b/1000-1999/1300-1399/1340-1349/1349/verifierE.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refE-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1349E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		if rng.Intn(3) == 0 {
+			sb.WriteByte('0')
+		} else {
+			fmt.Fprintf(&sb, "%d", rng.Int63n(10)+1)
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", tcase+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nGot: %s\ninput:\n%s", tcase+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1349/verifierF1.go
+++ b/1000-1999/1300-1399/1340-1349/1349/verifierF1.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refF1-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1349F1.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", tcase+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nGot: %s\ninput:\n%s", tcase+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1340-1349/1349/verifierF2.go
+++ b/1000-1999/1300-1399/1340-1349/1349/verifierF2.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refF2-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1349F2.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", tcase+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nGot: %s\ninput:\n%s", tcase+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifiers for every problem in contest 1349
- each verifier compiles a reference solution and runs 100 random tests
- brute force solver included for Problem D

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF1.go`
- `go build verifierF2.go`


------
https://chatgpt.com/codex/tasks/task_e_6885dc423fc88324a9a2341d33e6f872