### PR TITLE
Add Go verifiers for contest 1370

### DIFF
--- a/1000-1999/1300-1399/1370-1379/1370/verifierA.go
+++ b/1000-1999/1300-1399/1370-1379/1370/verifierA.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		cases[i].n = rng.Intn(1_000_000-1) + 2
+	}
+	return cases
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		input := fmt.Sprintf("1\n%d\n", tc.n)
+		expected := strconv.Itoa(tc.n / 2)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1370/verifierB.go
+++ b/1000-1999/1300-1399/1370-1379/1370/verifierB.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	arr []int
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 2 // n between 2 and 6
+		arr := make([]int, 2*n)
+		for j := range arr {
+			arr[j] = rng.Intn(1000) + 1
+		}
+		cases[i] = testCase{n: n, arr: arr}
+	}
+	return cases
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func check(tc testCase, output string) error {
+	fields := strings.Fields(output)
+	if len(fields) != 2*(tc.n-1) {
+		return fmt.Errorf("expected %d numbers got %d", 2*(tc.n-1), len(fields))
+	}
+	used := make([]bool, 2*tc.n+1)
+	g := 0
+	for i := 0; i < tc.n-1; i++ {
+		a, err := strconv.Atoi(fields[2*i])
+		if err != nil {
+			return fmt.Errorf("invalid integer %s", fields[2*i])
+		}
+		b, err := strconv.Atoi(fields[2*i+1])
+		if err != nil {
+			return fmt.Errorf("invalid integer %s", fields[2*i+1])
+		}
+		if a < 1 || a > 2*tc.n || b < 1 || b > 2*tc.n || a == b || used[a] || used[b] {
+			return fmt.Errorf("invalid indices")
+		}
+		used[a] = true
+		used[b] = true
+		sum := tc.arr[a-1] + tc.arr[b-1]
+		if g == 0 {
+			g = sum
+		} else {
+			g = gcd(g, sum)
+		}
+	}
+	if g <= 1 {
+		return fmt.Errorf("gcd <= 1")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j, v := range tc.arr {
+			sb.WriteString(fmt.Sprintf("%d", v))
+			if j+1 < len(tc.arr) {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(tc, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1370/verifierC.go
+++ b/1000-1999/1300-1399/1370-1379/1370/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int64
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1370C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		cases[i].n = rng.Int63n(1_000_000_000) + 1
+	}
+	return cases
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	input := fmt.Sprintf("1\n%d\n", tc.n)
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	cases := generateCases()
+	for i, tc := range cases {
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1370/verifierD.go
+++ b/1000-1999/1300-1399/1370-1379/1370/verifierD.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	k   int
+	arr []int
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1370D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(50) + 1
+		if n < 2 {
+			n = 2
+		}
+		k := rng.Intn(n) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(1000) + 1
+		}
+		cases[i] = testCase{n: n, k: k, arr: arr}
+	}
+	return cases
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+	for i, v := range tc.arr {
+		sb.WriteString(fmt.Sprintf("%d", v))
+		if i+1 < len(tc.arr) {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	cases := generateCases()
+	for i, tc := range cases {
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1370/verifierE.go
+++ b/1000-1999/1300-1399/1370-1379/1370/verifierE.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	s string
+	t string
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1370E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(200) + 1
+		b1 := make([]byte, n)
+		b2 := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				b1[j] = '0'
+			} else {
+				b1[j] = '1'
+			}
+			if rng.Intn(2) == 0 {
+				b2[j] = '0'
+			} else {
+				b2[j] = '1'
+			}
+		}
+		cases[i] = testCase{n: n, s: string(b1), t: string(b2)}
+	}
+	return cases
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	input := fmt.Sprintf("%d\n%s\n%s\n", tc.n, tc.s, tc.t)
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	cases := generateCases()
+	for i, tc := range cases {
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1370-1379/1370/verifierF1.go
+++ b/1000-1999/1300-1399/1370-1379/1370/verifierF1.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem F1 is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1300-1399/1370-1379/1370/verifierF2.go
+++ b/1000-1999/1300-1399/1370-1379/1370/verifierF2.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem F2 is interactive and cannot be automatically verified.")
+}


### PR DESCRIPTION
## Summary
- add verification programs for contest 1370 problems A–E and placeholders for F1/F2
- generators create 100 random test cases
- oracles built from reference solutions where output is unique
- pairings for problem B are validated algorithmically

## Testing
- `go build 1000-1999/1300-1399/1370-1379/1370/verifierA.go`
- `go build 1000-1999/1300-1399/1370-1379/1370/verifierB.go`
- `go build 1000-1999/1300-1399/1370-1379/1370/verifierC.go`
- `go build 1000-1999/1300-1399/1370-1379/1370/verifierD.go`
- `go build 1000-1999/1300-1399/1370-1379/1370/verifierE.go`
- `go build 1000-1999/1300-1399/1370-1379/1370/verifierF1.go`
- `go build 1000-1999/1300-1399/1370-1379/1370/verifierF2.go`


------
https://chatgpt.com/codex/tasks/task_e_6885e7bfba888324980759fb41dafcce