### PR TITLE
Add solution verifiers for contest 1394

### DIFF
--- a/1000-1999/1300-1399/1390-1399/1394/verifierA.go
+++ b/1000-1999/1300-1399/1390-1399/1394/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(20) + 1
+		d := r.Intn(n)
+		m := r.Int63n(50)
+		arr := make([]int64, n)
+		for j := 0; j < n; j++ {
+			arr[j] = r.Int63n(50)
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d %d\n", n, d, m)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", arr[j])
+		}
+		b.WriteByte('\n')
+		tests[i] = b.String()
+	}
+	return tests
+}
+
+func runCmd(cmdPath string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	c := exec.CommandContext(ctx, cmdPath)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = io.Discard
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	solPath := "./solA.bin"
+	if err := exec.Command("go", "build", "-o", solPath, "1394A.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(solPath)
+	bin := os.Args[1]
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runCmd(solPath, t)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(bin, t)
+		if err != nil {
+			fmt.Printf("binary failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\nexpected: %s\n got: %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1394/verifierB.go
+++ b/1000-1999/1300-1399/1390-1399/1394/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(5) + 2
+		k := r.Intn(3) + 1
+		type Edge struct{ u, v, w int }
+		edges := make([]Edge, 0)
+		weight := 1
+		for u := 1; u <= n; u++ {
+			out := r.Intn(k) + 1
+			if out > n-1 {
+				out = n - 1
+			}
+			perm := r.Perm(n)
+			count := 0
+			idx := 0
+			for count < out && idx < n {
+				v := perm[idx] + 1
+				idx++
+				if v == u {
+					continue
+				}
+				edges = append(edges, Edge{u, v, weight})
+				weight++
+				count++
+			}
+		}
+		m := len(edges)
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d %d\n", n, m, k)
+		for _, e := range edges {
+			fmt.Fprintf(&b, "%d %d %d\n", e.u, e.v, e.w)
+		}
+		tests[i] = b.String()
+	}
+	return tests
+}
+
+func runCmd(cmdPath string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	c := exec.CommandContext(ctx, cmdPath)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = io.Discard
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	solPath := "./solB.bin"
+	if err := exec.Command("go", "build", "-o", solPath, "1394B.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(solPath)
+	bin := os.Args[1]
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runCmd(solPath, t)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(bin, t)
+		if err != nil {
+			fmt.Printf("binary failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\nexpected: %s\n got: %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1394/verifierC.go
+++ b/1000-1999/1300-1399/1390-1399/1394/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(20) + 1
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d\n", n)
+		for j := 0; j < n; j++ {
+			length := r.Intn(10) + 1
+			for k := 0; k < length; k++ {
+				if r.Intn(2) == 0 {
+					b.WriteByte('B')
+				} else {
+					b.WriteByte('N')
+				}
+			}
+			if j+1 < n {
+				b.WriteByte(' ')
+			}
+		}
+		b.WriteByte('\n')
+		tests[i] = b.String()
+	}
+	return tests
+}
+
+func runCmd(cmdPath string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	c := exec.CommandContext(ctx, cmdPath)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = io.Discard
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	solPath := "./solC.bin"
+	if err := exec.Command("go", "build", "-o", solPath, "1394C.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(solPath)
+	bin := os.Args[1]
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runCmd(solPath, t)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(bin, t)
+		if err != nil {
+			fmt.Printf("binary failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\nexpected: %s\n got: %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1394/verifierD.go
+++ b/1000-1999/1300-1399/1390-1399/1394/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(5) + 2
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d\n", n)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&b, "%d ", r.Int63n(100)+1)
+		}
+		b.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&b, "%d ", r.Intn(20)+1)
+		}
+		b.WriteByte('\n')
+		for j := 2; j <= n; j++ {
+			u := j
+			v := r.Intn(j-1) + 1
+			fmt.Fprintf(&b, "%d %d\n", u, v)
+		}
+		tests[i] = b.String()
+	}
+	return tests
+}
+
+func runCmd(cmdPath string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	c := exec.CommandContext(ctx, cmdPath)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = io.Discard
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	solPath := "./solD.bin"
+	if err := exec.Command("go", "build", "-o", solPath, "1394D.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(solPath)
+	bin := os.Args[1]
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runCmd(solPath, t)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(bin, t)
+		if err != nil {
+			fmt.Printf("binary failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\nexpected: %s\n got: %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1394/verifierE.go
+++ b/1000-1999/1300-1399/1390-1399/1394/verifierE.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(20) + 1
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", r.Intn(n)+1)
+		}
+		b.WriteByte('\n')
+		tests[i] = b.String()
+	}
+	return tests
+}
+
+func runCmd(cmdPath string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	c := exec.CommandContext(ctx, cmdPath)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = io.Discard
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	solPath := "./solE.bin"
+	if err := exec.Command("go", "build", "-o", solPath, "1394E.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(solPath)
+	bin := os.Args[1]
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runCmd(solPath, t)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(bin, t)
+		if err != nil {
+			fmt.Printf("binary failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\nexpected: %s\n got: %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of Codeforces contest 1394
- each verifier generates 100 random tests and compares a candidate solution with the repository's reference implementation

## Testing
- `go build 1000-1999/1300-1399/1390-1399/1394/verifierA.go`
- `go build 1000-1999/1300-1399/1390-1399/1394/verifierB.go`
- `go build 1000-1999/1300-1399/1390-1399/1394/verifierC.go`
- `go build 1000-1999/1300-1399/1390-1399/1394/verifierD.go`
- `go build 1000-1999/1300-1399/1390-1399/1394/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6885f4e1f6bc83248911e9057d7c670f