### PR TITLE
Add verifiers for contest 1393

### DIFF
--- a/1000-1999/1300-1399/1390-1399/1393/verifierA.go
+++ b/1000-1999/1300-1399/1390-1399/1393/verifierA.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateTests() []int64 {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]int64, 100)
+	for i := range tests {
+		tests[i] = r.Int63n(1e9) + 1
+	}
+	return tests
+}
+
+func expected(n int64) int64 {
+	return (n + 1) / 2
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := generateTests()
+	for i, n := range tests {
+		input := fmt.Sprintf("1\n%d\n", n)
+		exp := expected(n)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var ans int64
+		if _, err := fmt.Sscan(got, &ans); err != nil {
+			fmt.Printf("Test %d: cannot parse output %q\n", i+1, got)
+			os.Exit(1)
+		}
+		if ans != exp {
+			fmt.Printf("Test %d failed. Input: %sExpected %d got %d\n", i+1, input, exp, ans)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1393/verifierB.go
+++ b/1000-1999/1300-1399/1390-1399/1393/verifierB.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type operation struct {
+	op  byte
+	val int
+}
+
+type testB struct {
+	n    int
+	init []int
+	q    int
+	ops  []operation
+}
+
+func generateTests() []testB {
+	r := rand.New(rand.NewSource(43))
+	tests := make([]testB, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(10) + 1
+		init := make([]int, n)
+		cnt := map[int]int{}
+		for j := 0; j < n; j++ {
+			v := r.Intn(10) + 1
+			init[j] = v
+			cnt[v]++
+		}
+		q := r.Intn(20) + 1
+		ops := make([]operation, q)
+		for j := 0; j < q; j++ {
+			if len(cnt) == 0 || r.Intn(2) == 0 {
+				v := r.Intn(10) + 1
+				cnt[v]++
+				ops[j] = operation{'+', v}
+			} else {
+				// choose a value with count>0
+				keys := make([]int, 0, len(cnt))
+				for k := range cnt {
+					if cnt[k] > 0 {
+						keys = append(keys, k)
+					}
+				}
+				if len(keys) == 0 {
+					v := r.Intn(10) + 1
+					cnt[v]++
+					ops[j] = operation{'+', v}
+				} else {
+					v := keys[r.Intn(len(keys))]
+					cnt[v]--
+					if cnt[v] == 0 {
+						delete(cnt, v)
+					}
+					ops[j] = operation{'-', v}
+				}
+			}
+		}
+		tests[i] = testB{n: n, init: init, q: q, ops: ops}
+	}
+	return tests
+}
+
+func expected(t testB) []string {
+	cnt := make(map[int]int)
+	P, Q := 0, 0
+	for _, x := range t.init {
+		c := cnt[x]
+		P -= c / 2
+		Q -= c / 4
+		c++
+		cnt[x] = c
+		P += c / 2
+		Q += c / 4
+	}
+	res := make([]string, t.q)
+	for i, op := range t.ops {
+		c := cnt[op.val]
+		P -= c / 2
+		Q -= c / 4
+		if op.op == '+' {
+			c++
+		} else {
+			c--
+		}
+		cnt[op.val] = c
+		P += c / 2
+		Q += c / 4
+		if Q >= 2 || (Q >= 1 && P >= 4) {
+			res[i] = "YES"
+		} else {
+			res[i] = "NO"
+		}
+	}
+	return res
+}
+
+func (t testB) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.n))
+	for i, v := range t.init {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", t.q))
+	for _, op := range t.ops {
+		sb.WriteString(fmt.Sprintf("%c %d\n", op.op, op.val))
+	}
+	return sb.String()
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := generateTests()
+	for i, tc := range tests {
+		expLines := expected(tc)
+		gotRaw, err := run(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i+1, err, gotRaw)
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(strings.NewReader(gotRaw))
+		var idx int
+		for idx = 0; idx < len(expLines) && scanner.Scan(); idx++ {
+			got := strings.TrimSpace(scanner.Text())
+			if got != expLines[idx] {
+				fmt.Printf("test %d failed\ninput:\n%sexpected: %s got: %s\n", i+1, tc.Input(), expLines[idx], got)
+				os.Exit(1)
+			}
+		}
+		if idx != len(expLines) || scanner.Scan() {
+			fmt.Printf("test %d: wrong number of output lines\n", i+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1393/verifierC.go
+++ b/1000-1999/1300-1399/1390-1399/1393/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateTests() [][]int {
+	r := rand.New(rand.NewSource(44))
+	tests := make([][]int, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(50) + 2
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = r.Intn(n) + 1
+		}
+		// ensure at least one duplicate
+		arr[0] = arr[1]
+		tests[i] = arr
+	}
+	return tests
+}
+
+func expected(arr []int) int {
+	n := len(arr)
+	freq := make(map[int]int)
+	for _, v := range arr {
+		freq[v]++
+	}
+	mX := 0
+	for _, f := range freq {
+		if f > mX {
+			mX = f
+		}
+	}
+	c := 0
+	for _, f := range freq {
+		if f == mX {
+			c++
+		}
+	}
+	ans := (n - c) / (mX - 1)
+	ans--
+	if ans < 0 {
+		ans = 0
+	}
+	return ans
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := generateTests()
+	for i, arr := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(len(arr)))
+		sb.WriteByte('\n')
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		exp := expected(arr)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var ans int
+		if _, err := fmt.Sscan(got, &ans); err != nil {
+			fmt.Printf("Test %d: cannot parse output %q\n", i+1, got)
+			os.Exit(1)
+		}
+		if ans != exp {
+			fmt.Printf("Test %d failed. Input:\n%sExpected %d got %d\n", i+1, sb.String(), exp, ans)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1393/verifierD.go
+++ b/1000-1999/1300-1399/1390-1399/1393/verifierD.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateTests() [][][]byte {
+	r := rand.New(rand.NewSource(45))
+	tests := make([][][]byte, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(6) + 1
+		m := r.Intn(6) + 1
+		grid := make([][]byte, n)
+		for a := 0; a < n; a++ {
+			row := make([]byte, m)
+			for b := 0; b < m; b++ {
+				row[b] = byte('a' + r.Intn(3))
+			}
+			grid[a] = row
+		}
+		tests[i] = grid
+	}
+	return tests
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expected(grid [][]byte) int64 {
+	n := len(grid)
+	m := len(grid[0])
+	lft := make([][]int, n)
+	rgt := make([][]int, n)
+	for i := 0; i < n; i++ {
+		lft[i] = make([]int, m)
+		rgt[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			if j > 0 && grid[i][j] == grid[i][j-1] {
+				lft[i][j] = lft[i][j-1] + 1
+			} else {
+				lft[i][j] = 1
+			}
+		}
+		for j := m - 1; j >= 0; j-- {
+			if j+1 < m && grid[i][j] == grid[i][j+1] {
+				rgt[i][j] = rgt[i][j+1] + 1
+			} else {
+				rgt[i][j] = 1
+			}
+		}
+	}
+	d1 := make([][]int, n)
+	for i := 0; i < n; i++ {
+		d1[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			d1[i][j] = 1
+			if i > 0 && grid[i][j] == grid[i-1][j] {
+				ext := min(d1[i-1][j], min(lft[i][j], rgt[i][j])-1)
+				if ext >= 0 {
+					d1[i][j] = ext + 1
+				}
+			}
+		}
+	}
+	d2 := make([][]int, n)
+	for i := n - 1; i >= 0; i-- {
+		d2[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			d2[i][j] = 1
+			if i+1 < n && grid[i][j] == grid[i+1][j] {
+				ext := min(d2[i+1][j], min(lft[i][j], rgt[i][j])-1)
+				if ext >= 0 {
+					d2[i][j] = ext + 1
+				}
+			}
+		}
+	}
+	var ans int64
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			cnt := d1[i][j]
+			if d2[i][j] < cnt {
+				cnt = d2[i][j]
+			}
+			ans += int64(cnt)
+		}
+	}
+	return ans
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := generateTests()
+	for idx, grid := range tests {
+		var sb strings.Builder
+		n := len(grid)
+		m := len(grid[0])
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			sb.WriteString(string(grid[i]))
+			sb.WriteByte('\n')
+		}
+		exp := expected(grid)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		var ans int64
+		if _, err := fmt.Sscan(got, &ans); err != nil {
+			fmt.Printf("Test %d: cannot parse output %q\n", idx+1, got)
+			os.Exit(1)
+		}
+		if ans != exp {
+			fmt.Printf("Test %d failed. Input:\n%sExpected %d got %d\n", idx+1, sb.String(), exp, ans)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1393/verifierE1.go
+++ b/1000-1999/1300-1399/1390-1399/1393/verifierE1.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testE struct {
+	words []string
+}
+
+func generateTests() []testE {
+	r := rand.New(rand.NewSource(46))
+	tests := make([]testE, 100)
+	letters := []rune("abc")
+	for i := 0; i < 100; i++ {
+		n := r.Intn(5) + 1
+		words := make([]string, n)
+		for j := 0; j < n; j++ {
+			l := r.Intn(5) + 1
+			var sb strings.Builder
+			for k := 0; k < l; k++ {
+				sb.WriteRune(letters[r.Intn(len(letters))])
+			}
+			words[j] = sb.String()
+		}
+		tests[i] = testE{words: words}
+	}
+	return tests
+}
+
+func (t testE) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.words)))
+	for _, w := range t.words {
+		sb.WriteString(w)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE1")
+	cmd := exec.Command("go", "build", "-o", oracle, "1393E1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rand.Seed(time.Now().UnixNano())
+	tests := generateTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("Test %d failed\ninput:\n%sexpected: %s got: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1393/verifierE2.go
+++ b/1000-1999/1300-1399/1390-1399/1393/verifierE2.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testE struct {
+	words []string
+}
+
+func generateTests() []testE {
+	r := rand.New(rand.NewSource(47))
+	tests := make([]testE, 100)
+	letters := []rune("abcd")
+	for i := 0; i < 100; i++ {
+		n := r.Intn(5) + 1
+		words := make([]string, n)
+		for j := 0; j < n; j++ {
+			l := r.Intn(8) + 1
+			var sb strings.Builder
+			for k := 0; k < l; k++ {
+				sb.WriteRune(letters[r.Intn(len(letters))])
+			}
+			words[j] = sb.String()
+		}
+		tests[i] = testE{words: words}
+	}
+	return tests
+}
+
+func (t testE) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.words)))
+	for _, w := range t.words {
+		sb.WriteString(w)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE2")
+	cmd := exec.Command("go", "build", "-o", oracle, "1393E2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rand.Seed(time.Now().UnixNano())
+	tests := generateTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("Test %d failed\ninput:\n%sexpected: %s got: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers in Go for all problems of contest 1393
- each verifier generates 100 random tests and checks a given binary
- complex problems E1 and E2 build reference solutions as oracles

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE1.go`
- `go build verifierE2.go`


------
https://chatgpt.com/codex/tasks/task_e_6885f455e3b0832496f7da79c1fe1f3b