### PR TITLE
Fix verifier slice bounds for 580C

### DIFF
--- a/0-999/500-599/580-589/580/verifierC.go
+++ b/0-999/500-599/580-589/580/verifierC.go
@@ -109,7 +109,9 @@ func main() {
 	bin := os.Args[1]
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	cats := []int{0, 1, 1}
+	// the cats slice is 1-indexed, so allocate n+1 elements
+	// to avoid out-of-bounds access when n == len(cats)-1
+	cats := []int{0, 1, 1, 0}
 	edges := [][2]int{{1, 2}, {1, 3}}
 	cases := []testCase{
 		buildCase(3, 1, cats, edges),


### PR DESCRIPTION
## Summary
- increase length of hard-coded `cats` slice in `verifierC.go`
- add comment explaining 1-indexing

## Testing
- `go build -o testbin 0-999/500-599/580-589/580/580C.go`
- `go run 0-999/500-599/580-589/580/verifierC.go ./testbin | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_6885f0270f2483249df9575bdafbc932