### PR TITLE
Add contest 1396 verifiers

### DIFF
--- a/1000-1999/1300-1399/1390-1399/1396/verifierA.go
+++ b/1000-1999/1300-1399/1390-1399/1396/verifierA.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// applyOps verifies the operations output and checks that the array becomes all zeros.
+func applyOps(n int, arr []int64, out string) error {
+	reader := bufio.NewReader(strings.NewReader(out))
+	for op := 0; op < 3; op++ {
+		var l, r int
+		if _, err := fmt.Fscan(reader, &l, &r); err != nil {
+			return fmt.Errorf("failed to read l r for op %d: %v", op+1, err)
+		}
+		if l < 1 || r < l || r > n {
+			return fmt.Errorf("invalid segment %d: %d %d", op+1, l, r)
+		}
+		segLen := int64(r - l + 1)
+		for i := l - 1; i < r; i++ {
+			var bStr string
+			if _, err := fmt.Fscan(reader, &bStr); err != nil {
+				return fmt.Errorf("failed to read value for op %d: %v", op+1, err)
+			}
+			b, err := strconv.ParseInt(bStr, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid integer in op %d: %v", op+1, err)
+			}
+			if b%segLen != 0 {
+				return fmt.Errorf("value %d not divisible by %d in op %d", b, segLen, op+1)
+			}
+			arr[i] += b
+		}
+	}
+	var tmp string
+	if _, err := fmt.Fscan(reader, &tmp); err == nil {
+		return fmt.Errorf("extra output")
+	}
+	for i, v := range arr {
+		if v != 0 {
+			return fmt.Errorf("a[%d]=%d not zero", i+1, v)
+		}
+	}
+	return nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprintf(&buf, "%d", rng.Intn(21)-10)
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		reader := bufio.NewReader(strings.NewReader(input))
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int64, n)
+		for j := 0; j < n; j++ {
+			fmt.Fscan(reader, &arr[j])
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := applyOps(n, append([]int64(nil), arr...), out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1396/verifierB.go
+++ b/1000-1999/1300-1399/1390-1399/1396/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(reader, &t)
+	var sb strings.Builder
+	for i := 0; i < t; i++ {
+		var n int
+		fmt.Fscan(reader, &n)
+		sum := 0
+		maxv := 0
+		for j := 0; j < n; j++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			sum += x
+			if x > maxv {
+				maxv = x
+			}
+		}
+		if maxv > sum-maxv || sum%2 == 1 {
+			sb.WriteString("T")
+		} else {
+			sb.WriteString("HL")
+		}
+		if i+1 < t {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func genTest(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(5) + 1
+		fmt.Fprintf(&buf, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprintf(&buf, "%d", rng.Intn(10)+1)
+		}
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		expect := solveB(input)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1396/verifierC.go
+++ b/1000-1999/1300-1399/1390-1399/1396/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveC(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n int
+	var r1, r2, r3, d int64
+	if _, err := fmt.Fscan(reader, &n, &r1, &r2, &r3, &d); err != nil {
+		return ""
+	}
+	const INF int64 = math.MaxInt64 / 4
+	dp0 := -d
+	dp1 := INF
+	for i := 0; i < n; i++ {
+		var a int64
+		fmt.Fscan(reader, &a)
+		t1 := a*r1 + r3
+		t2 := min(r2, (a+1)*r1)
+		ndp0 := min(dp0+d+t1, dp1+r3+d+t1)
+		ndp1 := min(dp0+d+t2, dp1+d+t2)
+		dp0, dp1 = ndp0, ndp1
+	}
+	ans := min(dp0, dp1+r3)
+	return fmt.Sprint(ans)
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	r1 := rng.Intn(5) + 1
+	r2 := rng.Intn(5) + 1
+	r3 := rng.Intn(5) + 1
+	d := rng.Intn(5) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d %d %d %d %d\n", n, r1, r2, r3, d)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprintf(&buf, "%d", rng.Intn(5)+1)
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		expect := solveC(input)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1396/verifierD.go
+++ b/1000-1999/1300-1399/1390-1399/1396/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func solveD(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n, k int
+	var L int
+	fmt.Fscan(reader, &n, &k, &L)
+	xs := make([]int, n)
+	ys := make([]int, n)
+	cs := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &xs[i], &ys[i], &cs[i])
+		cs[i]--
+	}
+	var ans int64
+	for x1 := 0; x1 < L; x1++ {
+		for x2 := x1 + 1; x2 <= L; x2++ {
+			for y1 := 0; y1 < L; y1++ {
+				for y2 := y1 + 1; y2 <= L; y2++ {
+					seen := make([]bool, k)
+					cnt := 0
+					for i := 0; i < n; i++ {
+						if xs[i] >= x1 && xs[i] < x2 && ys[i] >= y1 && ys[i] < y2 {
+							if !seen[cs[i]] {
+								seen[cs[i]] = true
+								cnt++
+							}
+						}
+					}
+					if cnt == k {
+						ans++
+					}
+				}
+			}
+		}
+	}
+	ans %= mod
+	return fmt.Sprint(ans)
+}
+
+func genTest(rng *rand.Rand) string {
+	k := rng.Intn(3) + 1
+	n := k + rng.Intn(3)
+	if n < k {
+		n = k
+	}
+	L := rng.Intn(4) + 2
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d %d %d\n", n, k, L)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(L)
+		y := rng.Intn(L)
+		c := rng.Intn(k) + 1
+		fmt.Fprintf(&buf, "%d %d %d\n", x, y, c)
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		expect := solveD(input)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1300-1399/1390-1399/1396/verifierE.go
+++ b/1000-1999/1300-1399/1390-1399/1396/verifierE.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func bfs(n int, g [][]int, start int) []int {
+	dist := make([]int, n)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := []int{start}
+	dist[start] = 0
+	for head := 0; head < len(q); head++ {
+		v := q[head]
+		for _, to := range g[v] {
+			if dist[to] == -1 {
+				dist[to] = dist[v] + 1
+				q = append(q, to)
+			}
+		}
+	}
+	return dist
+}
+
+func allDistances(n int, edges [][2]int) [][]int {
+	g := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0]-1, e[1]-1
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	dist := make([][]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = bfs(n, g, i)
+	}
+	return dist
+}
+
+func possible(dist [][]int, k int) bool {
+	n := len(dist)
+	dp := make([]map[int]struct{}, 1<<n)
+	dp[0] = map[int]struct{}{0: {}}
+	for mask := 0; mask < (1 << n); mask++ {
+		if dp[mask] == nil {
+			continue
+		}
+		var first int
+		for first = 0; first < n; first++ {
+			if mask&(1<<first) == 0 {
+				break
+			}
+		}
+		if first >= n {
+			continue
+		}
+		for second := first + 1; second < n; second++ {
+			if mask&(1<<second) != 0 {
+				continue
+			}
+			newMask := mask | 1<<first | 1<<second
+			if dp[newMask] == nil {
+				dp[newMask] = make(map[int]struct{})
+			}
+			for sum := range dp[mask] {
+				dp[newMask][sum+dist[first][second]] = struct{}{}
+			}
+		}
+	}
+	_, ok := dp[(1<<n)-1][k]
+	return ok
+}
+
+func verifyOutput(n, k int, edges [][2]int, out string) error {
+	dist := allDistances(n, edges)
+	reader := bufio.NewReader(strings.NewReader(strings.TrimSpace(out)))
+	var firstTok string
+	if _, err := fmt.Fscan(reader, &firstTok); err != nil {
+		return fmt.Errorf("failed to read first token: %v", err)
+	}
+	if firstTok == "NO" {
+		if possible(dist, k) {
+			return fmt.Errorf("matching exists but NO given")
+		}
+		if _, err := fmt.Fscan(reader); err == nil {
+			return fmt.Errorf("extra output")
+		}
+		return nil
+	}
+	if firstTok != "YES" {
+		return fmt.Errorf("expected YES or NO")
+	}
+	m := n / 2
+	used := make([]bool, n)
+	sum := 0
+	for i := 0; i < m; i++ {
+		var u, v int
+		if _, err := fmt.Fscan(reader, &u, &v); err != nil {
+			return fmt.Errorf("failed to read pair %d: %v", i+1, err)
+		}
+		if u < 1 || u > n || v < 1 || v > n || u == v {
+			return fmt.Errorf("invalid pair %d", i+1)
+		}
+		if used[u-1] || used[v-1] {
+			return fmt.Errorf("node reused in pair %d", i+1)
+		}
+		used[u-1] = true
+		used[v-1] = true
+		sum += dist[u-1][v-1]
+	}
+	if _, err := fmt.Fscan(reader); err == nil {
+		return fmt.Errorf("extra output")
+	}
+	for _, u := range used {
+		if !u {
+			return fmt.Errorf("not all nodes matched")
+		}
+	}
+	if sum != k {
+		return fmt.Errorf("sum %d does not match k %d", sum, k)
+	}
+	return nil
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(4)*2 + 2 // 2,4,6,8,10
+	if n > 8 {
+		n = 8
+	}
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{i, p}
+	}
+	kVal := rng.Intn(n*n) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d %d\n", n, kVal)
+	for _, e := range edges {
+		fmt.Fprintf(&buf, "%d %d\n", e[0], e[1])
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		reader := bufio.NewReader(strings.NewReader(input))
+		var n, kVal int
+		fmt.Fscan(reader, &n, &kVal)
+		edges := make([][2]int, n-1)
+		for j := 0; j < n-1; j++ {
+			fmt.Fscan(reader, &edges[j][0], &edges[j][1])
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verifyOutput(n, kVal, edges, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces contest 1396 problems A–E
- each verifier generates 100 random tests
- constructive verifier for problem A checks the operations
- problems B–E use reference solutions or brute force to validate outputs

## Testing
- `go build verifierA.go && ./verifierA 1396A.go`


------
https://chatgpt.com/codex/tasks/task_e_6885f5fa3ef48324bb8f8bdcf1d41e33