### PR TITLE
Add Go verifiers for contest 1359

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1359/verifierA.go
+++ b/1000-1999/1300-1399/1350-1359/1359/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct{ n, m, k int }
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(49) + 2 // 2..50
+	// collect divisors >=2 and <=n
+	divs := make([]int, 0)
+	for d := 2; d <= n; d++ {
+		if n%d == 0 {
+			divs = append(divs, d)
+		}
+	}
+	k := divs[rng.Intn(len(divs))]
+	m := rng.Intn(n + 1)
+	return testCase{n, m, k}
+}
+
+func expected(tc testCase) string {
+	per := tc.n / tc.k
+	x := tc.m
+	if x > per {
+		x = per
+	}
+	remaining := tc.m - x
+	y := 0
+	if tc.k > 1 {
+		y = (remaining + tc.k - 2) / (tc.k - 1)
+	}
+	return fmt.Sprintf("%d", x-y)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		input := fmt.Sprintf("1\n%d %d %d\n", tc.n, tc.m, tc.k)
+		want := expected(tc)
+		got, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1359/verifierB.go
+++ b/1000-1999/1300-1399/1350-1359/1359/verifierB.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m, x, y int, grid []string) string {
+	total := 0
+	for i := 0; i < n; i++ {
+		row := grid[i]
+		j := 0
+		for j < m {
+			if row[j] == '*' {
+				j++
+				continue
+			}
+			if j+1 < m && row[j+1] == '.' && y < 2*x {
+				total += y
+				j += 2
+			} else {
+				total += x
+				j++
+			}
+		}
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+type testCase struct {
+	n, m, x, y int
+	grid       []string
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	x := rng.Intn(1000) + 1
+	y := rng.Intn(1000) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = '.'
+			} else {
+				b[j] = '*'
+			}
+		}
+		grid[i] = string(b)
+	}
+	return testCase{n, m, x, y, grid}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", tc.n, tc.m, tc.x, tc.y))
+		for _, row := range tc.grid {
+			sb.WriteString(row + "\n")
+		}
+		input := sb.String()
+		want := expected(tc.n, tc.m, tc.x, tc.y, tc.grid)
+		got, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1359/verifierC.go
+++ b/1000-1999/1300-1399/1350-1359/1359/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct{ h, c, t int64 }
+
+func generateCase(rng *rand.Rand) testCase {
+	h := int64(rng.Intn(1_000_000-1) + 2)
+	c := int64(rng.Intn(int(h-1)) + 1)
+	t := c + int64(rng.Intn(int(h-c)+1))
+	return testCase{h, c, t}
+}
+
+func expected(tc testCase) string {
+	h, c, t := tc.h, tc.c, tc.t
+	if t >= h {
+		return "1"
+	}
+	if 2*t <= h+c {
+		return "2"
+	}
+	k := (h - t) / (2*t - h - c)
+	n1 := 2*k + 1
+	diff1 := math.Abs(float64((k+1)*h+k*c)/float64(n1) - float64(t))
+	k++
+	n2 := 2*k + 1
+	diff2 := math.Abs(float64((k+1)*h+k*c)/float64(n2) - float64(t))
+	if diff1 <= diff2 {
+		return fmt.Sprintf("%d", n1)
+	}
+	return fmt.Sprintf("%d", n2)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		input := fmt.Sprintf("1\n%d %d %d\n", tc.h, tc.c, tc.t)
+		want := expected(tc)
+		got, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1359/verifierD.go
+++ b/1000-1999/1300-1399/1350-1359/1359/verifierD.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n   int
+	arr []int
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(61) - 30
+	}
+	return testCase{n, arr}
+}
+
+func expected(tc testCase) string {
+	n := tc.n
+	arr := tc.arr
+	ans := 0
+	for m := -30; m <= 30; m++ {
+		sum := 0
+		hasMax := false
+		for i := 0; i < n; i++ {
+			if arr[i] > m {
+				sum = 0
+				hasMax = false
+				continue
+			}
+			sum += arr[i]
+			if arr[i] == m {
+				hasMax = true
+			}
+			if hasMax {
+				val := sum - m
+				if val > ans {
+					ans = val
+				}
+			}
+			if sum < 0 {
+				sum = 0
+				hasMax = false
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j, v := range tc.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want := expected(tc)
+		got, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1359/verifierE.go
+++ b/1000-1999/1300-1399/1350-1359/1359/verifierE.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 998244353
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func powMod(a, e int) int {
+	res := 1
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func initFactorials(n int) ([]int, []int) {
+	fact := make([]int, n+1)
+	inv := make([]int, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * i % MOD
+	}
+	inv[n] = powMod(fact[n], MOD-2)
+	for i := n; i > 0; i-- {
+		inv[i-1] = inv[i] * i % MOD
+	}
+	return fact, inv
+}
+
+func comb(n, k int, fact, inv []int) int {
+	if k < 0 || k > n {
+		return 0
+	}
+	return fact[n] * inv[k] % MOD * inv[n-k] % MOD
+}
+
+type testCase struct{ n, k int }
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(500) + 1
+	k := rng.Intn(n) + 1
+	return testCase{n, k}
+}
+
+func expected(tc testCase) string {
+	fact, inv := initFactorials(tc.n)
+	ans := 0
+	for m := 1; m <= tc.n; m++ {
+		cnt := tc.n / m
+		if cnt >= tc.k {
+			ans += comb(cnt-1, tc.k-1, fact, inv)
+			if ans >= MOD {
+				ans -= MOD
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		input := fmt.Sprintf("%d %d\n", tc.n, tc.k)
+		want := expected(tc)
+		got, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1350-1359/1359/verifierF.go
+++ b/1000-1999/1300-1399/1350-1359/1359/verifierF.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleF")
+	if out, err := exec.Command("go", "build", "-o", oracle, "1359F.go").CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n    int
+	vals []string
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	vals := make([]string, n)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(21) - 10
+		y := rng.Intn(21) - 10
+		dx := rng.Intn(10) + 1
+		if rng.Intn(2) == 0 {
+			dx = -dx
+		}
+		dy := rng.Intn(10) + 1
+		if rng.Intn(2) == 0 {
+			dy = -dy
+		}
+		s := rng.Intn(10) + 1
+		vals[i] = fmt.Sprintf("%d %d %d %d %d", x, y, dx, dy, s)
+	}
+	return testCase{n, vals}
+}
+
+func compareFloats(a, b float64) bool {
+	diff := math.Abs(a - b)
+	denom := math.Max(1.0, math.Abs(a))
+	return diff/denom <= 1e-6
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for _, v := range tc.vals {
+			sb.WriteString(v + "\n")
+		}
+		input := sb.String()
+		expStr, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		gotStr, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if expStr == "No show :(" {
+			if gotStr != expStr {
+				fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, expStr, gotStr, input)
+				os.Exit(1)
+			}
+			continue
+		}
+		expF, _ := strconv.ParseFloat(expStr, 64)
+		gotF, err := strconv.ParseFloat(gotStr, 64)
+		if err != nil || !compareFloats(expF, gotF) {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, expStr, gotStr, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- provide verifierA.go to test Berland poker solutions
- add verifierB.go-F.go covering remaining problems
- each verifier generates at least 100 random testcases

## Testing
- `go build 1000-1999/1300-1399/1350-1359/1359/verifierA.go`
- `go build 1000-1999/1300-1399/1350-1359/1359/verifierB.go`
- `go build 1000-1999/1300-1399/1350-1359/1359/verifierC.go`
- `go build 1000-1999/1300-1399/1350-1359/1359/verifierD.go`
- `go build 1000-1999/1300-1399/1350-1359/1359/verifierE.go`
- `go build 1000-1999/1300-1399/1350-1359/1359/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885e1bacd1c8324ab06751a2f3437d4