### PR TITLE
Add Go verifiers for contest 1373

### DIFF
--- a/1000-1999/1300-1399/1370-1379/1373/verifierA.go
+++ b/1000-1999/1300-1399/1370-1379/1373/verifierA.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./1373A_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "1373A.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for i := 0; i < 100; i++ {
+		a := rand.Int63n(1e9) + 1
+		b := rand.Int63n(1e9-1) + 2
+		c := rand.Int63n(1e9) + 1
+		input := fmt.Sprintf("1\n%d %d %d\n", a, b, c)
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", i+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", i+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1370-1379/1373/verifierB.go
+++ b/1000-1999/1300-1399/1370-1379/1373/verifierB.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if rand.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./1373B_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "1373B.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(30) + 1
+		s := randString(n)
+		input := fmt.Sprintf("1\n%s\n", s)
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", i+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", i+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1370-1379/1373/verifierC.go
+++ b/1000-1999/1300-1399/1370-1379/1373/verifierC.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if rand.Intn(2) == 0 {
+			b[i] = '+'
+		} else {
+			b[i] = '-'
+		}
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./1373C_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "1373C.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(30) + 1
+		s := randString(n)
+		input := fmt.Sprintf("1\n%s\n", s)
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", i+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", i+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1370-1379/1373/verifierD.go
+++ b/1000-1999/1300-1399/1370-1379/1373/verifierD.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./1373D_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "1373D.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		arr := make([]int64, n)
+		for i := range arr {
+			arr[i] = rand.Int63n(201) - 100
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1370-1379/1373/verifierE.go
+++ b/1000-1999/1300-1399/1370-1379/1373/verifierE.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./1373E_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "1373E.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(150) + 1
+		k := rand.Intn(10)
+		input := fmt.Sprintf("1\n%d %d\n", n, k)
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1370-1379/1373/verifierF.go
+++ b/1000-1999/1300-1399/1370-1379/1373/verifierF.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./1373F_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "1373F.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		a := make([]int64, n)
+		b := make([]int64, n)
+		for i := 0; i < n; i++ {
+			a[i] = rand.Int63n(20) + 1
+			b[i] = rand.Int63n(20) + a[i]
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", b[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1300-1399/1370-1379/1373/verifierG.go
+++ b/1000-1999/1300-1399/1370-1379/1373/verifierG.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./1373G_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "1373G.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(n) + 1
+		m := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, m))
+		for i := 0; i < m; i++ {
+			x := rand.Intn(n) + 1
+			y := rand.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		}
+		input := sb.String()
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for Codeforces contest 1373
- verifiers compile the reference solutions and compare the output of a user binary on 100 randomized test cases

## Testing
- `go vet verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_6885e963fbf083248a10ac378a6ec103