### PR TITLE
Add Go verifiers for contest 1371

### DIFF
--- a/1000-1999/1300-1399/1370-1379/1371/verifierA.go
+++ b/1000-1999/1300-1399/1370-1379/1371/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genCase(rng *rand.Rand) (string, []int64) {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	ans := make([]int64, t)
+	for i := 0; i < t; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		ans[i] = (n + 1) / 2
+	}
+	return sb.String(), ans
+}
+
+func runCase(bin, input string, exp []int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	for i, e := range exp {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing output line %d", i+1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(scanner.Text(), &got); err != nil {
+			return fmt.Errorf("bad output on line %d: %v", i+1, err)
+		}
+		if got != e {
+			return fmt.Errorf("line %d: expected %d got %d", i+1, e, got)
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1371/verifierB.go
+++ b/1000-1999/1300-1399/1370-1379/1371/verifierB.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, r int64) int64 {
+	if r < n {
+		return r * (r + 1) / 2
+	}
+	return n*(n-1)/2 + 1
+}
+
+func genCase(rng *rand.Rand) (string, []int64) {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	ans := make([]int64, t)
+	for i := 0; i < t; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		r := rng.Int63n(1_000_000_000) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, r)
+		ans[i] = expected(n, r)
+	}
+	return sb.String(), ans
+}
+
+func runCase(bin, input string, exp []int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	for i, e := range exp {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing output line %d", i+1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(scanner.Text(), &got); err != nil {
+			return fmt.Errorf("bad output on line %d: %v", i+1, err)
+		}
+		if got != e {
+			return fmt.Errorf("line %d: expected %d got %d", i+1, e, got)
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1371/verifierC.go
+++ b/1000-1999/1300-1399/1370-1379/1371/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a, b, n, m int64) string {
+	if a+b < n+m || min(a, b) < m {
+		return "No"
+	}
+	return "Yes"
+}
+
+func min(x, y int64) int64 {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func genCase(rng *rand.Rand) (string, []string) {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	ans := make([]string, t)
+	for i := 0; i < t; i++ {
+		a := rng.Int63n(1_000_000_000) + 1
+		b := rng.Int63n(1_000_000_000) + 1
+		n := rng.Int63n(1_000_000_000) + 1
+		m := rng.Int63n(1_000_000_000) + 1
+		fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, n, m)
+		ans[i] = expected(a, b, n, m)
+	}
+	return sb.String(), ans
+}
+
+func runCase(bin, input string, exp []string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	for i, e := range exp {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing output line %d", i+1)
+		}
+		got := strings.TrimSpace(scanner.Text())
+		if got != e {
+			return fmt.Errorf("line %d: expected %s got %s", i+1, e, got)
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1371/verifierD.go
+++ b/1000-1999/1300-1399/1370-1379/1371/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedFirst(n, k int) int {
+	if k%n == 0 {
+		return 0
+	}
+	return 2
+}
+
+func genCase(rng *rand.Rand) (string, int, int) {
+	n := rng.Intn(10) + 1 // limit to 1..10 for speed
+	k := rng.Intn(n*n + 1)
+	input := fmt.Sprintf("1\n%d %d\n", n, k)
+	return input, n, k
+}
+
+func checkMatrix(n, k int, lines []string) error {
+	if len(lines) != n {
+		return fmt.Errorf("expected %d rows, got %d", n, len(lines))
+	}
+	ones := 0
+	row := make([]int, n)
+	col := make([]int, n)
+	for i := 0; i < n; i++ {
+		if len(lines[i]) != n {
+			return fmt.Errorf("row %d length %d", i, len(lines[i]))
+		}
+		for j := 0; j < n; j++ {
+			c := lines[i][j]
+			if c == '1' {
+				ones++
+				row[i]++
+				col[j]++
+			} else if c != '0' {
+				return fmt.Errorf("invalid char %c at %d,%d", c, i, j)
+			}
+		}
+	}
+	if ones != k {
+		return fmt.Errorf("expected %d ones got %d", k, ones)
+	}
+	minRow, maxRow := row[0], row[0]
+	minCol, maxCol := col[0], col[0]
+	for i := 1; i < n; i++ {
+		if row[i] < minRow {
+			minRow = row[i]
+		}
+		if row[i] > maxRow {
+			maxRow = row[i]
+		}
+		if col[i] < minCol {
+			minCol = col[i]
+		}
+		if col[i] > maxCol {
+			maxCol = col[i]
+		}
+	}
+	if maxRow-minRow > 1 {
+		return fmt.Errorf("row diff too big")
+	}
+	if maxCol-minCol > 1 {
+		return fmt.Errorf("column diff too big")
+	}
+	return nil
+}
+
+func runCase(bin string, input string, n, k int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	if !scanner.Scan() {
+		return fmt.Errorf("missing first line")
+	}
+	var first int
+	if _, err := fmt.Sscan(scanner.Text(), &first); err != nil {
+		return fmt.Errorf("bad first line: %v", err)
+	}
+	expFirst := expectedFirst(n, k)
+	if first != expFirst {
+		return fmt.Errorf("expected first line %d got %d", expFirst, first)
+	}
+	matrix := make([]string, 0, n)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			matrix = append(matrix, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return checkMatrix(n, k, matrix)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n, k := genCase(rng)
+		if err := runCase(bin, in, n, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1371/verifierE1.go
+++ b/1000-1999/1300-1399/1370-1379/1371/verifierE1.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE1")
+	cmd := exec.Command("go", "build", "-o", oracle, "1371E1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	cmd := exec.Command(prog)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	p := rng.Intn(50) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, p)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(40)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := runProg(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := runProg(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1371/verifierE2.go
+++ b/1000-1999/1300-1399/1370-1379/1371/verifierE2.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE2")
+	cmd := exec.Command("go", "build", "-o", oracle, "1371E2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	cmd := exec.Command(prog)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	p := rng.Intn(50) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, p)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(50)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := runProg(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := runProg(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1371/verifierF.go
+++ b/1000-1999/1300-1399/1370-1379/1371/verifierF.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1371F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	cmd := exec.Command(prog)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('<')
+		} else {
+			sb.WriteByte('>')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := runProg(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := runProg(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 1371 problems A–F
- each verifier generates 100 random tests and checks the output
- some verifiers build the official solutions as oracles

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE1.go`
- `go build verifierE2.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885e84bccc08324bcf9df491aa094b6