### PR TITLE
Add Go verifiers for CF 1385

### DIFF
--- a/1000-1999/1300-1399/1380-1389/1385/verifierA.go
+++ b/1000-1999/1300-1399/1380-1389/1385/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	x, y, z  int64
+	input    string
+	expected string
+}
+
+func solveCase(x, y, z int64) (bool, int64, int64, int64) {
+	if x == y && y == z {
+		return true, x, y, z
+	}
+	if x == y {
+		if x >= z {
+			return true, x, z, 1
+		}
+		return false, 0, 0, 0
+	}
+	if x == z {
+		if x >= y {
+			return true, y, 1, x
+		}
+		return false, 0, 0, 0
+	}
+	if y == z {
+		if y >= x {
+			return true, 1, x, y
+		}
+		return false, 0, 0, 0
+	}
+	return false, 0, 0, 0
+}
+
+func buildCase(x, y, z int64) testCase {
+	ok, a, b, c := solveCase(x, y, z)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", x, y, z))
+	var exp strings.Builder
+	if ok {
+		exp.WriteString("YES\n")
+		exp.WriteString(fmt.Sprintf("%d %d %d\n", a, b, c))
+	} else {
+		exp.WriteString("NO\n")
+	}
+	return testCase{x: x, y: y, z: z, input: sb.String(), expected: exp.String()}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	x := rng.Int63n(100) + 1
+	y := rng.Int63n(100) + 1
+	z := rng.Int63n(100) + 1
+	return buildCase(x, y, z)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(tc.expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(tc.expected), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase(1, 1, 1),
+		buildCase(3, 3, 2),
+		buildCase(10, 20, 30),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1385/verifierB.go
+++ b/1000-1999/1300-1399/1380-1389/1385/verifierB.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n        int
+	a        []int
+	input    string
+	expected string
+}
+
+func solveCase(n int, arr []int) string {
+	seen := make([]bool, n+1)
+	res := make([]int, 0, n)
+	for _, v := range arr {
+		if !seen[v] {
+			seen[v] = true
+			res = append(res, v)
+		}
+	}
+	var sb strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildCase(p []int) testCase {
+	n := len(p)
+	// generate random merge of two copies of p
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	arr := make([]int, 0, 2*n)
+	i, j := 0, 0
+	for i < n || j < n {
+		if i == n {
+			arr = append(arr, p[j])
+			j++
+		} else if j == n {
+			arr = append(arr, p[i])
+			i++
+		} else if rng.Intn(2) == 0 {
+			arr = append(arr, p[i])
+			i++
+		} else {
+			arr = append(arr, p[j])
+			j++
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for idx, v := range arr {
+		if idx > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	exp := solveCase(n, arr)
+	return testCase{n: n, a: arr, input: sb.String(), expected: exp}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	return buildCase(perm)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(tc.expected)
+	if got != want {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase([]int{1}),
+		buildCase([]int{2, 1}),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1385/verifierC.go
+++ b/1000-1999/1300-1399/1380-1389/1385/verifierC.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n        int
+	a        []int
+	input    string
+	expected string
+}
+
+func solveCase(arr []int) int {
+	n := len(arr)
+	i := n - 1
+	for i > 0 && arr[i-1] >= arr[i] {
+		i--
+	}
+	for i > 0 && arr[i-1] <= arr[i] {
+		i--
+	}
+	return i
+}
+
+func buildCase(a []int) testCase {
+	n := len(a)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for idx, v := range a {
+		if idx > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	res := solveCase(a)
+	return testCase{n: n, a: a, input: sb.String(), expected: fmt.Sprintf("%d\n", res)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(50)
+	}
+	return buildCase(a)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(tc.expected)
+	if got != want {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase([]int{1}),
+		buildCase([]int{5, 4, 3, 2, 1}),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1385/verifierD.go
+++ b/1000-1999/1300-1399/1380-1389/1385/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n        int
+	s        string
+	input    string
+	expected string
+}
+
+func solveRec(b []byte, l, r int, c byte) int {
+	if r-l == 1 {
+		if b[l] == c {
+			return 0
+		}
+		return 1
+	}
+	mid := (l + r) / 2
+	cntLeft := 0
+	for i := l; i < mid; i++ {
+		if b[i] == c {
+			cntLeft++
+		}
+	}
+	cntRight := 0
+	for i := mid; i < r; i++ {
+		if b[i] == c {
+			cntRight++
+		}
+	}
+	cost1 := (mid - l - cntLeft) + solveRec(b, mid, r, c+1)
+	cost2 := (r - mid - cntRight) + solveRec(b, l, mid, c+1)
+	if cost1 < cost2 {
+		return cost1
+	}
+	return cost2
+}
+
+func buildCase(s string) testCase {
+	n := len(s)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+	res := solveRec([]byte(s), 0, n, 'a')
+	return testCase{n: n, s: s, input: sb.String(), expected: fmt.Sprintf("%d\n", res)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	k := rng.Intn(4) + 1
+	n := 1 << k
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return buildCase(string(b))
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(tc.expected)
+	if got != want {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase("a"),
+		buildCase("ba"),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1385/verifierE.go
+++ b/1000-1999/1300-1399/1380-1389/1385/verifierE.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	t int // 1 directed, 0 undirected
+	u int
+	v int
+}
+
+type testCase struct {
+	n, m     int
+	edges    []edge
+	input    string
+	possible bool
+}
+
+func topoPossible(n int, edges []edge) bool {
+	deg := make([]int, n+1)
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		if e.t == 1 {
+			adj[e.u] = append(adj[e.u], e.v)
+			deg[e.v]++
+		}
+	}
+	q := make([]int, 0)
+	for i := 1; i <= n; i++ {
+		if deg[i] == 0 {
+			q = append(q, i)
+		}
+	}
+	cnt := 0
+	for i := 0; i < len(q); i++ {
+		v := q[i]
+		cnt++
+		for _, to := range adj[v] {
+			deg[to]--
+			if deg[to] == 0 {
+				q = append(q, to)
+			}
+		}
+	}
+	return cnt == n
+}
+
+func buildCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 2
+	var edges []edge
+	possible := true
+	if rng.Float64() < 0.3 {
+		// create directed cycle
+		if n < 3 {
+			n = 3
+		}
+		a, b, c := 1, 2, 3
+		edges = append(edges, edge{1, a, b}, edge{1, b, c}, edge{1, c, a})
+		m := rng.Intn(3)
+		for i := 0; i < m; i++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				v = (v % n) + 1
+			}
+			edges = append(edges, edge{0, u, v})
+		}
+		possible = false
+	} else {
+		perm := rng.Perm(n)
+		for i := range perm {
+			perm[i]++
+		}
+		m := rng.Intn(n*2) + n
+		for i := 0; i < m; i++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			for u == v {
+				v = rng.Intn(n) + 1
+			}
+			if perm[u-1] < perm[v-1] {
+				if rng.Intn(2) == 0 {
+					edges = append(edges, edge{1, u, v})
+				} else {
+					edges = append(edges, edge{0, u, v})
+				}
+			} else {
+				if rng.Intn(2) == 0 {
+					edges = append(edges, edge{1, v, u})
+				} else {
+					edges = append(edges, edge{0, v, u})
+				}
+			}
+		}
+		possible = true
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.t, e.u, e.v))
+	}
+	return testCase{n: n, m: len(edges), edges: edges, input: sb.String(), possible: possible}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	first := strings.TrimSpace(lines[0])
+	if first == "NO" {
+		if tc.possible {
+			return fmt.Errorf("expected YES got NO")
+		}
+		return nil
+	}
+	if first != "YES" {
+		return fmt.Errorf("expected YES or NO got %s", first)
+	}
+	if !tc.possible {
+		return fmt.Errorf("expected NO but got YES")
+	}
+	if len(lines)-1 != tc.m {
+		return fmt.Errorf("expected %d edges, got %d", tc.m, len(lines)-1)
+	}
+	orient := make([]edge, 0, tc.m)
+	for _, line := range lines[1:] {
+		var u, v int
+		if _, err := fmt.Sscanf(strings.TrimSpace(line), "%d %d", &u, &v); err != nil {
+			return fmt.Errorf("bad edge line: %v", err)
+		}
+		orient = append(orient, edge{1, u, v})
+	}
+	// check edges correspond
+	used := make([]bool, tc.m)
+	for _, o := range orient {
+		found := false
+		for i, e := range tc.edges {
+			if used[i] {
+				continue
+			}
+			if e.t == 1 {
+				if e.u == o.u && e.v == o.v {
+					used[i] = true
+					found = true
+					break
+				}
+			} else {
+				// undirected can be either direction
+				if (e.u == o.u && e.v == o.v) || (e.u == o.v && e.v == o.u) {
+					used[i] = true
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return fmt.Errorf("output edge %d %d not in input", o.u, o.v)
+		}
+	}
+	for i, u := range used {
+		if !u {
+			return fmt.Errorf("missing edge %d in output", i)
+		}
+	}
+	// check acyclicity
+	deg := make([]int, tc.n+1)
+	adj := make([][]int, tc.n+1)
+	for _, e := range orient {
+		adj[e.u] = append(adj[e.u], e.v)
+		deg[e.v]++
+	}
+	q := make([]int, 0)
+	for i := 1; i <= tc.n; i++ {
+		if deg[i] == 0 {
+			q = append(q, i)
+		}
+	}
+	cnt := 0
+	for i := 0; i < len(q); i++ {
+		v := q[i]
+		cnt++
+		for _, to := range adj[v] {
+			deg[to]--
+			if deg[to] == 0 {
+				q = append(q, to)
+			}
+		}
+	}
+	if cnt != tc.n {
+		return fmt.Errorf("output edges form a cycle")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0)
+	for i := 0; i < 100; i++ {
+		cases = append(cases, buildCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1385/verifierF.go
+++ b/1000-1999/1300-1399/1380-1389/1385/verifierF.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, k     int
+	edges    [][2]int
+	input    string
+	expected string
+}
+
+func solveCase(n, k int, edges [][2]int) int {
+	if k == 1 {
+		return n - 1
+	}
+	adj := make([][]int, n+1)
+	deg := make([]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+		deg[u]++
+		deg[v]++
+	}
+	leafVec := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		if deg[i] == 1 {
+			p := adj[i][0]
+			leafVec[p] = append(leafVec[p], i)
+		}
+	}
+	leafCnt := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		leafCnt[i] = len(leafVec[i])
+	}
+	queue := make([]int, 0)
+	for i := 1; i <= n; i++ {
+		if leafCnt[i] >= k {
+			queue = append(queue, i)
+		}
+	}
+	head := 0
+	ans := 0
+	for head < len(queue) {
+		v := queue[head]
+		head++
+		if leafCnt[v] < k {
+			continue
+		}
+		times := leafCnt[v] / k
+		ans += times
+		for i := 0; i < times*k; i++ {
+			u := leafVec[v][len(leafVec[v])-1]
+			leafVec[v] = leafVec[v][:len(leafVec[v])-1]
+			deg[u] = 0
+			leafCnt[v]--
+		}
+		deg[v] -= times * k
+		if deg[v] == 1 {
+			var parent int
+			for _, to := range adj[v] {
+				if deg[to] > 0 {
+					parent = to
+					break
+				}
+			}
+			if parent > 0 {
+				leafVec[parent] = append(leafVec[parent], v)
+				leafCnt[parent]++
+				if leafCnt[parent] >= k {
+					queue = append(queue, parent)
+				}
+			}
+		}
+		if leafCnt[v] >= k {
+			queue = append(queue, v)
+		}
+	}
+	return ans
+}
+
+func buildCase(n, k int, edges [][2]int) testCase {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	res := solveCase(n, k, edges)
+	return testCase{n: n, k: k, edges: edges, input: sb.String(), expected: fmt.Sprintf("%d\n", res)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(15) + 2
+	k := rng.Intn(n-1) + 1
+	edges := make([][2]int, 0, n-1)
+	// generate random tree
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return buildCase(n, k, edges)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(tc.expected)
+	if got != want {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0)
+	cases = append(cases, buildCase(2, 1, [][2]int{{1, 2}}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1385/verifierG.go
+++ b/1000-1999/1300-1399/1380-1389/1385/verifierG.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n         int
+	row1      []int
+	row2      []int
+	input     string
+	expectedK int
+}
+
+func solveCase(n int, a1, a2 []int) (int, []int) {
+	a := make([]int, n+1)
+	b := make([]int, n+1)
+	copy(a[1:], a1)
+	copy(b[1:], a2)
+	c := make([]int, n+1)
+	d := make([]int, n+1)
+	num := make([]int, n+1)
+	res := make([]int, n+1)
+	vis := make([]bool, n+1)
+
+	for i := 1; i <= n; i++ {
+		if c[a[i]] == 0 {
+			c[a[i]] = i
+		} else {
+			d[a[i]] = i
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if c[b[i]] == 0 {
+			c[b[i]] = i
+		} else {
+			d[b[i]] = i
+		}
+	}
+	for i := 1; i <= n; i++ {
+		num[a[i]]++
+		num[b[i]]++
+	}
+	for i := 1; i <= n; i++ {
+		if num[i] != 2 {
+			return -1, nil
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if vis[i] {
+			continue
+		}
+		cur := i
+		x := c[i]
+		buf := []int{x}
+		cnt := 0
+		if a[x] != i {
+			res[x] = 1
+			cnt++
+		}
+		for {
+			vis[cur] = true
+			nxt := a[x] + b[x] - cur
+			x = c[nxt] + d[nxt] - x
+			cur = nxt
+			if vis[cur] {
+				break
+			}
+			buf = append(buf, x)
+			if b[x] == nxt {
+				res[x] = 1
+				cnt++
+			}
+		}
+		if cnt > len(buf)-cnt {
+			for _, v := range buf {
+				if res[v] == 1 {
+					res[v] = 0
+				} else {
+					res[v] = 1
+				}
+			}
+		}
+	}
+	var outIdx []int
+	for i := 1; i <= n; i++ {
+		if res[i] == 1 {
+			outIdx = append(outIdx, i)
+		}
+	}
+	return len(outIdx), outIdx
+}
+
+func performSwaps(r1, r2 []int, idx []int) ([]int, []int) {
+	row1 := append([]int(nil), r1...)
+	row2 := append([]int(nil), r2...)
+	for _, p := range idx {
+		row1[p], row2[p] = row2[p], row1[p]
+	}
+	return row1, row2
+}
+
+func isPermutation(row []int) bool {
+	seen := make([]bool, len(row))
+	for _, v := range row[1:] {
+		if v <= 0 || v >= len(row) || seen[v] {
+			return false
+		}
+		seen[v] = true
+	}
+	return true
+}
+
+func buildCase(n int, r1, r2 []int) testCase {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range r1 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteString("\n")
+	for i, v := range r2 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteString("\n")
+	k, _ := solveCase(n, append([]int(nil), r1...), append([]int(nil), r2...))
+	return testCase{n: n, row1: r1, row2: r2, input: sb.String(), expectedK: k}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	positions := make([]int, 2*n)
+	for i := range positions {
+		positions[i] = i
+	}
+	rng.Shuffle(len(positions), func(i, j int) { positions[i], positions[j] = positions[j], positions[i] })
+	r1 := make([]int, n)
+	r2 := make([]int, n)
+	for val := 1; val <= n; val++ {
+		p1 := positions[2*(val-1)]
+		p2 := positions[2*(val-1)+1]
+		if p1 < n {
+			r1[p1] = val
+		} else {
+			r2[p1-n] = val
+		}
+		if p2 < n {
+			r1[p2] = val
+		} else {
+			r2[p2-n] = val
+		}
+	}
+	return buildCase(n, r1, r2)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	var k int
+	if _, err := fmt.Sscan(fields[0], &k); err != nil {
+		return fmt.Errorf("bad first line")
+	}
+	if k == -1 {
+		if tc.expectedK != -1 {
+			return fmt.Errorf("expected %d got -1", tc.expectedK)
+		}
+		return nil
+	}
+	if tc.expectedK == -1 {
+		return fmt.Errorf("expected -1 got %d", k)
+	}
+	if len(fields)-1 != k {
+		return fmt.Errorf("expected %d indices, got %d", k, len(fields)-1)
+	}
+	idx := make([]int, k)
+	used := make(map[int]bool)
+	for i := 0; i < k; i++ {
+		var v int
+		if _, err := fmt.Sscan(fields[i+1], &v); err != nil {
+			return fmt.Errorf("bad index")
+		}
+		if v < 1 || v > tc.n || used[v] {
+			return fmt.Errorf("invalid index %d", v)
+		}
+		used[v] = true
+		idx[i] = v
+	}
+	r1, r2 := performSwaps(append([]int{0}, tc.row1...), append([]int{0}, tc.row2...), idx)
+	if !isPermutation(r1) || !isPermutation(r2) {
+		return fmt.Errorf("result not permutations")
+	}
+	if k != tc.expectedK {
+		return fmt.Errorf("expected %d swaps got %d", tc.expectedK, k)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{buildCase(1, []int{1}, []int{1})}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement standalone Go verifiers for contest 1385 problems A–G
- each verifier generates over 100 test cases and checks the user program

## Testing
- `go build 1000-1999/1300-1399/1380-1389/1385/verifierA.go`
- `go build 1000-1999/1300-1399/1380-1389/1385/verifierB.go`
- `go build 1000-1999/1300-1399/1380-1389/1385/verifierC.go`
- `go build 1000-1999/1300-1399/1380-1389/1385/verifierD.go`
- `go build 1000-1999/1300-1399/1380-1389/1385/verifierE.go`
- `go build 1000-1999/1300-1399/1380-1389/1385/verifierF.go`
- `go build 1000-1999/1300-1399/1380-1389/1385/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6885eff525648324939085dc59afa6a8