### PR TITLE
Add verifiers for contest 1365

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1365/verifierA.go
+++ b/1000-1999/1300-1399/1360-1369/1365/verifierA.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct{
+    input string
+    expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var stderr bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &stderr
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(input string) string {
+    in := bufio.NewReader(strings.NewReader(input))
+    var t int
+    fmt.Fscan(in, &t)
+    var out strings.Builder
+    for ; t>0; t-- {
+        var n, m int
+        fmt.Fscan(in, &n, &m)
+        rows := make([]int, n)
+        cols := make([]int, m)
+        for i:=0; i<n; i++ {
+            for j:=0; j<m; j++ {
+                var x int
+                fmt.Fscan(in, &x)
+                if x==1 {
+                    rows[i]=1
+                    cols[j]=1
+                }
+            }
+        }
+        er, ec := 0,0
+        for _,v := range rows { if v==0 { er++ } }
+        for _,v := range cols { if v==0 { ec++ } }
+        moves := er
+        if ec < moves { moves = ec }
+        if moves%2==1 { out.WriteString("Ashish\n") } else { out.WriteString("Vivek\n") }
+    }
+    return strings.TrimSpace(out.String())
+}
+
+func genTests() []test {
+    r := rand.New(rand.NewSource(1365))
+    tests := make([]test, 0, 100)
+    for len(tests) < 100 {
+        n := r.Intn(4)+1
+        m := r.Intn(4)+1
+        var sb strings.Builder
+        sb.WriteString("1\n")
+        sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+        for i:=0; i<n; i++ {
+            for j:=0; j<m; j++ {
+                if j>0 { sb.WriteByte(' ') }
+                sb.WriteString(fmt.Sprintf("%d", r.Intn(2)))
+            }
+            sb.WriteByte('\n')
+        }
+        input := sb.String()
+        expected := solveA(input)
+        tests = append(tests, test{input, expected})
+    }
+    return tests
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, t := range tests {
+        out, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t.input)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+            fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1300-1399/1360-1369/1365/verifierB.go
+++ b/1000-1999/1300-1399/1360-1369/1365/verifierB.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct{
+    input string
+    expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var stderr bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &stderr
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(input string) string {
+    in := bufio.NewReader(strings.NewReader(input))
+    var t int
+    fmt.Fscan(in, &t)
+    var out strings.Builder
+    for ; t>0; t-- {
+        var n int
+        fmt.Fscan(in, &n)
+        a := make([]int, n)
+        for i:=0; i<n; i++ { fmt.Fscan(in, &a[i]) }
+        has0, has1 := false, false
+        b := make([]int, n)
+        for i:=0; i<n; i++ {
+            fmt.Fscan(in, &b[i])
+            if b[i]==0 { has0 = true } else { has1 = true }
+        }
+        sorted := true
+        for i:=1; i<n; i++ {
+            if a[i] < a[i-1] { sorted=false; break }
+        }
+        if sorted || (has0 && has1) {
+            out.WriteString("Yes\n")
+        } else {
+            out.WriteString("No\n")
+        }
+    }
+    return strings.TrimSpace(out.String())
+}
+
+func genTests() []test {
+    r := rand.New(rand.NewSource(1365))
+    tests := make([]test, 0, 100)
+    for len(tests) < 100 {
+        n := r.Intn(5)+1
+        var sb strings.Builder
+        sb.WriteString("1\n")
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for i:=0; i<n; i++ {
+            if i>0 { sb.WriteByte(' ') }
+            sb.WriteString(fmt.Sprintf("%d", r.Intn(10)))
+        }
+        sb.WriteByte('\n')
+        for i:=0; i<n; i++ {
+            if i>0 { sb.WriteByte(' ') }
+            if r.Intn(2)==0 { sb.WriteByte('0') } else { sb.WriteByte('1') }
+        }
+        sb.WriteByte('\n')
+        input := sb.String()
+        expected := solveB(input)
+        tests = append(tests, test{input, expected})
+    }
+    return tests
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i,t := range tests {
+        out, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t.input)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+            fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1300-1399/1360-1369/1365/verifierC.go
+++ b/1000-1999/1300-1399/1360-1369/1365/verifierC.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct{ input, expected string }
+
+func runBin(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else { cmd = exec.Command(bin) }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errb bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errb
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(input string) string {
+    in := bufio.NewReader(strings.NewReader(input))
+    var n int
+    fmt.Fscan(in, &n)
+    a := make([]int, n)
+    b := make([]int, n)
+    for i:=0; i<n; i++ { fmt.Fscan(in, &a[i]) }
+    for i:=0; i<n; i++ { fmt.Fscan(in, &b[i]) }
+    pos := make([]int, n+1)
+    for i:=0; i<n; i++ { pos[a[i]] = i }
+    cnt := make(map[int]int)
+    best := 0
+    for i:=0; i<n; i++ {
+        shift := (i - pos[b[i]] + n) % n
+        cnt[shift]++
+        if cnt[shift] > best { best = cnt[shift] }
+    }
+    return fmt.Sprintf("%d", best)
+}
+
+func genTests() []test {
+    r := rand.New(rand.NewSource(1365))
+    tests := make([]test,0,100)
+    for len(tests) < 100 {
+        n := r.Intn(6)+1
+        perm := rand.Perm(n)
+        a := make([]int, n)
+        for i:=0;i<n;i++ { a[i] = perm[i]+1 }
+        perm2 := rand.Perm(n)
+        b := make([]int, n)
+        for i:=0;i<n;i++ { b[i] = perm2[i]+1 }
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for i, v := range a { if i>0 { sb.WriteByte(' ') }; sb.WriteString(fmt.Sprintf("%d", v)) }
+        sb.WriteByte('\n')
+        for i, v := range b { if i>0 { sb.WriteByte(' ') }; sb.WriteString(fmt.Sprintf("%d", v)) }
+        sb.WriteByte('\n')
+        input := sb.String()
+        expected := solveC(input)
+        tests = append(tests, test{input, expected})
+    }
+    return tests
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, t := range tests {
+        out, err := runBin(bin, t.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t.input)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+            fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1300-1399/1360-1369/1365/verifierD.go
+++ b/1000-1999/1300-1399/1360-1369/1365/verifierD.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct{ input, expected string }
+
+func runBin(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else { cmd = exec.Command(bin) }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errb bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errb
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(input string) string {
+    in := bufio.NewReader(strings.NewReader(input))
+    var T int
+    fmt.Fscan(in, &T)
+    var out strings.Builder
+    dirs := [][2]int{{1,0},{-1,0},{0,1},{0,-1}}
+    for ; T>0; T-- {
+        var n,m int
+        fmt.Fscan(in, &n, &m)
+        grid := make([][]byte, n)
+        for i:=0;i<n;i++ {
+            var s string
+            fmt.Fscan(in,&s)
+            grid[i] = []byte(s)
+        }
+        possible := true
+        for i:=0;i<n;i++ {
+            for j:=0;j<m;j++ {
+                if grid[i][j]=='B' {
+                    for _,d := range dirs {
+                        nx,ny := i+d[0], j+d[1]
+                        if nx>=0 && nx<n && ny>=0 && ny<m {
+                            switch grid[nx][ny] {
+                            case 'G': possible=false
+                            case '.': grid[nx][ny]='#'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if !possible {
+            out.WriteString("No\n")
+            continue
+        }
+        visited := make([][]bool, n)
+        for i:=range visited { visited[i]=make([]bool,m) }
+        q := make([][2]int,0)
+        if grid[n-1][m-1] != '#' {
+            q = append(q,[2]int{n-1,m-1})
+            visited[n-1][m-1]=true
+        }
+        for head:=0; head<len(q); head++ {
+            x,y := q[head][0], q[head][1]
+            for _,d := range dirs {
+                nx,ny := x+d[0], y+d[1]
+                if nx>=0 && nx<n && ny>=0 && ny<m && !visited[nx][ny] && grid[nx][ny] != '#' && grid[nx][ny] != 'B' {
+                    visited[nx][ny]=true
+                    q = append(q,[2]int{nx,ny})
+                }
+            }
+        }
+        ok := true
+        for i:=0;i<n;i++ {
+            for j:=0;j<m;j++ {
+                if grid[i][j]=='G' && !visited[i][j] { ok=false }
+                if grid[i][j]=='B' && visited[i][j] { ok=false }
+            }
+        }
+        if ok { out.WriteString("Yes\n") } else { out.WriteString("No\n") }
+    }
+    return strings.TrimSpace(out.String())
+}
+
+func genTests() []test {
+    r := rand.New(rand.NewSource(1365))
+    tests := make([]test,0,100)
+    chars := []byte{'.', '#', 'G', 'B'}
+    for len(tests) < 100 {
+        n := r.Intn(4) + 1
+        m := r.Intn(4) + 1
+        var sb strings.Builder
+        sb.WriteString("1\n")
+        sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+        for i := 0; i < n; i++ {
+            for j := 0; j < m; j++ {
+                sb.WriteByte(chars[r.Intn(len(chars))])
+            }
+            sb.WriteByte('\n')
+        }
+        input := sb.String()
+        expected := solveD(input)
+        tests = append(tests, test{input, expected})
+    }
+    return tests
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, t := range tests {
+        out, err := runBin(bin, t.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t.input)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+            fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1300-1399/1360-1369/1365/verifierE.go
+++ b/1000-1999/1300-1399/1360-1369/1365/verifierE.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct{ input, expected string }
+
+func runBin(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else { cmd = exec.Command(bin) }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errb bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errb
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(input string) string {
+    in := bufio.NewReader(strings.NewReader(input))
+    var n int
+    fmt.Fscan(in, &n)
+    arr := make([]int64, n)
+    for i:=0;i<n;i++ { fmt.Fscan(in,&arr[i]) }
+    var ans int64
+    for i:=0;i<n;i++ {
+        if arr[i] > ans { ans = arr[i] }
+        for j:=i+1;j<n;j++ {
+            v := arr[i] | arr[j]
+            if v > ans { ans = v }
+            for k:=j+1;k<n;k++ {
+                v3 := v | arr[k]
+                if v3 > ans { ans = v3 }
+            }
+        }
+    }
+    return fmt.Sprintf("%d", ans)
+}
+
+func genTests() []test {
+    r := rand.New(rand.NewSource(1365))
+    tests := make([]test,0,100)
+    for len(tests) < 100 {
+        n := r.Intn(6)+1
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for i:=0;i<n;i++ {
+            if i>0 { sb.WriteByte(' ') }
+            sb.WriteString(fmt.Sprintf("%d", r.Int63n(512)))
+        }
+        sb.WriteByte('\n')
+        input := sb.String()
+        expected := solveE(input)
+        tests = append(tests, test{input, expected})
+    }
+    return tests
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, t := range tests {
+        out, err := runBin(bin, t.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t.input)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+            fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1300-1399/1360-1369/1365/verifierF.go
+++ b/1000-1999/1300-1399/1360-1369/1365/verifierF.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+type test struct{ input, expected string }
+
+func runBin(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else { cmd = exec.Command(bin) }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errb bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errb
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+type pair struct{ x,y int64 }
+
+func solveF(input string) string {
+    in := bufio.NewReader(strings.NewReader(input))
+    var t int
+    fmt.Fscan(in, &t)
+    var out strings.Builder
+    for ; t>0; t-- {
+        var n int
+        fmt.Fscan(in, &n)
+        a := make([]int64, n)
+        b := make([]int64, n)
+        for i:=0;i<n;i++ { fmt.Fscan(in,&a[i]) }
+        for i:=0;i<n;i++ { fmt.Fscan(in,&b[i]) }
+        if n%2==1 && a[n/2]!=b[n/2] {
+            out.WriteString("No\n")
+            continue
+        }
+        m := n/2
+        pa := make([]pair,m)
+        pb := make([]pair,m)
+        for i:=0;i<m;i++ {
+            x1,x2 := a[i], a[n-1-i]
+            if x1 > x2 { x1,x2 = x2,x1 }
+            pa[i]=pair{x1,x2}
+            y1,y2 := b[i], b[n-1-i]
+            if y1>y2 { y1,y2 = y2,y1 }
+            pb[i]=pair{y1,y2}
+        }
+        sort.Slice(pa, func(i,j int) bool {
+            if pa[i].x==pa[j].x { return pa[i].y < pa[j].y }
+            return pa[i].x < pa[j].x
+        })
+        sort.Slice(pb, func(i,j int) bool {
+            if pb[i].x==pb[j].x { return pb[i].y < pb[j].y }
+            return pb[i].x < pb[j].x
+        })
+        ok := true
+        for i:=0;i<m;i++ { if pa[i]!=pb[i] { ok=false; break } }
+        if ok { out.WriteString("Yes\n") } else { out.WriteString("No\n") }
+    }
+    return strings.TrimSpace(out.String())
+}
+
+func genTests() []test {
+    r := rand.New(rand.NewSource(1365))
+    tests := make([]test,0,100)
+    for len(tests)<100 {
+        n := r.Intn(6)+1
+        var sb strings.Builder
+        sb.WriteString("1\n")
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for i:=0;i<n;i++ { if i>0 {sb.WriteByte(' ')}; sb.WriteString(fmt.Sprintf("%d", r.Int63n(20))) }
+        sb.WriteByte('\n')
+        for i:=0;i<n;i++ { if i>0 {sb.WriteByte(' ')}; sb.WriteString(fmt.Sprintf("%d", r.Int63n(20))) }
+        sb.WriteByte('\n')
+        input := sb.String()
+        expected := solveF(input)
+        tests = append(tests, test{input, expected})
+    }
+    return tests
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i,t := range tests {
+        out, err := runBin(bin, t.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t.input)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+            fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1300-1399/1360-1369/1365/verifierG.go
+++ b/1000-1999/1300-1399/1360-1369/1365/verifierG.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Problem G is interactive and cannot be automatically verified.")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–F of contest 1365
- include an informational stub for the interactive problem G

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6885e50353748324a379543245af9116