### PR TITLE
Add verifiers for contest 1360

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1360/verifierA.go
+++ b/1000-1999/1300-1399/1360-1369/1360/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1360A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := range tests {
+		a := rand.Intn(100) + 1
+		b := rand.Intn(100) + 1
+		tests[i] = fmt.Sprintf("1\n%d %d\n", a, b)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1360-1369/1360/verifierB.go
+++ b/1000-1999/1300-1399/1360-1369/1360/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1360B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(2)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(49) + 2
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(1000)+1))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1360-1369/1360/verifierC.go
+++ b/1000-1999/1300-1399/1360-1369/1360/verifierC.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1360C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(3)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := (rand.Intn(25) + 1) * 2
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(100)+1))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1360-1369/1360/verifierD.go
+++ b/1000-1999/1300-1399/1360-1369/1360/verifierD.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1360D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(4)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Int63n(1_000_000_000) + 1
+		k := rand.Int63n(1_000_000_000) + 1
+		tests[i] = fmt.Sprintf("1\n%d %d\n", n, k)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1360-1369/1360/verifierE.go
+++ b/1000-1999/1300-1399/1360-1369/1360/verifierE.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1360E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(5)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for r := 0; r < n; r++ {
+			for c := 0; c < n; c++ {
+				if rand.Intn(2) == 1 {
+					sb.WriteByte('1')
+				} else {
+					sb.WriteByte('0')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1360-1369/1360/verifierF.go
+++ b/1000-1999/1300-1399/1360-1369/1360/verifierF.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1360F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randString(n int, r *rand.Rand) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + r.Intn(26))
+	}
+	return string(b)
+}
+
+func genTests() []string {
+	r := rand.New(rand.NewSource(6))
+	tests := make([]string, 100)
+	for i := range tests {
+		n := r.Intn(10) + 1
+		m := r.Intn(10) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 0; j < n; j++ {
+			sb.WriteString(randString(m, r))
+			sb.WriteByte('\n')
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1360-1369/1360/verifierG.go
+++ b/1000-1999/1300-1399/1360-1369/1360/verifierG.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1360G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(7)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(5) + 1
+		a := rand.Intn(m) + 1
+		b := rand.Intn(n) + 1
+		tests[i] = fmt.Sprintf("1\n%d %d %d %d\n", n, m, a, b)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1360-1369/1360/verifierH.go
+++ b/1000-1999/1300-1399/1360-1369/1360/verifierH.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refH.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1360H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randBinString(m int, r *rand.Rand) string {
+	b := make([]byte, m)
+	for i := range b {
+		if r.Intn(2) == 1 {
+			b[i] = '1'
+		} else {
+			b[i] = '0'
+		}
+	}
+	return string(b)
+}
+
+func genTests() []string {
+	r := rand.New(rand.NewSource(8))
+	tests := make([]string, 100)
+	for i := range tests {
+		m := r.Intn(8) + 1
+		maxN := 1<<m - 1
+		if maxN > 100 {
+			maxN = 100
+		}
+		n := r.Intn(maxN) + 1
+		set := make(map[string]struct{})
+		for len(set) < n {
+			set[randBinString(m, r)] = struct{}{}
+		}
+		strs := make([]string, 0, n)
+		for s := range set {
+			strs = append(strs, s)
+		}
+		sort.Strings(strs)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, s := range strs {
+			sb.WriteString(s)
+			sb.WriteByte('\n')
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for problems A through H of contest 1360
- each verifier builds the official solution, generates 100 randomized tests and checks a given binary

## Testing
- `go run verifierA.go ./candA`
- `go run verifierB.go ./candB`
- `go run verifierC.go ./candC`
- `go run verifierD.go ./candD`
- `go run verifierE.go ./candE`
- `go run verifierF.go ./candF`
- `go run verifierG.go ./candG`
- `go run verifierH.go ./candH`


------
https://chatgpt.com/codex/tasks/task_e_6885e246e22c8324afaac9fb1bbeb631