### PR TITLE
Fix 1010C verifier whitespace handling

### DIFF
--- a/1000-1999/1000-1099/1010-1019/1010/verifierC.go
+++ b/1000-1999/1000-1099/1010-1019/1010/verifierC.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 )
 
 func runTests(dir, binary string) error {
@@ -32,8 +33,10 @@ func runTests(dir, binary string) error {
 		if err != nil {
 			return fmt.Errorf("%s: %v", filepath.Base(inFile), err)
 		}
-		if string(out) != string(expected) {
-			return fmt.Errorf("%s: expected\n%sbut got\n%s", filepath.Base(inFile), expected, out)
+		got := strings.TrimSpace(string(out))
+		want := strings.TrimSpace(string(expected))
+		if got != want {
+			return fmt.Errorf("%s: expected\n%sbut got\n%s", filepath.Base(inFile), want, got)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- allow verifier for contest `1010` problem `C` to ignore trailing whitespace

## Testing
- `go build 1000-1999/1000-1099/1010-1019/1010/verifierC.go`
- `go run 1000-1999/1000-1099/1010-1019/1010/verifierC.go /tmp/solution_binary`
- `go run 1000-1999/1000-1099/1010-1019/1010/verifierC.go /tmp/user_solution_binary`

------
https://chatgpt.com/codex/tasks/task_e_6885f979628483248c9c46270fa3ed50