### PR TITLE
Add Go verifiers for Codeforces 1358

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1358/verifierA.go
+++ b/1000-1999/1300-1399/1350-1359/1358/verifierA.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m int64) string {
+	val := (n*m + 1) / 2
+	return fmt.Sprintf("%d", val)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		n := rng.Int63n(10000) + 1
+		m := rng.Int63n(10000) + 1
+		input := fmt.Sprintf("1\n%d %d\n", n, m)
+		want := expected(n, m)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1358/verifierB.go
+++ b/1000-1999/1300-1399/1350-1359/1358/verifierB.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(a []int) string {
+	sort.Ints(a)
+	ans := 1
+	for i, v := range a {
+		if v <= i+2 {
+			ans = i + 2
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		n := rng.Intn(100) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(200)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		sb.WriteByte('\n')
+		want := expected(append([]int(nil), arr...))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1358/verifierC.go
+++ b/1000-1999/1300-1399/1350-1359/1358/verifierC.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(x1, y1, x2, y2 int64) string {
+	dx := x2 - x1
+	dy := y2 - y1
+	val := dx*dy + 1
+	return fmt.Sprintf("%d", val)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		x1 := rng.Int63n(1_000_000_000) + 1
+		y1 := rng.Int63n(1_000_000_000) + 1
+		x2 := x1 + rng.Int63n(1_000_000)
+		y2 := y1 + rng.Int63n(1_000_000)
+		input := fmt.Sprintf("1\n%d %d %d %d\n", x1, y1, x2, y2)
+		want := expected(x1, y1, x2, y2)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1358/verifierD.go
+++ b/1000-1999/1300-1399/1350-1359/1358/verifierD.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func tri(x int64) int64 { return x * (x + 1) / 2 }
+
+func expected(d []int64, x int64) string {
+	n := len(d)
+	arr := make([]int64, 2*n)
+	for i := 0; i < 2*n; i++ {
+		arr[i] = d[i%n]
+	}
+	prefDays := make([]int64, 2*n+1)
+	prefHugs := make([]int64, 2*n+1)
+	for i := 0; i < 2*n; i++ {
+		prefDays[i+1] = prefDays[i] + arr[i]
+		prefHugs[i+1] = prefHugs[i] + tri(arr[i])
+	}
+	var best int64
+	for r := 1; r <= 2*n; r++ {
+		if prefDays[r] < x {
+			continue
+		}
+		need := prefDays[r] - x
+		idx := sort.Search(len(prefDays), func(i int) bool { return prefDays[i] > need }) - 1
+		if idx < 0 {
+			idx = 0
+		}
+		leftover := need - prefDays[idx]
+		partial := tri(arr[idx]) - tri(leftover)
+		val := partial + prefHugs[r] - prefHugs[idx+1]
+		if val > best {
+			best = val
+		}
+	}
+	return fmt.Sprintf("%d", best)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		n := rng.Intn(10) + 1
+		x := int64(rng.Intn(50) + 1)
+		d := make([]int64, n)
+		for i := range d {
+			d[i] = int64(rng.Intn(10) + 1)
+		}
+		// ensure x <= sum(d)
+		sum := int64(0)
+		for _, v := range d {
+			sum += v
+		}
+		if x > sum {
+			x = sum
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", d[i]))
+		}
+		sb.WriteByte('\n')
+		want := expected(d, x)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1358/verifierE.go
+++ b/1000-1999/1300-1399/1350-1359/1358/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, a []int64, x int64) string {
+	m := (n + 1) / 2
+	s := int64(0)
+	for i := 0; i < m; i++ {
+		s += a[i]
+	}
+	if s+int64(n/2)*x <= 0 && x >= 0 {
+		return "-1"
+	}
+	le := n
+	half := m
+	for i := 0; le*2 > n && i+le <= n; i++ {
+		for le*2 > n && s+x*int64(le+i-half) <= 0 {
+			le--
+		}
+		s -= a[i]
+	}
+	if le*2 > n {
+		return fmt.Sprintf("%d", le)
+	}
+	return "-1"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		n := rng.Intn(20) + 2 // ensure at least 2
+		m := (n + 1) / 2
+		a := make([]int64, m)
+		for i := 0; i < m; i++ {
+			a[i] = int64(rng.Intn(20) - 10)
+		}
+		x := int64(rng.Intn(20) - 10)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i*2 < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d\n", x))
+		want := expected(n, append([]int64(nil), a...), x)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1358/verifierF.go
+++ b/1000-1999/1300-1399/1350-1359/1358/verifierF.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	exe := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", exe, "1358F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		n := rng.Intn(3) + 1
+		A := make([]int64, n)
+		B := make([]int64, n)
+		for i := 0; i < n; i++ {
+			A[i] = int64(rng.Intn(5) + 1)
+		}
+		for i := 0; i < n; i++ {
+			B[i] = int64(rng.Intn(5) + 1)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", A[i]))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", B[i]))
+		}
+		sb.WriteByte('\n')
+		expect, err := run(oracle, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, sb.String())
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t, expect, got, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for contest 1358 problem A
- add verifierB.go for contest 1358 problem B
- add verifierC.go for contest 1358 problem C
- add verifierD.go for contest 1358 problem D
- add verifierE.go for contest 1358 problem E
- add verifierF.go for contest 1358 problem F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `./verA 1358A.go`

------
https://chatgpt.com/codex/tasks/task_e_6885e12eb1d48324a88409b4e11b7138