### PR TITLE
Fix byte literals in contest 163 verifierA

### DIFF
--- a/0-999/100-199/160-169/163/verifierA.go
+++ b/0-999/100-199/160-169/163/verifierA.go
@@ -59,7 +59,8 @@ func run(bin, input string) (string, error) {
 }
 
 func randomString(rng *rand.Rand, n int) string {
-	letters := []byte{"a", "b", "c"}
+	// letters should be bytes not strings
+	letters := []byte{'a', 'b', 'c'}
 	b := make([]byte, n)
 	for i := 0; i < n; i++ {
 		b[i] = letters[rng.Intn(len(letters))]


### PR DESCRIPTION
## Summary
- correct byte slice in `randomString` helper for contest 163

## Testing
- `go build 0-999/100-199/160-169/163/verifierA.go`
- `./verifierA 0-999/100-199/160-169/163/163A.go`

------
https://chatgpt.com/codex/tasks/task_e_6885f0fd3d48832497af6a8f7081cb43