### PR TITLE
Add verifiers for Codeforces 1354

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1354/verifierA.go
+++ b/1000-1999/1300-1399/1350-1359/1354/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleA.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1354A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n5 10 3 1\n",
+		"1\n10 5 3 3\n",
+		"1\n10 3 6 1\n",
+		fmt.Sprintf("1\n%d %d %d %d\n", 1000000, 999999, 1000000, 1),
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	a := rng.Int63n(1000000) + 1
+	b := rng.Int63n(1000000) + 1
+	c := rng.Int63n(1000000) + 1
+	d := rng.Int63n(1000000) + 1
+	return fmt.Sprintf("1\n%d %d %d %d\n", a, b, c, d)
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if result != expected {
+		return fmt.Errorf("expected %s got %s", expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, input := range cases {
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1354/verifierB.go
+++ b/1000-1999/1300-1399/1350-1359/1354/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleB.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1354B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1\n",
+		"1\n2\n",
+		"1\n3\n",
+		"1\n123\n",
+		"1\n111222333\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	l := rng.Intn(20) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		b[i] = byte('1' + rng.Intn(3))
+	}
+	return fmt.Sprintf("1\n%s\n", string(b))
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if result != expected {
+		return fmt.Errorf("expected %s got %s", expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, input := range cases {
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1354/verifierC1.go
+++ b/1000-1999/1300-1399/1350-1359/1354/verifierC1.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleC1.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1354C1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n2\n",
+		"1\n4\n",
+		"1\n6\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := 2 * (rng.Intn(100) + 1)
+	return fmt.Sprintf("1\n%d\n", n)
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if result != expected {
+		return fmt.Errorf("expected %s got %s", expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, input := range cases {
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1354/verifierC2.go
+++ b/1000-1999/1300-1399/1350-1359/1354/verifierC2.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleC2.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1354C2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n3\n",
+		"1\n5\n",
+		"1\n7\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := 2*(rng.Intn(100)) + 1
+	if n < 3 {
+		n = 3
+	}
+	return fmt.Sprintf("1\n%d\n", n)
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if result != expected {
+		return fmt.Errorf("expected %s got %s", expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, input := range cases {
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1354/verifierD.go
+++ b/1000-1999/1300-1399/1350-1359/1354/verifierD.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleD.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1354D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+type testCase struct {
+	n       int
+	q       int
+	a       []int
+	queries []int
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	q := rng.Intn(5) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(n) + 1
+	}
+	sort.Ints(a)
+	cur := n
+	queries := make([]int, q)
+	for i := 0; i < q; i++ {
+		if cur == 0 || rng.Intn(2) == 0 {
+			queries[i] = rng.Intn(n+q) + 1
+			cur++
+		} else {
+			idx := rng.Intn(cur) + 1
+			queries[i] = -idx
+			cur--
+		}
+	}
+	return testCase{n, q, a, queries}
+}
+
+func deterministicCases() []testCase {
+	return []testCase{
+		{1, 1, []int{1}, []int{-1}},
+		{2, 2, []int{1, 2}, []int{-1, -1}},
+		{2, 2, []int{1, 1}, []int{3, -1}},
+	}
+}
+
+func (tc testCase) input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.q))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.queries {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	input := tc.input()
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if result != expected {
+		return fmt.Errorf("expected %s got %s", expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := deterministicCases()
+	for len(tests) < 100 {
+		tests = append(tests, randomCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1354/verifierE.go
+++ b/1000-1999/1300-1399/1350-1359/1354/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleE.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1354E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+type testCase struct {
+	n     int
+	m     int
+	n1    int
+	n2    int
+	n3    int
+	edges [][2]int
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 3
+	n1 := rng.Intn(n + 1)
+	n2 := rng.Intn(n - n1 + 1)
+	n3 := n - n1 - n2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	used := make(map[[2]int]bool)
+	edges := make([][2]int, 0, m)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		edges = append(edges, key)
+	}
+	return testCase{n, m, n1, n2, n3, edges}
+}
+
+func deterministicCases() []testCase {
+	return []testCase{
+		{3, 0, 1, 1, 1, nil},
+		{4, 2, 1, 1, 2, [][2]int{{1, 2}, {3, 4}}},
+	}
+}
+
+func (tc testCase) input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n1, tc.n2, tc.n3))
+	for _, e := range tc.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	input := tc.input()
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if result != expected {
+		return fmt.Errorf("expected:\n%s\n---\ngot:\n%s", expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := deterministicCases()
+	for len(tests) < 100 {
+		tests = append(tests, randomCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1354/verifierF.go
+++ b/1000-1999/1300-1399/1350-1359/1354/verifierF.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleF.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1354F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+type testCase struct {
+	n int
+	k int
+	a []int
+	b []int
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(n) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(20) + 1
+		b[i] = rng.Intn(20)
+	}
+	return testCase{n, k, a, b}
+}
+
+func deterministicCases() []testCase {
+	return []testCase{
+		{1, 1, []int{1}, []int{0}},
+		{2, 1, []int{5, 3}, []int{0, 0}},
+	}
+}
+
+func (tc testCase) input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+	for i := 0; i < tc.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.a[i], tc.b[i]))
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	input := tc.input()
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if result != expected {
+		return fmt.Errorf("expected:\n%s\n---\ngot:\n%s", expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := deterministicCases()
+	for len(tests) < 100 {
+		tests = append(tests, randomCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1354/verifierG.go
+++ b/1000-1999/1300-1399/1350-1359/1354/verifierG.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleG.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1354G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+type testCase struct {
+	n int
+	k int
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 2
+	k := rng.Intn(n/2) + 1
+	return testCase{n, k}
+}
+
+func deterministicCases() []testCase {
+	return []testCase{{2, 1}, {3, 1}}
+}
+
+func (tc testCase) input() string {
+	return fmt.Sprintf("1\n%d %d\n", tc.n, tc.k)
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	input := tc.input()
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if result != expected {
+		return fmt.Errorf("expected %q got %q", expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := deterministicCases()
+	for len(tests) < 100 {
+		tests = append(tests, randomCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 1354 problems A–G
- each verifier compiles the official solution as an oracle
- run at least 100 deterministic or random testcases per problem

## Testing
- `go build verifierA.go verifierB.go verifierC1.go verifierC2.go verifierD.go verifierE.go verifierF.go verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_6885defe692483249d350fad48dd5f31