### PR TITLE
Add Go solution for Codeforces 1598D

### DIFF
--- a/1000-1999/1500-1599/1590-1599/1598/1598D.go
+++ b/1000-1999/1500-1599/1590-1599/1598/1598D.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		b := make([]int, n)
+		cntA := make(map[int]int)
+		cntB := make(map[int]int)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i], &b[i])
+			cntA[a[i]]++
+			cntB[b[i]]++
+		}
+		total := int64(n) * int64(n-1) * int64(n-2) / 6
+		var bad int64
+		for i := 0; i < n; i++ {
+			bad += int64(cntA[a[i]]-1) * int64(cntB[b[i]]-1)
+		}
+		fmt.Fprintln(out, total-bad)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `1598D` problem

## Testing
- `go build 1000-1999/1500-1599/1590-1599/1598/1598D.go`
- `go run 1000-1999/1500-1599/1590-1599/1598/1598D.go` with custom cases

------
https://chatgpt.com/codex/tasks/task_e_6885f6cc5c348324a92de38033cb3a4c