### PR TITLE
Add Go solution for 1513C

### DIFF
--- a/1000-1999/1500-1599/1510-1519/1513/1513C.go
+++ b/1000-1999/1500-1599/1510-1519/1513/1513C.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 1_000_000_007
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+
+	const maxM = 200000
+	dp := make([]int64, maxM+10+1)
+	for i := 0; i <= 9; i++ {
+		dp[i] = 1
+	}
+	for i := 10; i <= maxM+9; i++ {
+		dp[i] = (dp[i-9] + dp[i-10]) % mod
+	}
+
+	for ; t > 0; t-- {
+		var n string
+		var m int
+		fmt.Fscan(reader, &n, &m)
+		var ans int64
+		for _, ch := range n {
+			d := int(ch - '0')
+			ans = (ans + dp[d+m]) % mod
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1513C in Go using DP

## Testing
- `go build 1000-1999/1500-1599/1510-1519/1513/1513C.go`


------
https://chatgpt.com/codex/tasks/task_e_6885e91deee483249022d02ddf4b1ed2