### PR TITLE
Add Go verifiers for contest 1362

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1362/verifierA.go
+++ b/1000-1999/1300-1399/1360-1369/1362/verifierA.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	a, b     int64
+	expected int
+}
+
+func computeExpected(a, b int64) int {
+	if a == b {
+		return 0
+	}
+	var bigger, smaller int64
+	if a > b {
+		bigger = a
+		smaller = b
+	} else {
+		bigger = b
+		smaller = a
+	}
+	if bigger%smaller != 0 {
+		return -1
+	}
+	ratio := bigger / smaller
+	k := 0
+	for ratio > 1 && ratio%2 == 0 {
+		ratio /= 2
+		k++
+	}
+	if ratio != 1 {
+		return -1
+	}
+	return (k + 2) / 3
+}
+
+func generateTests() []testCase {
+	const numTests = 100
+	rand.Seed(1)
+	tests := make([]testCase, 0, numTests+5)
+	for i := 0; i < numTests; i++ {
+		a := rand.Int63n(1e18) + 1
+		b := rand.Int63n(1e18) + 1
+		tests = append(tests, testCase{a: a, b: b, expected: computeExpected(a, b)})
+	}
+	edge := []testCase{
+		{1, 1, computeExpected(1, 1)},
+		{1, 2, computeExpected(1, 2)},
+		{2, 1, computeExpected(2, 1)},
+		{3, 6, computeExpected(3, 6)},
+		{96, 3, computeExpected(96, 3)},
+	}
+	tests = append(tests, edge...)
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	var input strings.Builder
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.a, tc.b)
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error running binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(&out)
+	for i, tc := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		line := strings.TrimSpace(scanner.Text())
+		got, err := strconv.Atoi(line)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid output on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d (%d %d)\n", i+1, tc.expected, got, tc.a, tc.b)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output detected")
+		os.Exit(1)
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1300-1399/1360-1369/1362/verifierB.go
+++ b/1000-1999/1300-1399/1360-1369/1362/verifierB.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseB struct {
+	arr      []int
+	expected int
+}
+
+func computeExpectedB(arr []int) int {
+	set := make(map[int]bool, len(arr))
+	for _, v := range arr {
+		set[v] = true
+	}
+	for k := 1; k < 1024; k++ {
+		valid := true
+		for _, v := range arr {
+			if !set[v^k] {
+				valid = false
+				break
+			}
+		}
+		if valid {
+			return k
+		}
+	}
+	return -1
+}
+
+func generateTestsB() []testCaseB {
+	const numTests = 100
+	rand.Seed(2)
+	tests := make([]testCaseB, 0, numTests+5)
+	for i := 0; i < numTests; i++ {
+		n := rand.Intn(10) + 1
+		used := make(map[int]bool)
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			for {
+				x := rand.Intn(1024)
+				if !used[x] {
+					used[x] = true
+					arr[j] = x
+					break
+				}
+			}
+		}
+		tests = append(tests, testCaseB{arr: arr, expected: computeExpectedB(arr)})
+	}
+	edge := []testCaseB{
+		{arr: []int{0, 1, 2, 3}, expected: computeExpectedB([]int{0, 1, 2, 3})},
+		{arr: []int{1}, expected: computeExpectedB([]int{1})},
+		{arr: []int{5, 9, 12}, expected: computeExpectedB([]int{5, 9, 12})},
+	}
+	tests = append(tests, edge...)
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTestsB()
+	var input strings.Builder
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprint(&input, len(tc.arr))
+		for _, v := range tc.arr {
+			fmt.Fprintf(&input, " %d", v)
+		}
+		fmt.Fprintln(&input)
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error running binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(&out)
+	for i, tc := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		line := strings.TrimSpace(scanner.Text())
+		got, err := strconv.Atoi(line)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid output on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", i+1, tc.expected, got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output detected")
+		os.Exit(1)
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1300-1399/1360-1369/1362/verifierC.go
+++ b/1000-1999/1300-1399/1360-1369/1362/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseC struct {
+	n        int64
+	expected int64
+}
+
+func computeExpectedC(n int64) int64 {
+	var ans int64
+	for n > 0 {
+		ans += n
+		n >>= 1
+	}
+	return ans
+}
+
+func generateTestsC() []testCaseC {
+	const numTests = 100
+	rand.Seed(3)
+	tests := make([]testCaseC, 0, numTests+5)
+	for i := 0; i < numTests; i++ {
+		n := rand.Int63n(1e18) + 1
+		tests = append(tests, testCaseC{n: n, expected: computeExpectedC(n)})
+	}
+	edge := []testCaseC{
+		{1, computeExpectedC(1)},
+		{5, computeExpectedC(5)},
+		{10, computeExpectedC(10)},
+	}
+	tests = append(tests, edge...)
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTestsC()
+	var input strings.Builder
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d\n", tc.n)
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error running binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(&out)
+	for i, tc := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		line := strings.TrimSpace(scanner.Text())
+		got, err := strconv.ParseInt(line, 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid output on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", i+1, tc.expected, got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output detected")
+		os.Exit(1)
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`, `verifierB.go`, and `verifierC.go` for contest 1362
- each verifier generates at least 100 deterministic test cases
- verifiers execute an arbitrary binary, check its output and report mismatches

## Testing
- `go build 1000-1999/1300-1399/1360-1369/1362/verifierA.go`
- `go build 1000-1999/1300-1399/1360-1369/1362/verifierB.go`
- `go build 1000-1999/1300-1399/1360-1369/1362/verifierC.go`


------
https://chatgpt.com/codex/tasks/task_e_6885e35f22508324ab8d6045d36645d5