### PR TITLE
Add verifiers for contest 1383

### DIFF
--- a/1000-1999/1300-1399/1380-1389/1383/verifierA.go
+++ b/1000-1999/1300-1399/1380-1389/1383/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1383A.go")
+	bin := filepath.Join(os.TempDir(), "1383A_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(20) + 1
+	a := make([]byte, n)
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		a[i] = byte('a' + rng.Intn(20))
+		b[i] = byte('a' + rng.Intn(20))
+	}
+	return []byte(fmt.Sprintf("1\n%d\n%s\n%s\n", n, string(a), string(b)))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1383/verifierB.go
+++ b/1000-1999/1300-1399/1380-1389/1383/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1383B.go")
+	bin := filepath.Join(os.TempDir(), "1383B_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(50) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(1000)))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1383/verifierC.go
+++ b/1000-1999/1300-1399/1380-1389/1383/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1383C.go")
+	bin := filepath.Join(os.TempDir(), "1383C_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(20) + 1
+	a := make([]byte, n)
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		a[i] = byte('a' + rng.Intn(20))
+		b[i] = byte('a' + rng.Intn(20))
+	}
+	return []byte(fmt.Sprintf("1\n%d\n%s\n%s\n", n, string(a), string(b)))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1383/verifierD.go
+++ b/1000-1999/1300-1399/1380-1389/1383/verifierD.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1383D.go")
+	bin := filepath.Join(os.TempDir(), "1383D_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	perm := rng.Perm(n * m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", perm[i*m+j]+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1383/verifierE.go
+++ b/1000-1999/1300-1399/1380-1389/1383/verifierE.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1383E.go")
+	bin := filepath.Join(os.TempDir(), "1383E_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(8) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return []byte(fmt.Sprintf("%s\n", string(b)))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1383/verifierF.go
+++ b/1000-1999/1300-1399/1380-1389/1383/verifierF.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1383F.go")
+	bin := filepath.Join(os.TempDir(), "1383F_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(5) + n
+	k := rng.Intn(3) + 1
+	if k > m {
+		k = m
+	}
+	q := rng.Intn(3) + 1
+	type E struct{ u, v, w int }
+	edges := make([]E, m)
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		w := 0
+		if i >= k {
+			w = rng.Intn(6)
+		}
+		edges[i] = E{u, v, w}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, k, q))
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", edges[i].u, edges[i].v, edges[i].w))
+	}
+	for j := 0; j < q; j++ {
+		for i := 0; i < k; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(6)))
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–F of contest 1383
- each verifier builds the reference implementation, generates 100 random tests and compares the results

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_6885eedce5dc832486c34654480ac936