### PR TITLE
Add solution verifiers for contest 1353

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1353/verifierA.go
+++ b/1000-1999/1300-1399/1350-1359/1353/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testA struct {
+	n int64
+	m int64
+}
+
+func genTestsA() []testA {
+	rand.Seed(1353)
+	tests := make([]testA, 0, 100)
+	// edge cases
+	tests = append(tests, testA{1, 0}, testA{2, 5}, testA{3, 7}, testA{2, 0})
+	tests = append(tests, testA{1, 1000000000}, testA{2, 1000000000}, testA{3, 1000000000})
+	for len(tests) < 100 {
+		n := rand.Int63n(1000) + 1
+		m := rand.Int63n(1000000000)
+		tests = append(tests, testA{n, m})
+	}
+	return tests[:100]
+}
+
+func expectedA(n, m int64) int64 {
+	if n == 1 {
+		return 0
+	}
+	if n == 2 {
+		return m
+	}
+	return 2 * m
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d %d\n", tc.n, tc.m)
+		exp := fmt.Sprintf("%d", expectedA(tc.n, tc.m))
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1300-1399/1350-1359/1353/verifierB.go
+++ b/1000-1999/1300-1399/1350-1359/1353/verifierB.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testB struct {
+	n int
+	k int
+	a []int
+	b []int
+}
+
+func genTestsB() []testB {
+	rand.Seed(2353)
+	tests := make([]testB, 0, 100)
+	// some edge tests
+	tests = append(tests, testB{n: 1, k: 0, a: []int{1}, b: []int{2}})
+	tests = append(tests, testB{n: 1, k: 1, a: []int{5}, b: []int{10}})
+	tests = append(tests, testB{n: 2, k: 1, a: []int{1, 2}, b: []int{3, 4}})
+	for len(tests) < 100 {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(n + 1)
+		a := make([]int, n)
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(50)
+			b[i] = rand.Intn(50)
+		}
+		tests = append(tests, testB{n: n, k: k, a: a, b: b})
+	}
+	return tests[:100]
+}
+
+func expectedB(tc testB) int {
+	a := append([]int(nil), tc.a...)
+	b := append([]int(nil), tc.b...)
+	sort.Ints(a)
+	sort.Slice(b, func(i, j int) bool { return b[i] > b[j] })
+	for i := 0; i < tc.k && i < tc.n; i++ {
+		if a[i] < b[i] {
+			a[i] = b[i]
+		} else {
+			break
+		}
+	}
+	sum := 0
+	for _, v := range a {
+		sum += v
+	}
+	return sum
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+		for i2, v := range tc.a {
+			if i2 > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for i2, v := range tc.b {
+			if i2 > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		exp := fmt.Sprintf("%d", expectedB(tc))
+		got, err := runProg(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1300-1399/1350-1359/1353/verifierC.go
+++ b/1000-1999/1300-1399/1350-1359/1353/verifierC.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testC struct {
+	n int64
+}
+
+func genTestsC() []testC {
+	rand.Seed(3353)
+	tests := make([]testC, 0, 100)
+	tests = append(tests, testC{1}, testC{3}, testC{5})
+	for len(tests) < 100 {
+		// n must be odd and <= 500000
+		n := int64(rand.Intn(250000))*2 + 1
+		tests = append(tests, testC{n})
+	}
+	return tests[:100]
+}
+
+func expectedC(n int64) int64 {
+	return n * (n*n - 1) / 3
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n", tc.n)
+		exp := fmt.Sprintf("%d", expectedC(tc.n))
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1300-1399/1350-1359/1353/verifierD.go
+++ b/1000-1999/1300-1399/1350-1359/1353/verifierD.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type segment struct{ l, r int }
+
+type segHeap []segment
+
+func (h segHeap) Len() int { return len(h) }
+func (h segHeap) Less(i, j int) bool {
+	lenI := h[i].r - h[i].l + 1
+	lenJ := h[j].r - h[j].l + 1
+	if lenI == lenJ {
+		return h[i].l < h[j].l
+	}
+	return lenI > lenJ
+}
+func (h segHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *segHeap) Push(x interface{}) { *h = append(*h, x.(segment)) }
+func (h *segHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+type testD struct{ n int }
+
+func genTestsD() []testD {
+	rand.Seed(4353)
+	tests := make([]testD, 0, 100)
+	tests = append(tests, testD{1}, testD{2}, testD{3}, testD{10})
+	for len(tests) < 100 {
+		n := rand.Intn(100) + 1
+		tests = append(tests, testD{n})
+	}
+	return tests[:100]
+}
+
+func expectedD(n int) []int {
+	ans := make([]int, n+1)
+	h := &segHeap{{1, n}}
+	heap.Init(h)
+	for i := 1; i <= n; i++ {
+		seg := heap.Pop(h).(segment)
+		l, r := seg.l, seg.r
+		var mid int
+		length := r - l + 1
+		if length%2 == 1 {
+			mid = (l + r) / 2
+		} else {
+			mid = (l + r - 1) / 2
+		}
+		ans[mid] = i
+		if l <= mid-1 {
+			heap.Push(h, segment{l, mid - 1})
+		}
+		if mid+1 <= r {
+			heap.Push(h, segment{mid + 1, r})
+		}
+	}
+	return ans[1:]
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	for idx, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n", tc.n)
+		expArr := expectedD(tc.n)
+		exp := make([]string, len(expArr))
+		for i, v := range expArr {
+			exp[i] = fmt.Sprintf("%d", v)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", idx+1, err, got)
+			os.Exit(1)
+		}
+		gotFields := strings.Fields(got)
+		if len(gotFields) != len(expArr) {
+			fmt.Printf("test %d failed: expected %d numbers got %d\n", idx+1, len(expArr), len(gotFields))
+			os.Exit(1)
+		}
+		for i, v := range expArr {
+			if gotFields[i] != fmt.Sprintf("%d", v) {
+				fmt.Printf("test %d failed at pos %d: expected %d got %s\n", idx+1, i+1, v, gotFields[i])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1300-1399/1350-1359/1353/verifierE.go
+++ b/1000-1999/1300-1399/1350-1359/1353/verifierE.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testE struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "oracleE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1353E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []testE {
+	rand.Seed(5353)
+	tests := make([]testE, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(50) + 1
+		k := rand.Intn(n) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, testE{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%s", tc.input)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\nexpected: %s\n got: %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1300-1399/1350-1359/1353/verifierF.go
+++ b/1000-1999/1300-1399/1350-1359/1353/verifierF.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testF struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "oracleF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1353F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []testF {
+	rand.Seed(6353)
+	tests := make([]testF, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				val := rand.Int63n(100) + 1
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", val))
+			}
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, testF{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%s", tc.input)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\nexpected: %s\n got: %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1353
- each verifier generates 100 random tests and checks results
- verifiers for E and F compile reference solutions to compare outputs

## Testing
- `go build 1000-1999/1300-1399/1350-1359/1353/verifierA.go`
- `go build 1000-1999/1300-1399/1350-1359/1353/verifierB.go`
- `go build 1000-1999/1300-1399/1350-1359/1353/verifierC.go`
- `go build 1000-1999/1300-1399/1350-1359/1353/verifierD.go`
- `go build 1000-1999/1300-1399/1350-1359/1353/verifierE.go`
- `go build 1000-1999/1300-1399/1350-1359/1353/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885de7266948324860695fce85c8933