### PR TITLE
Fix 182 verifiers path

### DIFF
--- a/0-999/100-199/180-189/182/verifierA.go
+++ b/0-999/100-199/180-189/182/verifierA.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 )
 
-const refDirA = "./0-999/100-199/180-189/182"
+// refDirA points to the directory containing the solution and verifier.
+// The evaluator runs this verifier with its working directory already set
+// to the folder where these files live, so just use ".".
+const refDirA = "."
 
 func runBinary(path, input string) (string, error) {
 	cmd := exec.Command(path)

--- a/0-999/100-199/180-189/182/verifierB.go
+++ b/0-999/100-199/180-189/182/verifierB.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 )
 
-const refDirB = "./0-999/100-199/180-189/182"
+// refDirB points to the directory containing the solution and verifier.
+// The evaluator executes this verifier with that directory as the working
+// directory, so "." is sufficient.
+const refDirB = "."
 
 func runBinary(path, input string) (string, error) {
 	cmd := exec.Command(path)

--- a/0-999/100-199/180-189/182/verifierC.go
+++ b/0-999/100-199/180-189/182/verifierC.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 )
 
-const refDirC = "./0-999/100-199/180-189/182"
+// refDirC refers to the directory containing the verifier and solutions.
+// The evaluator already sets the working directory to this folder.
+const refDirC = "."
 
 func runBinary(path, input string) (string, error) {
 	cmd := exec.Command(path)

--- a/0-999/100-199/180-189/182/verifierD.go
+++ b/0-999/100-199/180-189/182/verifierD.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 )
 
-const refDirD = "./0-999/100-199/180-189/182"
+// refDirD references the directory of this verifier. The evaluation driver
+// runs the verifier with its working directory already set here, so use ".".
+const refDirD = "."
 
 func runBinary(path, input string) (string, error) {
 	cmd := exec.Command(path)

--- a/0-999/100-199/180-189/182/verifierE.go
+++ b/0-999/100-199/180-189/182/verifierE.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 )
 
-const refDirE = "./0-999/100-199/180-189/182"
+// refDirE points to the directory containing the solutions and this verifier.
+// The verifier is executed with that directory as the current working
+// directory, so use ".".
+const refDirE = "."
 
 func runBinary(path, input string) (string, error) {
 	cmd := exec.Command(path)


### PR DESCRIPTION
## Summary
- fix reference directory constants in contest 182 verifiers so they build in-place

## Testing
- `go build 0-999/100-199/180-189/182/verifierA.go`
- `go build 0-999/100-199/180-189/182/verifierB.go`
- `go build 0-999/100-199/180-189/182/verifierC.go`
- `go build 0-999/100-199/180-189/182/verifierD.go`
- `go build 0-999/100-199/180-189/182/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6885eebe067483249acc37a95e4fafb4