### PR TITLE
Add Go solution verifiers for contest 1398

### DIFF
--- a/1000-1999/1300-1399/1390-1399/1398/verifierA.go
+++ b/1000-1999/1300-1399/1390-1399/1398/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveCase(input string) string {
+	sc := bufio.NewScanner(strings.NewReader(input))
+	sc.Split(bufio.ScanWords)
+	sc.Scan() // t
+	t, _ := strconv.Atoi(sc.Text())
+	outLines := make([]string, t)
+	for caseIdx := 0; caseIdx < t; caseIdx++ {
+		sc.Scan()
+		n, _ := strconv.Atoi(sc.Text())
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			sc.Scan()
+			v, _ := strconv.Atoi(sc.Text())
+			arr[i] = v
+		}
+		ans := "-1"
+		for i := 2; i < n; i++ {
+			if arr[0]+arr[1] <= arr[i] {
+				ans = fmt.Sprintf("%d %d %d", 1, 2, i+1)
+				break
+			}
+		}
+		outLines[caseIdx] = ans
+	}
+	return strings.Join(outLines, "\n")
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := 1
+	n := rng.Intn(8) + 3
+	a := make([]int, n)
+	a[0] = rng.Intn(5) + 1
+	a[1] = a[0] + rng.Intn(5)
+	for i := 2; i < n; i++ {
+		a[i] = a[i-1] + rng.Intn(5)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintln(t))
+	sb.WriteString(fmt.Sprintln(n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected = strings.TrimSpace(expected)
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solveCase(in)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1398/verifierB.go
+++ b/1000-1999/1300-1399/1390-1399/1398/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveCase(input string) string {
+	sc := bufio.NewScanner(strings.NewReader(input))
+	sc.Split(bufio.ScanWords)
+	sc.Scan() // t
+	t := 1    // we always generate t=1
+	_ = sc.Text()
+	outputs := make([]string, t)
+	for caseIdx := 0; caseIdx < t; caseIdx++ {
+		sc.Scan()
+		s := sc.Text()
+		// collect lengths of runs of '1'
+		var runs []int
+		cnt := 0
+		for i := 0; i < len(s); i++ {
+			if s[i] == '1' {
+				cnt++
+			} else {
+				if cnt > 0 {
+					runs = append(runs, cnt)
+					cnt = 0
+				}
+			}
+		}
+		if cnt > 0 {
+			runs = append(runs, cnt)
+		}
+		sort.Sort(sort.Reverse(sort.IntSlice(runs)))
+		score := 0
+		for i := 0; i < len(runs); i += 2 {
+			score += runs[i]
+		}
+		outputs[caseIdx] = fmt.Sprint(score)
+	}
+	return strings.Join(outputs, "\n")
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	sb := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb[i] = '0'
+		} else {
+			sb[i] = '1'
+		}
+	}
+	var b strings.Builder
+	b.WriteString("1\n")
+	b.WriteString(string(sb))
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected = strings.TrimSpace(expected)
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solveCase(in)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1398/verifierC.go
+++ b/1000-1999/1300-1399/1390-1399/1398/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveCase(input string) string {
+	sc := bufio.NewScanner(strings.NewReader(input))
+	sc.Split(bufio.ScanWords)
+	sc.Scan() // t
+	t := 1
+	_ = sc.Text()
+	outputs := make([]string, t)
+	for caseIdx := 0; caseIdx < t; caseIdx++ {
+		sc.Scan()
+		n, _ := strconv.Atoi(sc.Text())
+		sc.Scan()
+		s := sc.Text()
+		freq := map[int]int{0: 1}
+		sum := 0
+		var ans int64
+		for i := 0; i < n; i++ {
+			sum += int(s[i]-'0') - 1
+			if c, ok := freq[sum]; ok {
+				ans += int64(c)
+			}
+			freq[sum]++
+		}
+		outputs[caseIdx] = fmt.Sprint(ans)
+	}
+	return strings.Join(outputs, "\n")
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	sb := make([]byte, n)
+	for i := 0; i < n; i++ {
+		sb[i] = byte('0' + rng.Intn(3))
+	}
+	var b strings.Builder
+	b.WriteString("1\n")
+	b.WriteString(fmt.Sprintln(n))
+	b.WriteString(string(sb))
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected = strings.TrimSpace(expected)
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solveCase(in)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1398/verifierD.go
+++ b/1000-1999/1300-1399/1390-1399/1398/verifierD.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func brute(r, g, b []int) int {
+	sort.Slice(r, func(i, j int) bool { return r[i] > r[j] })
+	sort.Slice(g, func(i, j int) bool { return g[i] > g[j] })
+	sort.Slice(b, func(i, j int) bool { return b[i] > b[j] })
+	memo := make(map[[3]int]int)
+	var f func(int, int, int) int
+	f = func(i, j, k int) int {
+		key := [3]int{i, j, k}
+		if v, ok := memo[key]; ok {
+			return v
+		}
+		best := 0
+		if i < len(r) && j < len(g) {
+			v := r[i]*g[j] + f(i+1, j+1, k)
+			if v > best {
+				best = v
+			}
+		}
+		if i < len(r) && k < len(b) {
+			v := r[i]*b[k] + f(i+1, j, k+1)
+			if v > best {
+				best = v
+			}
+		}
+		if j < len(g) && k < len(b) {
+			v := g[j]*b[k] + f(i, j+1, k+1)
+			if v > best {
+				best = v
+			}
+		}
+		memo[key] = best
+		return best
+	}
+	return f(0, 0, 0)
+}
+
+func solveCase(input string) string {
+	fields := strings.Fields(input)
+	idx := 0
+	R, _ := strconv.Atoi(fields[idx])
+	idx++
+	G, _ := strconv.Atoi(fields[idx])
+	idx++
+	B, _ := strconv.Atoi(fields[idx])
+	idx++
+	r := make([]int, R)
+	gArr := make([]int, G)
+	bArr := make([]int, B)
+	for i := 0; i < R; i++ {
+		val, _ := strconv.Atoi(fields[idx])
+		idx++
+		r[i] = val
+	}
+	for i := 0; i < G; i++ {
+		val, _ := strconv.Atoi(fields[idx])
+		idx++
+		gArr[i] = val
+	}
+	for i := 0; i < B; i++ {
+		val, _ := strconv.Atoi(fields[idx])
+		idx++
+		bArr[i] = val
+	}
+	ans := brute(r, gArr, bArr)
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) string {
+	R := rng.Intn(3) + 1
+	G := rng.Intn(3) + 1
+	B := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", R, G, B))
+	for i := 0; i < R; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rng.Intn(9)+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < G; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rng.Intn(9)+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < B; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rng.Intn(9)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected = strings.TrimSpace(expected)
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solveCase(in)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1398/verifierE.go
+++ b/1000-1999/1300-1399/1390-1399/1398/verifierE.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type spell struct {
+	tp int
+	d  int64
+}
+
+func maxDamage(fire []int64, light []int64) int64 {
+	spells := make([]spell, 0, len(fire)+len(light))
+	for _, v := range fire {
+		spells = append(spells, spell{0, v})
+	}
+	for _, v := range light {
+		spells = append(spells, spell{1, v})
+	}
+	n := len(spells)
+	used := make([]bool, n)
+	var best int64
+	var dfs func(int, int64, int64)
+	dfs = func(k int, mult int64, dmg int64) {
+		if k == n {
+			if dmg > best {
+				best = dmg
+			}
+			return
+		}
+		for i := 0; i < n; i++ {
+			if !used[i] {
+				used[i] = true
+				sp := spells[i]
+				if sp.tp == 0 {
+					dfs(k+1, mult, dmg+mult*sp.d)
+				} else {
+					dfs(k+1, mult*2, dmg+mult*sp.d)
+				}
+				used[i] = false
+			}
+		}
+	}
+	dfs(0, 1, 0)
+	return best
+}
+
+func solveCase(input string) string {
+	sc := bufio.NewScanner(strings.NewReader(input))
+	sc.Split(bufio.ScanWords)
+	sc.Scan()
+	n, _ := strconv.Atoi(sc.Text())
+	fire := make(map[int64]bool)
+	light := make(map[int64]bool)
+	var outputs []string
+	for i := 0; i < n; i++ {
+		sc.Scan()
+		tp, _ := strconv.Atoi(sc.Text())
+		sc.Scan()
+		d64, _ := strconv.ParseInt(sc.Text(), 10, 64)
+		if d64 > 0 {
+			if tp == 0 {
+				fire[d64] = true
+			} else {
+				light[d64] = true
+			}
+		} else {
+			if tp == 0 {
+				delete(fire, -d64)
+			} else {
+				delete(light, -d64)
+			}
+		}
+		f := make([]int64, 0, len(fire))
+		l := make([]int64, 0, len(light))
+		for v := range fire {
+			f = append(f, v)
+		}
+		for v := range light {
+			l = append(l, v)
+		}
+		outputs = append(outputs, fmt.Sprint(maxDamage(f, l)))
+	}
+	return strings.Join(outputs, "\n")
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintln(n))
+	fire := make(map[int64]bool)
+	light := make(map[int64]bool)
+	for i := 0; i < n; i++ {
+		tp := rng.Intn(2)
+		add := rng.Intn(2) == 0 || len(fire)+len(light) == 0
+		var d int64
+		if add {
+			// ensure unique
+			for {
+				d = int64(rng.Intn(9) + 1)
+				if tp == 0 {
+					if !fire[d] {
+						break
+					}
+				} else {
+					if !light[d] {
+						break
+					}
+				}
+			}
+			if tp == 0 {
+				fire[d] = true
+			} else {
+				light[d] = true
+			}
+			sb.WriteString(fmt.Sprintf("%d %d\n", tp, d))
+		} else {
+			// remove existing
+			if tp == 0 && len(fire) > 0 {
+				for v := range fire {
+					d = v
+					break
+				}
+				delete(fire, d)
+				sb.WriteString(fmt.Sprintf("%d %d\n", tp, -d))
+			} else if tp == 1 && len(light) > 0 {
+				for v := range light {
+					d = v
+					break
+				}
+				delete(light, d)
+				sb.WriteString(fmt.Sprintf("%d %d\n", tp, -d))
+			} else {
+				// if chosen type empty, add instead
+				d = int64(rng.Intn(9) + 1)
+				if tp == 0 {
+					fire[d] = true
+				} else {
+					light[d] = true
+				}
+				sb.WriteString(fmt.Sprintf("%d %d\n", tp, d))
+			}
+		}
+	}
+	return sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected = strings.TrimSpace(expected)
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solveCase(in)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1398/verifierF.go
+++ b/1000-1999/1300-1399/1390-1399/1398/verifierF.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func canUniform(seg string) bool {
+	has0 := strings.Contains(seg, "0")
+	has1 := strings.Contains(seg, "1")
+	return !(has0 && has1)
+}
+
+func solveCase(input string) string {
+	fields := strings.Fields(input)
+	if len(fields) == 0 {
+		return ""
+	}
+	n, _ := strconv.Atoi(fields[0])
+	s := fields[1]
+	res := make([]string, n)
+	for x := 1; x <= n; x++ {
+		cnt := 0
+		i := 0
+		for i+x <= n {
+			seg := s[i : i+x]
+			if canUniform(seg) {
+				cnt++
+				i += x
+			} else {
+				i++
+			}
+		}
+		res[x-1] = fmt.Sprint(cnt)
+	}
+	return strings.Join(res, " ")
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	bytesS := make([]byte, n)
+	chars := []byte{'0', '1', '?'}
+	for i := 0; i < n; i++ {
+		bytesS[i] = chars[rng.Intn(3)]
+	}
+	return fmt.Sprintf("%d\n%s\n", n, string(bytesS))
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected = strings.TrimSpace(expected)
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solveCase(in)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1398/verifierG.go
+++ b/1000-1999/1300-1399/1390-1399/1398/verifierG.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveCase(input string) string {
+	sc := bufio.NewScanner(strings.NewReader(input))
+	sc.Split(bufio.ScanWords)
+	sc.Scan()
+	n, _ := strconv.Atoi(sc.Text())
+	sc.Scan()
+	x, _ := strconv.Atoi(sc.Text())
+	_ = x
+	sc.Scan()
+	y, _ := strconv.Atoi(sc.Text())
+	a := make([]int, n+1)
+	for i := 0; i <= n; i++ {
+		sc.Scan()
+		a[i], _ = strconv.Atoi(sc.Text())
+	}
+	diffs := make(map[int]bool)
+	for i := 0; i <= n; i++ {
+		for j := 0; j <= n; j++ {
+			d := a[i] - a[j]
+			if d > 0 {
+				diffs[d] = true
+			}
+		}
+	}
+	const maxL = 1000000
+	best := make([]int, maxL+1)
+	for d := range diffs {
+		L := 2 * (d + y)
+		for m := L; m <= maxL; m += L {
+			if best[m] < L {
+				best[m] = L
+			}
+		}
+	}
+	sc.Scan()
+	q, _ := strconv.Atoi(sc.Text())
+	out := make([]string, q)
+	for i := 0; i < q; i++ {
+		sc.Scan()
+		li, _ := strconv.Atoi(sc.Text())
+		if li <= maxL && best[li] > 0 {
+			out[i] = fmt.Sprint(best[li])
+		} else {
+			out[i] = "-1"
+		}
+	}
+	return strings.Join(out, " ")
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	x := rng.Intn(10) + 1
+	y := rng.Intn(5)
+	a := make([]int, n+1)
+	for i := 0; i <= n; i++ {
+		a[i] = rng.Intn(x + 1)
+	}
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x, y))
+	for i := 0; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", a[i]))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintln(q))
+	for i := 0; i < q; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rng.Intn(20)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected = strings.TrimSpace(expected)
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp := solveCase(in)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A-G of contest 1398
- each verifier generates 100 random test cases and checks a binary's output

## Testing
- `env GO111MODULE=off go build 1000-1999/1300-1399/1390-1399/1398/verifierA.go`
- `env GO111MODULE=off go build 1000-1999/1300-1399/1390-1399/1398/verifierB.go`
- `env GO111MODULE=off go build 1000-1999/1300-1399/1390-1399/1398/verifierC.go`
- `env GO111MODULE=off go build 1000-1999/1300-1399/1390-1399/1398/verifierD.go`
- `env GO111MODULE=off go build 1000-1999/1300-1399/1390-1399/1398/verifierE.go`
- `env GO111MODULE=off go build 1000-1999/1300-1399/1390-1399/1398/verifierF.go`
- `env GO111MODULE=off go build 1000-1999/1300-1399/1390-1399/1398/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6885f71270148324ad85aa9aaadd8029