### PR TITLE
Add verifiers for contest 1395

### DIFF
--- a/1000-1999/1300-1399/1390-1399/1395/verifierA.go
+++ b/1000-1999/1300-1399/1390-1399/1395/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1395A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	r := rng.Intn(6)
+	g := rng.Intn(6)
+	b := rng.Intn(6)
+	w := rng.Intn(6)
+	return fmt.Sprintf("1\n%d %d %d %d\n", r, g, b, w)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1395/verifierB.go
+++ b/1000-1999/1300-1399/1390-1399/1395/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func genCase(rng *rand.Rand) (int, int, int, int, string) {
+	n := rng.Intn(7) + 3
+	m := rng.Intn(7) + 3
+	x := rng.Intn(n-2) + 2
+	y := rng.Intn(m-2) + 2
+	input := fmt.Sprintf("%d %d %d %d\n", n, m, x, y)
+	return n, m, x, y, input
+}
+
+func checkOutput(n, m, x, y int, output string) error {
+	fields := strings.Fields(output)
+	if len(fields) != 2*n*m {
+		return fmt.Errorf("expected %d pairs, got %d", n*m, len(fields)/2)
+	}
+	visited := make([][]bool, n)
+	for i := range visited {
+		visited[i] = make([]bool, m)
+	}
+	px, py := x, y
+	for i := 0; i < n*m; i++ {
+		xi, err1 := strconv.Atoi(fields[2*i])
+		yi, err2 := strconv.Atoi(fields[2*i+1])
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("invalid integer in output")
+		}
+		if xi < 1 || xi > n || yi < 1 || yi > m {
+			return fmt.Errorf("cell out of range: %d %d", xi, yi)
+		}
+		if visited[xi-1][yi-1] {
+			return fmt.Errorf("cell repeated: %d %d", xi, yi)
+		}
+		if i == 0 {
+			if xi != x || yi != y {
+				return fmt.Errorf("first cell should be %d %d", x, y)
+			}
+		} else {
+			if xi != px && yi != py {
+				return fmt.Errorf("illegal move from %d %d to %d %d", px, py, xi, yi)
+			}
+		}
+		visited[xi-1][yi-1] = true
+		px, py = xi, yi
+	}
+	// ensure all cells visited
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if !visited[i][j] {
+				return fmt.Errorf("cell %d %d not visited", i+1, j+1)
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, x, y, input := genCase(rng)
+		out, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if err := checkOutput(n, m, x, y, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1395/verifierC.go
+++ b/1000-1999/1300-1399/1390-1399/1395/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1395C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(512)))
+	}
+	sb.WriteByte('\n')
+	for j := 0; j < m; j++ {
+		if j > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(512)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems 1395A, 1395B and 1395C
- each verifier builds the oracle solution and runs 100 random tests
- verifierB implements path validation for arbitrary solutions

## Testing
- `go build ./1000-1999/1300-1399/1390-1399/1395/verifierA.go`
- `go build ./1000-1999/1300-1399/1390-1399/1395/verifierB.go`
- `go build ./1000-1999/1300-1399/1390-1399/1395/verifierC.go`

------
https://chatgpt.com/codex/tasks/task_e_6885f56e16608324bda3166109a5b314