### PR TITLE
Add Go verifiers for contest 1369

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1369/verifierA.go
+++ b/1000-1999/1300-1399/1360-1369/1369/verifierA.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveA(n int) string {
+	if n%4 == 0 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(1000000000-3+1) + 3 // 3..1e9
+		input := fmt.Sprintf("1\n%d\n", n)
+		expected := solveA(n) + "\n"
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", t+1, input, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1360-1369/1369/verifierB.go
+++ b/1000-1999/1300-1399/1360-1369/1369/verifierB.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveB(s string) string {
+	n := len(s)
+	prefix := 0
+	for prefix < n && s[prefix] == '0' {
+		prefix++
+	}
+	suffix := n - 1
+	for suffix >= 0 && s[suffix] == '1' {
+		suffix--
+	}
+	if prefix > suffix {
+		return s
+	}
+	return s[:prefix] + "0" + s[suffix+1:]
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randomString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if rand.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(20) + 1
+		s := randomString(n)
+		input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+		expected := solveB(s) + "\n"
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", t+1, input, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1360-1369/1369/verifierC.go
+++ b/1000-1999/1300-1399/1360-1369/1369/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func solveC(n, k int, a []int, w []int) int64 {
+	sort.Ints(a)
+	sort.Ints(w)
+	l := 0
+	r := n - 1
+	var res int64
+	for i := 0; i < k; i++ {
+		res += int64(a[r])
+		if w[i] == 1 {
+			res += int64(a[r])
+		}
+		r--
+	}
+	for i := k - 1; i >= 0; i-- {
+		if w[i] == 1 {
+			continue
+		}
+		res += int64(a[l])
+		l += w[i] - 1
+	}
+	return res
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(15) + 1
+		k := rand.Intn(n) + 1
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rand.Intn(100) + 1
+		}
+		w := make([]int, k)
+		for i := range w {
+			w[i] = 1
+		}
+		remaining := n - k
+		for j := 0; j < remaining; j++ {
+			idx := rand.Intn(k)
+			w[idx]++
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "1\n%d %d\n", n, k)
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, v)
+		}
+		sb.WriteByte('\n')
+		for i, v := range w {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, v)
+		}
+		sb.WriteByte('\n')
+		expected := fmt.Sprintf("%d\n", solveC(n, k, append([]int(nil), a...), append([]int(nil), w...)))
+		output, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", t+1, sb.String(), expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1360-1369/1369/verifierD.go
+++ b/1000-1999/1300-1399/1360-1369/1369/verifierD.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD int64 = 1000000007
+const MAXN = 2000000
+
+var precomputed []int64
+
+func initPrecompute() {
+	precomputed = make([]int64, MAXN+1)
+	precomputed[1] = 0
+	precomputed[2] = 0
+	precomputed[3] = 4
+	precomputed[4] = 4
+	for i := 5; i <= MAXN; i++ {
+		precomputed[i] = (2 * precomputed[i-1]) % MOD
+		switch i % 6 {
+		case 3, 5:
+			precomputed[i] = (precomputed[i] + 4) % MOD
+		case 4:
+			precomputed[i] = (precomputed[i] + MOD - 4) % MOD
+		}
+	}
+}
+
+func solveD(n int) int64 {
+	return precomputed[n]
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	initPrecompute()
+	rand.Seed(4)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(MAXN-1) + 1
+		input := fmt.Sprintf("1\n%d\n", n)
+		expected := fmt.Sprintf("%d\n", solveD(n))
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", t+1, input, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1360-1369/1369/verifierE.go
+++ b/1000-1999/1300-1399/1360-1369/1369/verifierE.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type edge struct {
+	id int
+	to int
+}
+
+func solveE(n, m int, cnt []int, a0 []int, a1 []int) (string, []int) {
+	adj := make([][]edge, n+1)
+	for i := 1; i <= m; i++ {
+		adj[a0[i]] = append(adj[a0[i]], edge{i, a1[i]})
+		adj[a1[i]] = append(adj[a1[i]], edge{i, a0[i]})
+	}
+	siz := make([]int, n+1)
+	vis := make([]bool, n+1)
+	inEdge := make([]bool, m+1)
+	queue := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		siz[i] = len(adj[i])
+		if cnt[i] >= siz[i] {
+			vis[i] = true
+			queue = append(queue, i)
+		}
+	}
+	var stack []int
+	qi := 0
+	for qi < len(queue) {
+		d := queue[qi]
+		qi++
+		for _, e := range adj[d] {
+			if !inEdge[e.id] {
+				inEdge[e.id] = true
+				stack = append(stack, e.id)
+			}
+			if vis[e.to] {
+				continue
+			}
+			siz[e.to]--
+			if cnt[e.to] >= siz[e.to] {
+				vis[e.to] = true
+				queue = append(queue, e.to)
+			}
+		}
+	}
+	if len(stack) != m {
+		return "DEAD", nil
+	}
+	order := make([]int, m)
+	for i := m - 1; i >= 0; i-- {
+		order[m-1-i] = stack[i]
+	}
+	return "ALIVE", order
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(6) + 2
+		maxEdges := n * (n - 1) / 2
+		m := rand.Intn(maxEdges) + 1
+		cnt := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			cnt[i] = rand.Intn(3)
+		}
+		a0 := make([]int, m+1)
+		a1 := make([]int, m+1)
+		for i := 1; i <= m; i++ {
+			x := rand.Intn(n) + 1
+			y := rand.Intn(n) + 1
+			for y == x {
+				y = rand.Intn(n) + 1
+			}
+			a0[i] = x
+			a1[i] = y
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, cnt[i])
+		}
+		sb.WriteByte('\n')
+		for i := 1; i <= m; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", a0[i], a1[i])
+		}
+		expStatus, expOrder := solveE(n, m, append([]int(nil), cnt...), append([]int(nil), a0...), append([]int(nil), a1...))
+		var expected strings.Builder
+		expected.WriteString(expStatus)
+		expected.WriteByte('\n')
+		if expStatus == "ALIVE" {
+			for i, v := range expOrder {
+				if i > 0 {
+					expected.WriteByte(' ')
+				}
+				fmt.Fprint(&expected, v)
+			}
+			expected.WriteByte('\n')
+		}
+		output, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != strings.TrimSpace(expected.String()) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", t+1, sb.String(), expected.String(), output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1360-1369/1369/verifierF.go
+++ b/1000-1999/1300-1399/1360-1369/1369/verifierF.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var memo map[[2]int64]bool
+
+func win(s, e int64) bool {
+	if s > e {
+		return false
+	}
+	key := [2]int64{s, e}
+	if v, ok := memo[key]; ok {
+		return v
+	}
+	var res bool
+	if 2*s > e {
+		res = (e-s)%2 == 1
+	} else {
+		res = !(win(s+1, e) && win(2*s, e))
+	}
+	memo[key] = res
+	return res
+}
+
+func solveF(s, e int64) string {
+	memo = make(map[[2]int64]bool)
+	if win(s, e) {
+		return "1 0"
+	}
+	return "0 1"
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(6)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		s := int64(rand.Intn(20) + 1)
+		e := s + int64(rand.Intn(20))
+		input := fmt.Sprintf("1\n%d %d\n", s, e)
+		expected := solveF(s, e) + "\n"
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", t+1, input, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E
- add verifierF.go for problem F

## Testing
- `go build 1000-1999/1300-1399/1360-1369/1369/verifierA.go`
- `go build 1000-1999/1300-1399/1360-1369/1369/verifierB.go`
- `go build 1000-1999/1300-1399/1360-1369/1369/verifierC.go`
- `go build 1000-1999/1300-1399/1360-1369/1369/verifierD.go`
- `go build 1000-1999/1300-1399/1360-1369/1369/verifierE.go`
- `go build 1000-1999/1300-1399/1360-1369/1369/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885e733a6448324978bea382299cabe