### PR TITLE
Add Go verifiers for contest 1363

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1363/verifierA.go
+++ b/1000-1999/1300-1399/1360-1369/1363/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, x int, arr []int) string {
+	odd := 0
+	for _, v := range arr {
+		if v%2 != 0 {
+			odd++
+		}
+	}
+	even := n - odd
+	for k := 1; k <= odd && k <= x; k += 2 {
+		if x-k <= even {
+			return "Yes"
+		}
+	}
+	return "No"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	x := rng.Intn(n) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	expect := solveCase(n, x, arr)
+	return sb.String(), expect
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1360-1369/1363/verifierB.go
+++ b/1000-1999/1300-1399/1360-1369/1363/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(s string) string {
+	n := len(s)
+	prefix0 := make([]int, n+1)
+	prefix1 := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		prefix0[i+1] = prefix0[i]
+		prefix1[i+1] = prefix1[i]
+		if s[i] == '0' {
+			prefix0[i+1]++
+		} else {
+			prefix1[i+1]++
+		}
+	}
+	total0 := prefix0[n]
+	total1 := prefix1[n]
+	minOps := n
+	for i := 0; i <= n; i++ {
+		ops01 := prefix1[i] + (total0 - prefix0[i])
+		if ops01 < minOps {
+			minOps = ops01
+		}
+		ops10 := prefix0[i] + (total1 - prefix1[i])
+		if ops10 < minOps {
+			minOps = ops10
+		}
+	}
+	return fmt.Sprintf("%d", minOps)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	s := sb.String()
+	input := fmt.Sprintf("1\n%s\n", s)
+	expect := solveCase(s)
+	return input, expect
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1360-1369/1363/verifierC.go
+++ b/1000-1999/1300-1399/1360-1369/1363/verifierC.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, x int, edges [][2]int) string {
+	deg := make([]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		deg[u]++
+		deg[v]++
+	}
+	if deg[x] <= 1 || n%2 == 0 {
+		return "Ayush"
+	}
+	return "Ashish"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 2
+	x := rng.Intn(n) + 1
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	expect := solveCase(n, x, edges)
+	return sb.String(), expect
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1360-1369/1363/verifierD.go
+++ b/1000-1999/1300-1399/1360-1369/1363/verifierD.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem D is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1300-1399/1360-1369/1363/verifierE.go
+++ b/1000-1999/1300-1399/1360-1369/1363/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func minInt64(x, y int64) int64 {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func solveCase(n int, a []int64, b, c []int, edges [][]int) int64 {
+	var ans int64
+	var dfs func(v, p int, mn int64) (int, int)
+	dfs = func(v, p int, mn int64) (int, int) {
+		cnt01, cnt10 := 0, 0
+		if b[v] != c[v] {
+			if b[v] == 0 {
+				cnt01 = 1
+			} else {
+				cnt10 = 1
+			}
+		}
+		for _, to := range edges[v] {
+			if to == p {
+				continue
+			}
+			x01, x10 := dfs(to, v, minInt64(mn, a[to]))
+			cnt01 += x01
+			cnt10 += x10
+		}
+		t := int(minInt64(int64(cnt01), int64(cnt10)))
+		ans += 2 * int64(t) * mn
+		cnt01 -= t
+		cnt10 -= t
+		return cnt01, cnt10
+	}
+	dfs01, dfs10 := dfs(0, -1, a[0])
+	if dfs01 != 0 || dfs10 != 0 {
+		return -1
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(7) + 1
+	a := make([]int64, n)
+	b := make([]int, n)
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(5) + 1)
+		b[i] = rng.Intn(2)
+		c[i] = rng.Intn(2)
+	}
+	edges := make([][]int, n)
+	pairs := make([][2]int, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		pairs[i-1] = [2]int{p + 1, i + 1}
+		edges[p] = append(edges[p], i)
+		edges[i] = append(edges[i], p)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a[i], b[i], c[i]))
+	}
+	for _, e := range pairs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	expect := solveCase(n, a, b, c, edges)
+	return sb.String(), fmt.Sprintf("%d", expect)
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1360-1369/1363/verifierF.go
+++ b/1000-1999/1300-1399/1360-1369/1363/verifierF.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func bfsSolve(s, t string) int {
+	if len(s) != len(t) {
+		return -1
+	}
+	n := len(s)
+	count := make(map[rune]int)
+	for _, ch := range s {
+		count[ch]++
+	}
+	for _, ch := range t {
+		count[ch]--
+	}
+	for _, v := range count {
+		if v != 0 {
+			return -1
+		}
+	}
+	visited := map[string]bool{s: true}
+	type node struct {
+		str  string
+		dist int
+	}
+	q := list.New()
+	q.PushBack(node{s, 0})
+	for q.Len() > 0 {
+		front := q.Remove(q.Front()).(node)
+		if front.str == t {
+			return front.dist
+		}
+		curr := front.str
+		for l := 0; l < n; l++ {
+			for r := l + 1; r < n; r++ {
+				bs := []byte(curr)
+				ch := bs[r]
+				copy(bs[l+1:r+1], bs[l:r])
+				bs[l] = ch
+				ns := string(bs)
+				if !visited[ns] {
+					visited[ns] = true
+					q.PushBack(node{ns, front.dist + 1})
+				}
+			}
+		}
+	}
+	return -1
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	sb1 := make([]byte, n)
+	sb2 := make([]byte, n)
+	for i := 0; i < n; i++ {
+		ch := byte('a' + rng.Intn(3))
+		sb1[i] = ch
+	}
+	for i := 0; i < n; i++ {
+		sb2[i] = sb1[i]
+	}
+	// permute sb2
+	rng.Shuffle(n, func(i, j int) { sb2[i], sb2[j] = sb2[j], sb2[i] })
+	s := string(sb1)
+	t := string(sb2)
+	input := fmt.Sprintf("1\n%s\n%s\n", s, t)
+	expect := bfsSolve(s, t)
+	return input, fmt.Sprintf("%d", expect)
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone verifiers for problems A–F of contest 1363
- problem D is interactive so the verifier just prints a notice
- each verifier runs 100 random test cases and reports success

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go vet verifierF.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885e3eb27d88324b0718b1fefdd720e