### PR TITLE
Add Go verifiers for CF 1389

### DIFF
--- a/1000-1999/1300-1399/1380-1389/1389/verifierA.go
+++ b/1000-1999/1300-1399/1380-1389/1389/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int) int {
+	return a / gcd(a, b) * b
+}
+
+func solveCase(l, r int) (int, int) {
+	for x := l; x <= r; x++ {
+		for y := x + 1; y <= r; y++ {
+			v := lcm(x, y)
+			if v >= l && v <= r {
+				return x, y
+			}
+		}
+	}
+	return -1, -1
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	l := rng.Intn(20) + 1
+	r := l + rng.Intn(20) + 1
+	input := fmt.Sprintf("1\n%d %d\n", l, r)
+	x, y := solveCase(l, r)
+	expected := fmt.Sprintf("%d %d", x, y)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, exp := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1389/verifierB.go
+++ b/1000-1999/1300-1399/1380-1389/1389/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	n, k, z int
+	a       []int
+}
+
+func solveCase(tc TestCase) int {
+	n := tc.n
+	k := tc.k
+	z := tc.z
+	a := tc.a
+	best := 0
+	var dfs func(pos, moves, leftUsed int, lastLeft bool, score int)
+	dfs = func(pos, moves, leftUsed int, lastLeft bool, score int) {
+		if moves == k {
+			if score > best {
+				best = score
+			}
+			return
+		}
+		if pos < n-1 {
+			dfs(pos+1, moves+1, leftUsed, false, score+a[pos+1])
+		}
+		if pos > 0 && !lastLeft && leftUsed < z {
+			dfs(pos-1, moves+1, leftUsed+1, true, score+a[pos-1])
+		}
+	}
+	dfs(0, 0, 0, false, a[0])
+	return best
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	k := rng.Intn(n-1) + 1
+	z := rng.Intn(3)
+	if z > k {
+		z = k
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(10) + 1
+	}
+	tc := TestCase{n, k, z, a}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, z))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d", solveCase(tc))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, exp := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1389/verifierC.go
+++ b/1000-1999/1300-1399/1380-1389/1389/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(s string) int {
+	n := len(s)
+	best := 0
+	freq := make([]int, 10)
+	for i := 0; i < n; i++ {
+		d := int(s[i] - '0')
+		freq[d]++
+	}
+	for i := 0; i < 10; i++ {
+		if freq[i] > best {
+			best = freq[i]
+		}
+	}
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 10; j++ {
+			if i == j {
+				continue
+			}
+			expect := i
+			length := 0
+			for k := 0; k < n; k++ {
+				d := int(s[k] - '0')
+				if d == expect {
+					length++
+					if expect == i {
+						expect = j
+					} else {
+						expect = i
+					}
+				}
+			}
+			if length%2 == 1 {
+				length--
+			}
+			if length > best {
+				best = length
+			}
+		}
+	}
+	return n - best
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	return string(b)
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := rng.Intn(12) + 1
+	s := randString(rng, n)
+	input := fmt.Sprintf("1\n%s\n", s)
+	exp := fmt.Sprintf("%d", solveCase(s))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, exp := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1389/verifierD.go
+++ b/1000-1999/1300-1399/1380-1389/1389/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveCase(n int, k int64, l1, r1, l2, r2 int64) int64 {
+	if l1 > l2 {
+		l1, l2 = l2, l1
+		r1, r2 = r2, r1
+	}
+	intersection := max64(0, min64(r1, r2)-max64(l1, l2))
+	unionLen := max64(r1, r2) - min64(l1, l2)
+	gap := int64(0)
+	if r1 < l2 {
+		gap = l2 - r1
+	} else if r2 < l1 {
+		gap = l1 - r2
+	}
+	base := int64(n) * intersection
+	if k <= base {
+		return 0
+	}
+	need := k - base
+	extraWithin := unionLen - intersection
+	if gap > 0 {
+		extraWithin = unionLen
+	}
+	ans := int64(1<<62 - 1)
+	for i := 1; i <= n; i++ {
+		cost := int64(0)
+		if gap > 0 {
+			cost += gap * int64(i)
+		}
+		gainLimit := extraWithin * int64(i)
+		take := min64(need, gainLimit)
+		cost += take
+		remain := need - take
+		cost += 2 * remain
+		if cost < ans {
+			ans = cost
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	k := int64(rng.Intn(20) + 1)
+	l1 := int64(rng.Intn(10))
+	r1 := l1 + int64(rng.Intn(10))
+	l2 := int64(rng.Intn(10))
+	r2 := l2 + int64(rng.Intn(10))
+	input := fmt.Sprintf("1\n%d %d\n%d %d\n%d %d\n", n, k, l1, r1, l2, r2)
+	exp := fmt.Sprintf("%d", solveCase(n, k, l1, r1, l2, r2))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, exp := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1389/verifierE.go
+++ b/1000-1999/1300-1399/1380-1389/1389/verifierE.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveCase(m, d, w int64) int64 {
+	if d == 1 {
+		return 0
+	}
+	if m > d {
+		m = d
+	}
+	g := gcd(w, d-1)
+	q := w / g
+	a := m / q
+	b := m % q
+	return b*(a+1)*a/2 + (q-b)*a*(a-1)/2
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	m := int64(rng.Intn(10) + 1)
+	d := int64(rng.Intn(10) + 1)
+	w := int64(rng.Intn(10) + 1)
+	input := fmt.Sprintf("1\n%d %d %d\n", m, d, w)
+	exp := fmt.Sprintf("%d", solveCase(m, d, w))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, exp := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1389/verifierF.go
+++ b/1000-1999/1300-1399/1380-1389/1389/verifierF.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Segment struct {
+	l, r int
+	t    int
+}
+
+func intersect(a, b Segment) bool {
+	if a.t == b.t {
+		return false
+	}
+	return !(a.r < b.l || b.r < a.l)
+}
+
+func solveCase(segs []Segment) int {
+	n := len(segs)
+	best := 0
+	for mask := 1; mask < (1 << n); mask++ {
+		ok := true
+		for i := 0; i < n && ok; i++ {
+			if mask&(1<<i) == 0 {
+				continue
+			}
+			for j := i + 1; j < n; j++ {
+				if mask&(1<<j) == 0 {
+					continue
+				}
+				if intersect(segs[i], segs[j]) {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok {
+			cnt := bits.OnesCount(uint(mask))
+			if cnt > best {
+				best = cnt
+			}
+		}
+	}
+	return best
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	segs := make([]Segment, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(10)
+		r := l + rng.Intn(10)
+		t := rng.Intn(2) + 1
+		segs[i] = Segment{l, r, t}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", segs[i].l, segs[i].r, segs[i].t))
+	}
+	exp := fmt.Sprintf("%d", solveCase(segs))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, exp := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1380-1389/1389/verifierG.go
+++ b/1000-1999/1300-1399/1380-1389/1389/verifierG.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	u, v int
+	w    int64
+}
+
+func bfs(adj [][]int, start int) []bool {
+	n := len(adj)
+	vis := make([]bool, n)
+	q := []int{start}
+	vis[start] = true
+	for len(q) > 0 {
+		v := q[0]
+		q = q[1:]
+		for _, to := range adj[v] {
+			if !vis[to] {
+				vis[to] = true
+				q = append(q, to)
+			}
+		}
+	}
+	return vis
+}
+
+func solveCase(n, m, k int, specials []int, c []int64, w []int64, edges []Edge) []int64 {
+	best := make([]int64, n)
+	for i := range best {
+		best[i] = int64(-1 << 60)
+	}
+	pow := 1
+	for i := 0; i < m; i++ {
+		pow *= 3
+	}
+	orient := make([]int, m)
+	for mask := 0; mask < pow; mask++ {
+		tmp := mask
+		cost := int64(0)
+		for i := 0; i < m; i++ {
+			orient[i] = tmp % 3
+			tmp /= 3
+			if orient[i] == 2 {
+				cost += w[i]
+			}
+		}
+		adj := make([][]int, n)
+		for i, e := range edges {
+			switch orient[i] {
+			case 0:
+				adj[e.u] = append(adj[e.u], e.v)
+			case 1:
+				adj[e.v] = append(adj[e.v], e.u)
+			case 2:
+				adj[e.u] = append(adj[e.u], e.v)
+				adj[e.v] = append(adj[e.v], e.u)
+			}
+		}
+		reachAll := make([]bool, n)
+		for i := range reachAll {
+			reachAll[i] = true
+		}
+		for _, s := range specials {
+			vis := bfs(adj, s)
+			for i := 0; i < n; i++ {
+				if !vis[i] {
+					reachAll[i] = false
+				}
+			}
+		}
+		profit := -cost
+		for i := 0; i < n; i++ {
+			if reachAll[i] {
+				profit += c[i]
+			}
+		}
+		for i := 0; i < n; i++ {
+			if reachAll[i] && profit > best[i] {
+				best[i] = profit
+			}
+		}
+	}
+	return best
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genGraph(rng *rand.Rand, n, m int) []Edge {
+	edges := make([]Edge, 0, m)
+	// ensure tree edges for connectivity
+	for i := 1; i < n; i++ {
+		u := i - 1
+		v := i
+		w := int64(rng.Intn(5))
+		edges = append(edges, Edge{u, v, w})
+	}
+	for len(edges) < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u == v {
+			continue
+		}
+		dup := false
+		for _, e := range edges {
+			if (e.u == u && e.v == v) || (e.u == v && e.v == u) {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		w := int64(rng.Intn(5))
+		edges = append(edges, Edge{u, v, w})
+	}
+	return edges
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(min(maxEdges, 4-n+1)) + n - 1
+	k := rng.Intn(n) + 1
+	specials := make([]int, k)
+	used := make([]bool, n)
+	for i := 0; i < k; i++ {
+		for {
+			v := rng.Intn(n)
+			if !used[v] {
+				specials[i] = v
+				used[v] = true
+				break
+			}
+		}
+	}
+	c := make([]int64, n)
+	for i := 0; i < n; i++ {
+		c[i] = int64(rng.Intn(6))
+	}
+	edges := genGraph(rng, n, m)
+	w := make([]int64, m)
+	for i := 0; i < m; i++ {
+		w[i] = int64(rng.Intn(6))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d %d %d\n", n, m, k))
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", specials[i]+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", w[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", edges[i].u+1, edges[i].v+1))
+	}
+	best := solveCase(n, m, k, specials, c, w, edges)
+	var exp strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprintf("%d", best[i]))
+	}
+	return sb.String(), exp.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, exp := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifierA..G.go for contest 1389
- each verifier generates 100 random tests and compares a candidate binary against an internal solver

## Testing
- `go build 1000-1999/1300-1399/1380-1389/1389/verifierA.go`
- `go build 1000-1999/1300-1399/1380-1389/1389/verifierB.go`
- `go build 1000-1999/1300-1399/1380-1389/1389/verifierC.go`
- `go build 1000-1999/1300-1399/1380-1389/1389/verifierD.go`
- `go build 1000-1999/1300-1399/1380-1389/1389/verifierE.go`
- `go build 1000-1999/1300-1399/1380-1389/1389/verifierF.go`
- `go build 1000-1999/1300-1399/1380-1389/1389/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6885f225d1548324a049dec30ed34914