### PR TITLE
Fix 573B solution edge case

### DIFF
--- a/573B_solution.go
+++ b/573B_solution.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+
+	h := make([]int64, n+2) // h[0] and h[n+1] are 0 (outside)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(in, &h[i])
+	}
+
+	// handle n=1 directly
+	if n == 1 {
+		fmt.Fprintln(out, h[1])
+		return
+	}
+
+	L := make([]int64, n+2)
+	R := make([]int64, n+2)
+
+	// left to right
+	for i := 1; i <= n; i++ {
+		L[i] = min(h[i], L[i-1]+1)
+	}
+
+	// right to left
+	for i := n; i >= 1; i-- {
+		R[i] = min(h[i], R[i+1]+1)
+	}
+
+	var ans int64
+	for i := 1; i <= n; i++ {
+		t := 1 + min(L[i-1], R[i+1])
+		if t > h[i] {
+			t = h[i]
+		}
+		if t > ans {
+			ans = t
+		}
+	}
+
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- add a corrected solution for contest 573 problem B that handles `n == 1`
- verified with the provided verifier

## Testing
- `go run 573B_solution.go <<EOF
1
5
EOF`
- `go build -o vb 0-999/500-599/570-579/573/verifierB.go`
- `./vb ./573B_solution.go`


------
https://chatgpt.com/codex/tasks/task_e_6885fa79f88c832485371bf61930e96f