### PR TITLE
Add Go verifiers for Codeforces contest 1381

### DIFF
--- a/1000-1999/1300-1399/1380-1389/1381/verifierA.go
+++ b/1000-1999/1300-1399/1380-1389/1381/verifierA.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n int
+	a string
+	b string
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(1381))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		var sb1, sb2 strings.Builder
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				sb1.WriteByte('0')
+			} else {
+				sb1.WriteByte('1')
+			}
+			if rng.Intn(2) == 0 {
+				sb2.WriteByte('0')
+			} else {
+				sb2.WriteByte('1')
+			}
+		}
+		tests[i] = testCase{n, sb1.String(), sb2.String()}
+	}
+	return tests
+}
+
+func apply(arr []byte, p int) {
+	for i := 0; i < p/2; i++ {
+		arr[i], arr[p-1-i] = arr[p-1-i], arr[i]
+	}
+	for i := 0; i < p; i++ {
+		if arr[i] == '0' {
+			arr[i] = '1'
+		} else {
+			arr[i] = '0'
+		}
+	}
+}
+
+func verify(n int, a, b string, ops []int) bool {
+	s := []byte(a)
+	for _, v := range ops {
+		if v < 1 || v > n {
+			return false
+		}
+		apply(s, v)
+	}
+	return string(s) == b
+}
+
+func parseOutput(out string, n int) ([]int, error) {
+	r := strings.NewReader(out)
+	var k int
+	if _, err := fmt.Fscan(r, &k); err != nil {
+		return nil, err
+	}
+	if k < 0 || k > 3*n {
+		return nil, fmt.Errorf("invalid k %d", k)
+	}
+	ops := make([]int, k)
+	for i := 0; i < k; i++ {
+		if _, err := fmt.Fscan(r, &ops[i]); err != nil {
+			return nil, err
+		}
+	}
+	return ops, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%s\n%s\n", tc.n, tc.a, tc.b)
+		out, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		ops, err := parseOutput(out, tc.n)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: parse error: %v\noutput:%s\n", i+1, err, out)
+			os.Exit(1)
+		}
+		if !verify(tc.n, tc.a, tc.b, ops) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:%soutput:%s\n", i+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1381/verifierB.go
+++ b/1000-1999/1300-1399/1380-1389/1381/verifierB.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func buildOracle() (string, error) {
+	tmp, err := os.CreateTemp("", "oracle*")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	if out, err := exec.Command("go", "build", "-o", tmp.Name(), "1381B.go").CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return tmp.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n int
+	p []int
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		perm := rng.Perm(2 * n)
+		for j := 0; j < 2*n; j++ {
+			perm[j]++
+		}
+		tests[i] = testCase{n, perm}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j, v := range tc.p {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle fail case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1381/verifierC.go
+++ b/1000-1999/1300-1399/1380-1389/1381/verifierC.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func buildOracle() (string, error) {
+	tmp, err := os.CreateTemp("", "oracle*")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	if out, err := exec.Command("go", "build", "-o", tmp.Name(), "1381C.go").CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return tmp.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseCandidate(out string, n int) (bool, []int, error) {
+	r := strings.NewReader(out)
+	var token string
+	if _, err := fmt.Fscan(r, &token); err != nil {
+		return false, nil, err
+	}
+	token = strings.ToUpper(token)
+	if token == "NO" {
+		return false, nil, nil
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		if _, err := fmt.Fscan(r, &arr[i]); err != nil {
+			return false, nil, err
+		}
+	}
+	return true, arr, nil
+}
+
+func checkValidity(n, x, y int, b, ans []int) bool {
+	if len(ans) != n {
+		return false
+	}
+	cntB := make(map[int]int)
+	cntA := make(map[int]int)
+	matches := 0
+	for i := 0; i < n; i++ {
+		if ans[i] < 1 || ans[i] > n+1 {
+			return false
+		}
+		if ans[i] == b[i] {
+			matches++
+		}
+		cntA[ans[i]]++
+		cntB[b[i]]++
+	}
+	if matches != x {
+		return false
+	}
+	inter := 0
+	for c, ca := range cntA {
+		if cb, ok := cntB[c]; ok {
+			if ca < cb {
+				inter += ca
+			} else {
+				inter += cb
+			}
+		}
+	}
+	return inter == y
+}
+
+type testCase struct {
+	n int
+	x int
+	y int
+	b []int
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		x := rng.Intn(n + 1)
+		y := x + rng.Intn(n-x+1)
+		b := make([]int, n)
+		for j := 0; j < n; j++ {
+			b[j] = rng.Intn(n+1) + 1
+		}
+		tests[i] = testCase{n, x, y, b}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.x, tc.y))
+		for j, v := range tc.b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle fail case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		wantHas := strings.HasPrefix(strings.TrimSpace(want), "YES")
+		got, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		has, arr, err := parseCandidate(got, tc.n)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: parse error: %v\noutput:%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if wantHas != has {
+			fmt.Fprintf(os.Stderr, "case %d: expected %v got %v\ninput:%s", i+1, wantHas, has, input)
+			os.Exit(1)
+		}
+		if has {
+			if !checkValidity(tc.n, tc.x, tc.y, tc.b, arr) {
+				fmt.Fprintf(os.Stderr, "case %d: invalid solution\ninput:%soutput:%s", i+1, input, got)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1381/verifierD.go
+++ b/1000-1999/1300-1399/1380-1389/1381/verifierD.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func buildOracle() (string, error) {
+	tmp, err := os.CreateTemp("", "oracle*")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	if out, err := exec.Command("go", "build", "-o", tmp.Name(), "1381D.go").CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return tmp.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n     int
+	a     int
+	b     int
+	edges [][2]int
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 2
+		edges := make([][2]int, n-1)
+		for v := 2; v <= n; v++ {
+			p := rng.Intn(v-1) + 1
+			edges[v-2] = [2]int{p, v}
+		}
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		for b == a {
+			b = rng.Intn(n) + 1
+		}
+		tests[i] = testCase{n, a, b, edges}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.a, tc.b))
+		for _, e := range tc.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input := sb.String()
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle fail case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1381/verifierE.go
+++ b/1000-1999/1300-1399/1380-1389/1381/verifierE.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func buildOracle() (string, error) {
+	tmp, err := os.CreateTemp("", "oracle*")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	if out, err := exec.Command("go", "build", "-o", tmp.Name(), "1381E.go").CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return tmp.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n       int
+	q       int
+	poly    []point
+	queries []int
+}
+
+func genPolygon() []point {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	n := rng.Intn(4) + 3
+	angles := make([]float64, n)
+	for i := 0; i < n; i++ {
+		angles[i] = rng.Float64() * 2 * math.Pi
+	}
+	sort.Float64s(angles)
+	poly := make([]point, n)
+	for i := 0; i < n; i++ {
+		r := rng.Float64()*5 + 5
+		x := int(math.Round(r * math.Cos(angles[i]) * 10))
+		y := int(math.Round(r * math.Sin(angles[i]) * 10))
+		if i > 0 && y == poly[i-1].y {
+			y++
+		}
+		poly[i] = point{x, y}
+	}
+	return poly
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	basePoly := []point{{0, 0}, {0, 10}, {10, 9}, {10, -1}}
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		poly := basePoly
+		n := len(poly)
+		q := rng.Intn(3) + 1
+		qs := make([]int, 0, q)
+		used := map[int]bool{}
+		for len(qs) < q {
+			f := rng.Intn(9) + 1
+			if !used[f] {
+				used[f] = true
+				qs = append(qs, f)
+			}
+		}
+		tests[i] = testCase{n, q, poly, qs}
+	}
+	return tests
+}
+
+func parseFloats(s string, cnt int) ([]float64, error) {
+	r := strings.NewReader(s)
+	vals := make([]float64, cnt)
+	for i := 0; i < cnt; i++ {
+		if _, err := fmt.Fscan(r, &vals[i]); err != nil {
+			return nil, err
+		}
+	}
+	return vals, nil
+}
+
+func compare(a, b float64) bool {
+	diff := math.Abs(a - b)
+	den := math.Max(1.0, math.Abs(b))
+	return diff/den <= 1e-4
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.q))
+		for _, p := range tc.poly {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+		}
+		for _, f := range tc.queries {
+			sb.WriteString(fmt.Sprintf("%d\n", f))
+		}
+		input := sb.String()
+		wantStr, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle fail case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		gotStr, err := runProg(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		wantVals, err := parseFloats(wantStr, tc.q)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle output parse error case %d: %v", i+1, err)
+			os.Exit(1)
+		}
+		gotVals, err := parseFloats(gotStr, tc.q)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d parse error: %v\noutput:%s", i+1, err, gotStr)
+			os.Exit(1)
+		}
+		for j := 0; j < tc.q; j++ {
+			if !compare(wantVals[j], gotVals[j]) {
+				fmt.Fprintf(os.Stderr, "case %d mismatch on query %d\nexpected:%f got:%f\ninput:%s", i+1, j+1, wantVals[j], gotVals[j], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go validating prefix flip operations
- add verifierB.go using reference solution for expected output
- add verifierC.go validating arbitrary solutions using oracle and custom checks
- add verifierD.go and verifierE.go with oracle checks for tree and geometry problems
- each verifier generates 100 random test cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6885edc4b3ec8324b49a871e0ba9179d