### PR TITLE
Add solution verifiers for contest 1392

### DIFF
--- a/1000-1999/1300-1399/1390-1399/1392/verifierA.go
+++ b/1000-1999/1300-1399/1390-1399/1392/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(n int, arr []int) int {
+	same := true
+	for i := 1; i < n; i++ {
+		if arr[i] != arr[0] {
+			same = false
+			break
+		}
+	}
+	if same {
+		return n
+	}
+	return 1
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rand.Intn(5)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+
+	ans := solveCase(n, arr)
+	exp := fmt.Sprintf("%d\n", ans)
+	return sb.String(), exp
+}
+
+func referenceIO(t int) (string, string) {
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", t)
+	for i := 0; i < t; i++ {
+		tcIn, tcOut := generateTest()
+		in.WriteString(tcIn)
+		out.WriteString(tcOut)
+	}
+	return in.String(), out.String()
+}
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	rand.Seed(1)
+	in, expected := referenceIO(100)
+	out, err := runBinary(os.Args[1], in)
+	if err != nil {
+		fmt.Println("Runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(expected) {
+		fmt.Println("Wrong Answer")
+		fmt.Println("Expected:\n" + expected)
+		fmt.Println("Got:\n" + out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1392/verifierB.go
+++ b/1000-1999/1300-1399/1390-1399/1392/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(n int, k int64, arr []int64) []int64 {
+	res := make([]int64, n)
+	copy(res, arr)
+	if k%2 == 1 {
+		var mx int64 = res[0]
+		for _, v := range res {
+			if v > mx {
+				mx = v
+			}
+		}
+		for i, v := range res {
+			res[i] = mx - v
+		}
+	} else {
+		var mn int64 = res[0]
+		for _, v := range res {
+			if v < mn {
+				mn = v
+			}
+		}
+		for i, v := range res {
+			res[i] = v - mn
+		}
+	}
+	return res
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(8) + 1
+	k := rand.Int63n(20)
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rand.Intn(21) - 10)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+
+	res := solveCase(n, k, arr)
+	var out strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprintf(&out, "%d", v)
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func referenceIO(t int) (string, string) {
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", t)
+	for i := 0; i < t; i++ {
+		ti, to := generateTest()
+		in.WriteString(ti)
+		out.WriteString(to)
+	}
+	return in.String(), out.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	rand.Seed(2)
+	in, exp := referenceIO(100)
+	out, err := runBinary(os.Args[1], in)
+	if err != nil {
+		fmt.Println("Runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Println("Wrong Answer")
+		fmt.Println("Expected:\n" + exp)
+		fmt.Println("Got:\n" + out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1392/verifierC.go
+++ b/1000-1999/1300-1399/1390-1399/1392/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(arr []int64) int64 {
+	var ans int64
+	for i := 1; i < len(arr); i++ {
+		if arr[i] < arr[i-1] {
+			ans += arr[i-1] - arr[i]
+		}
+	}
+	return ans
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(10) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rand.Intn(21))
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+
+	ans := solveCase(arr)
+	exp := fmt.Sprintf("%d\n", ans)
+	return sb.String(), exp
+}
+
+func referenceIO(t int) (string, string) {
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", t)
+	for i := 0; i < t; i++ {
+		ti, to := generateTest()
+		in.WriteString(ti)
+		out.WriteString(to)
+	}
+	return in.String(), out.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	rand.Seed(3)
+	in, exp := referenceIO(100)
+	out, err := runBinary(os.Args[1], in)
+	if err != nil {
+		fmt.Println("Runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Println("Wrong Answer")
+		fmt.Println("Expected:\n" + exp)
+		fmt.Println("Got:\n" + out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1392/verifierD.go
+++ b/1000-1999/1300-1399/1390-1399/1392/verifierD.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(s string) int {
+	n := len(s)
+	runs := make([]int, 0, n)
+	cur := 1
+	for i := 1; i < n; i++ {
+		if s[i] == s[i-1] {
+			cur++
+		} else {
+			runs = append(runs, cur)
+			cur = 1
+		}
+	}
+	runs = append(runs, cur)
+	if len(runs) > 1 && s[0] == s[n-1] {
+		runs[0] += runs[len(runs)-1]
+		runs = runs[:len(runs)-1]
+	}
+	ans := 0
+	for _, r := range runs {
+		ans += r / 2
+	}
+	return ans
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(10) + 1
+	b := make([]byte, n)
+	for i := range b {
+		if rand.Intn(2) == 0 {
+			b[i] = 'L'
+		} else {
+			b[i] = 'R'
+		}
+	}
+	s := string(b)
+	inp := fmt.Sprintf("%d\n%s\n", n, s)
+	exp := fmt.Sprintf("%d\n", solveCase(s))
+	return inp, exp
+}
+
+func referenceIO(t int) (string, string) {
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", t)
+	for i := 0; i < t; i++ {
+		ti, to := generateTest()
+		in.WriteString(ti)
+		out.WriteString(to)
+	}
+	return in.String(), out.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	rand.Seed(4)
+	in, exp := referenceIO(100)
+	out, err := runBinary(os.Args[1], in)
+	if err != nil {
+		fmt.Println("Runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Println("Wrong Answer")
+		fmt.Println("Expected:\n" + exp)
+		fmt.Println("Got:\n" + out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1392/verifierE.go
+++ b/1000-1999/1300-1399/1390-1399/1392/verifierE.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildGrid(n int) [][]int64 {
+	g := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		g[i] = make([]int64, n)
+		for j := 0; j < n; j++ {
+			if (i+j)%2 == 1 {
+				g[i][j] = 1 << uint(i)
+			}
+		}
+	}
+	return g
+}
+
+func pathFromK(n int, g [][]int64, k int64) []string {
+	x, y := 0, 0
+	steps := make([]string, 0, 2*n-1)
+	steps = append(steps, fmt.Sprintf("%d %d", 1, 1))
+	for step := 0; step < 2*n-2; step++ {
+		if (x+y)%2 == 0 {
+			down := int64(0)
+			if x+1 < n {
+				down = g[x+1][y]
+			}
+			if down > 0 && (k&down) != 0 {
+				x++
+			} else {
+				y++
+			}
+		} else {
+			if x+1 < n {
+				x++
+			} else {
+				y++
+			}
+		}
+		steps = append(steps, fmt.Sprintf("%d %d", x+1, y+1))
+	}
+	return steps
+}
+
+func generateIO() (string, string) {
+	n := rand.Intn(4) + 2
+	q := 100
+	grid := buildGrid(n)
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d\n%d\n", n, q)
+	var out strings.Builder
+	fmt.Fprintf(&out, "%d\n", n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				out.WriteByte(' ')
+			}
+			fmt.Fprintf(&out, "%d", grid[i][j])
+		}
+		out.WriteByte('\n')
+	}
+	for i := 0; i < q; i++ {
+		k := rand.Int63n(1 << uint(n-1))
+		fmt.Fprintf(&in, "%d\n", k)
+		steps := pathFromK(n, grid, k)
+		for _, s := range steps {
+			fmt.Fprintln(&out, s)
+		}
+	}
+	return in.String(), out.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	rand.Seed(5)
+	in, exp := generateIO()
+	out, err := runBinary(os.Args[1], in)
+	if err != nil {
+		fmt.Println("Runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Println("Wrong Answer")
+		fmt.Println("Expected:\n" + exp)
+		fmt.Println("Got:\n" + out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1392/verifierF.go
+++ b/1000-1999/1300-1399/1390-1399/1392/verifierF.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(h []int64) []int64 {
+	n := len(h)
+	res := make([]int64, n)
+	copy(res, h)
+	for {
+		changed := false
+		for i := 0; i < n-1; i++ {
+			if res[i+1]-res[i] >= 2 {
+				m := (res[i+1] - res[i]) / 2
+				res[i] += m
+				res[i+1] -= m
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return res
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(6) + 1
+	h := make([]int64, n)
+	base := int64(rand.Intn(5))
+	for i := 0; i < n; i++ {
+		base += int64(rand.Intn(3) + 1)
+		h[i] = base
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range h {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+
+	res := solveCase(h)
+	var out strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprintf(&out, "%d", v)
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func referenceIO(t int) (string, string) {
+	var in strings.Builder
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		ti, to := generateTest()
+		in.WriteString(ti)
+		out.WriteString(to)
+	}
+	return in.String(), out.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	rand.Seed(6)
+	in, exp := referenceIO(100)
+	out, err := runBinary(os.Args[1], in)
+	if err != nil {
+		fmt.Println("Runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Println("Wrong Answer")
+		fmt.Println("Expected:\n" + exp)
+		fmt.Println("Got:\n" + out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1392/verifierG.go
+++ b/1000-1999/1300-1399/1390-1399/1392/verifierG.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func applySegment(k int, arr []byte, l, r int, a, b []int) []byte {
+	res := make([]byte, k)
+	copy(res, arr)
+	for i := l; i <= r; i++ {
+		x := a[i]
+		y := b[i]
+		res[x], res[y] = res[y], res[x]
+	}
+	return res
+}
+
+func matches(a, b []byte) int {
+	cnt := 0
+	for i := range a {
+		if a[i] == b[i] {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func solveCase(n, m, k int, s0, s1 string, aList, bList []int) (int, int, int) {
+	cur := []byte(s0)
+	target := []byte(s1)
+	best := -1
+	bestL, bestR := 1, m
+	for l := 0; l < n; l++ {
+		tray := make([]byte, k)
+		copy(tray, cur)
+		for r := l; r < n; r++ {
+			tray = applySegment(k, tray, r, r, aList, bList)
+			if r-l+1 >= m {
+				val := matches(tray, target)
+				if val > best {
+					best = val
+					bestL = l + 1
+					bestR = r + 1
+				}
+			}
+		}
+	}
+	return best, bestL, bestR
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(n) + 1
+	k := rand.Intn(4) + 2
+	s0 := make([]byte, k)
+	s1 := make([]byte, k)
+	for i := 0; i < k; i++ {
+		if rand.Intn(2) == 0 {
+			s0[i] = '0'
+		} else {
+			s0[i] = '1'
+		}
+		if rand.Intn(2) == 0 {
+			s1[i] = '0'
+		} else {
+			s1[i] = '1'
+		}
+	}
+	aList := make([]int, n)
+	bList := make([]int, n)
+	for i := 0; i < n; i++ {
+		aList[i] = rand.Intn(k)
+		bList[i] = rand.Intn(k)
+		for aList[i] == bList[i] {
+			bList[i] = rand.Intn(k)
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n%s\n%s\n", n, m, k, string(s0), string(s1))
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", aList[i]+1, bList[i]+1)
+	}
+
+	best, l, r := solveCase(n, m, k, string(s0), string(s1), aList, bList)
+	exp := fmt.Sprintf("%d\n%d %d\n", best, l, r)
+	return sb.String(), exp
+}
+
+func referenceIO(t int) (string, string) {
+	var in strings.Builder
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		ti, to := generateTest()
+		in.WriteString(ti)
+		out.WriteString(to)
+	}
+	return in.String(), out.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	rand.Seed(7)
+	in, exp := referenceIO(100)
+	out, err := runBinary(os.Args[1], in)
+	if err != nil {
+		fmt.Println("Runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Println("Wrong Answer")
+		fmt.Println("Expected:\n" + exp)
+		fmt.Println("Got:\n" + out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1392/verifierH.go
+++ b/1000-1999/1300-1399/1390-1399/1392/verifierH.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod = 998244353
+
+func modexp(a, e int) int {
+	res := 1
+	base := a % mod
+	for e > 0 {
+		if e&1 == 1 {
+			res = int(int64(res) * int64(base) % mod)
+		}
+		base = int(int64(base) * int64(base) % mod)
+		e >>= 1
+	}
+	return res
+}
+
+func modinv(a int) int {
+	return modexp((a%mod+mod)%mod, mod-2)
+}
+
+func solveCase(n, m int) int {
+	fact := make([]int, n+1)
+	invfact := make([]int, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = int(int64(fact[i-1]) * int64(i) % mod)
+	}
+	invfact[n] = modinv(fact[n])
+	for i := n; i > 0; i-- {
+		invfact[i-1] = int(int64(invfact[i]) * int64(i) % mod)
+	}
+	powA := make([]int, n+1)
+	powB := make([]int, n+1)
+	A := (m + 1) % mod
+	B := m % mod
+	powA[0], powB[0] = 1, 1
+	for i := 1; i <= n; i++ {
+		powA[i] = int(int64(powA[i-1]) * int64(A) % mod)
+		powB[i] = int(int64(powB[i-1]) * int64(B) % mod)
+	}
+	S := 0
+	for j := 1; j <= n; j++ {
+		bin := int(int64(fact[n]) * int64(invfact[j]) % mod * int64(invfact[n-j]) % mod)
+		aj := powA[j]
+		bj := powB[j]
+		denom := aj - bj
+		if denom < 0 {
+			denom += mod
+		}
+		invd := modinv(denom)
+		term := int(int64(bin) * int64(aj) % mod * int64(invd) % mod)
+		if j%2 == 1 {
+			S += term
+			if S >= mod {
+				S -= mod
+			}
+		} else {
+			S -= term
+			if S < 0 {
+				S += mod
+			}
+		}
+	}
+	coeff := int(int64(n+m+1) % mod * int64(modinv(m+1)) % mod)
+	ans := int(int64(S) * int64(coeff) % mod)
+	return ans
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(5) + 1
+	inp := fmt.Sprintf("%d %d\n", n, m)
+	out := fmt.Sprintf("%d\n", solveCase(n, m))
+	return inp, out
+}
+
+func referenceIO(t int) (string, string) {
+	var in strings.Builder
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		ti, to := generateTest()
+		in.WriteString(ti)
+		out.WriteString(to)
+	}
+	return in.String(), out.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	rand.Seed(8)
+	in, exp := referenceIO(100)
+	out, err := runBinary(os.Args[1], in)
+	if err != nil {
+		fmt.Println("Runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Println("Wrong Answer")
+		fmt.Println("Expected:\n" + exp)
+		fmt.Println("Got:\n" + out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1392/verifierI.go
+++ b/1000-1999/1300-1399/1390-1399/1392/verifierI.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func score(n, m int, a, b []int, x int) int {
+	grid := make([][]int, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			grid[i][j] = a[i] + b[j]
+		}
+	}
+	visited := make([][]bool, n)
+	for i := range visited {
+		visited[i] = make([]bool, m)
+	}
+	goodBig, badBig, goodSmall, badSmall := 0, 0, 0, 0
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if visited[i][j] {
+				continue
+			}
+			t := grid[i][j] >= x
+			queue := [][2]int{{i, j}}
+			visited[i][j] = true
+			border := i == 0 || j == 0 || i == n-1 || j == m-1
+			for q := 0; q < len(queue); q++ {
+				cx, cy := queue[q][0], queue[q][1]
+				for _, d := range dirs {
+					nx, ny := cx+d[0], cy+d[1]
+					if nx < 0 || ny < 0 || nx >= n || ny >= m || visited[nx][ny] {
+						continue
+					}
+					if (grid[nx][ny] >= x) == t {
+						visited[nx][ny] = true
+						if nx == 0 || ny == 0 || nx == n-1 || ny == m-1 {
+							border = true
+						}
+						queue = append(queue, [2]int{nx, ny})
+					}
+				}
+			}
+			if t {
+				if border {
+					goodBig++
+				} else {
+					badBig += 2
+				}
+			} else {
+				if border {
+					goodSmall++
+				} else {
+					badSmall += 2
+				}
+			}
+		}
+	}
+	return goodBig + badBig - (goodSmall + badSmall)
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(3) + 2
+	m := rand.Intn(3) + 2
+	q := 3
+	a := make([]int, n)
+	bArr := make([]int, m)
+	for i := range a {
+		a[i] = rand.Intn(10)
+	}
+	for i := range bArr {
+		bArr[i] = rand.Intn(10)
+	}
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d %d\n", n, m, q)
+	for i, v := range a {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		fmt.Fprintf(&in, "%d", v)
+	}
+	in.WriteByte('\n')
+	for i, v := range bArr {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		fmt.Fprintf(&in, "%d", v)
+	}
+	in.WriteByte('\n')
+	var out strings.Builder
+	for i := 0; i < q; i++ {
+		x := rand.Intn(20)
+		fmt.Fprintf(&in, "%d\n", x)
+		fmt.Fprintf(&out, "%d\n", score(n, m, a, bArr, x))
+	}
+	return in.String(), out.String()
+}
+
+func referenceIO(t int) (string, string) {
+	var in strings.Builder
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		ti, to := generateTest()
+		in.WriteString(ti)
+		out.WriteString(to)
+	}
+	return in.String(), out.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		return
+	}
+	rand.Seed(9)
+	in, exp := referenceIO(100)
+	out, err := runBinary(os.Args[1], in)
+	if err != nil {
+		fmt.Println("Runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Println("Wrong Answer")
+		fmt.Println("Expected:\n" + exp)
+		fmt.Println("Got:\n" + out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers in Go for problems A–I of contest 1392
- each verifier runs 100 random tests and checks a given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`

------
https://chatgpt.com/codex/tasks/task_e_6885f3ca038c83249da98ba677d661ef