### PR TITLE
Add Go verifiers for Codeforces contest 1391

### DIFF
--- a/1000-1999/1300-1399/1390-1399/1391/verifierA.go
+++ b/1000-1999/1300-1399/1390-1399/1391/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1391A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), errBuf.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+	}
+	return testCase{sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1391/verifierB.go
+++ b/1000-1999/1300-1399/1390-1399/1391/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1391B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), errBuf.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for caseIdx := 0; caseIdx < t; caseIdx++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				if rng.Intn(2) == 0 {
+					sb.WriteByte('R')
+				} else {
+					sb.WriteByte('D')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+	}
+	return testCase{sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1391/verifierC.go
+++ b/1000-1999/1300-1399/1390-1399/1391/verifierC.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1391C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), errBuf.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	return testCase{fmt.Sprintf("%d\n", n)}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1391/verifierD.go
+++ b/1000-1999/1300-1399/1390-1399/1391/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1391D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), errBuf.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	if n >= 4 && m >= 4 {
+		if rng.Intn(2) == 0 {
+			n = rng.Intn(3) + 1
+		} else {
+			m = rng.Intn(3) + 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return testCase{sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1391/verifierE.go
+++ b/1000-1999/1300-1399/1390-1399/1391/verifierE.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1391E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), errBuf.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-(n-1)+1) + (n - 1)
+	edges := make(map[[2]int]bool)
+	// build a tree to ensure connectivity
+	for i := 2; i <= n; i++ {
+		u := i - 1
+		v := i
+		if u > v {
+			u, v = v, u
+		}
+		edges[[2]int{u, v}] = true
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		pair := [2]int{u, v}
+		if edges[pair] {
+			continue
+		}
+		edges[pair] = true
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return testCase{sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected:\n%s\n got:\n%s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go through verifierE.go under contest 1391
- each verifier builds the reference solution and runs 100 random test cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_6885f33daf508324980354d549811084