### PR TITLE
Add verifiers for Codeforces contest 1405

### DIFF
--- a/1000-1999/1400-1499/1400-1409/1405/verifierA.go
+++ b/1000-1999/1400-1499/1400-1409/1405/verifierA.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	p []int
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyCase(in, out []int) error {
+	n := len(in)
+	if len(out) != n {
+		return fmt.Errorf("expected %d numbers, got %d", n, len(out))
+	}
+	used := make([]bool, n+1)
+	for _, v := range out {
+		if v < 1 || v > n {
+			return fmt.Errorf("value %d out of range 1..%d", v, n)
+		}
+		if used[v] {
+			return fmt.Errorf("value %d repeated", v)
+		}
+		used[v] = true
+	}
+	same := true
+	for i := 0; i < n; i++ {
+		if in[i] != out[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		return fmt.Errorf("output permutation equals input")
+	}
+	if n > 1 {
+		inFp := make([]int, n-1)
+		outFp := make([]int, n-1)
+		for i := 0; i < n-1; i++ {
+			inFp[i] = in[i] + in[i+1]
+			outFp[i] = out[i] + out[i+1]
+		}
+		sort.Ints(inFp)
+		sort.Ints(outFp)
+		for i := range inFp {
+			if inFp[i] != outFp[i] {
+				return fmt.Errorf("fingerprint mismatch")
+			}
+		}
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 2
+	p := rng.Perm(n)
+	for i := range p {
+		p[i]++
+	}
+	return testCase{n: n, p: p}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{n: 2, p: []int{1, 2}}, {n: 3, p: []int{3, 1, 2}}}
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(cases)))
+	for _, tc := range cases {
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for i := 0; i < tc.n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(tc.p[i]))
+		}
+		sb.WriteByte('\n')
+	}
+	out, err := runCandidate(bin, sb.String())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fields := strings.Fields(out)
+	pos := 0
+	for idx, tc := range cases {
+		if pos+tc.n > len(fields) {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d numbers, got %d\n", idx+1, tc.n, len(fields)-pos)
+			os.Exit(1)
+		}
+		arr := make([]int, tc.n)
+		for i := 0; i < tc.n; i++ {
+			v, err := strconv.Atoi(fields[pos])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d: invalid integer %q\n", idx+1, fields[pos])
+				os.Exit(1)
+			}
+			arr[i] = v
+			pos++
+		}
+		if err := verifyCase(tc.p, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %v\noutput: %v\n", idx+1, err, tc.p, arr)
+			os.Exit(1)
+		}
+	}
+	if pos != len(fields) {
+		fmt.Fprintf(os.Stderr, "extra output tokens: %d\n", len(fields)-pos)
+		os.Exit(1)
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1400-1499/1400-1409/1405/verifierB.go
+++ b/1000-1999/1400-1499/1400-1409/1405/verifierB.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr []int64
+}
+
+type supply struct {
+	idx int
+	rem int64
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(a []int64) int64 {
+	var total int64
+	for _, v := range a {
+		if v > 0 {
+			total += v
+		}
+	}
+	supplies := make([]supply, 0, len(a))
+	head := 0
+	var free int64
+	for i, v := range a {
+		if v > 0 {
+			supplies = append(supplies, supply{idx: i, rem: v})
+		} else if v < 0 {
+			need := -v
+			for need > 0 && head < len(supplies) && supplies[head].idx < i {
+				cur := &supplies[head]
+				d := cur.rem
+				if d > need {
+					d = need
+				}
+				free += d
+				cur.rem -= d
+				need -= d
+				if cur.rem == 0 {
+					head++
+				}
+			}
+		}
+	}
+	return total - free
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	arr := make([]int64, n)
+	var sum int64
+	for i := 0; i < n-1; i++ {
+		v := int64(rng.Intn(21) - 10)
+		arr[i] = v
+		sum += v
+	}
+	arr[n-1] = -sum
+	return testCase{arr: arr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{arr: []int64{0}}, {arr: []int64{1, -1}}, {arr: []int64{-1, 1, 0}}}
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(cases)))
+	for _, tc := range cases {
+		sb.WriteString(fmt.Sprintf("%d\n", len(tc.arr)))
+		for i, v := range tc.arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+	}
+	out, err := runCandidate(bin, sb.String())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fields := strings.Fields(out)
+	if len(fields) != len(cases) {
+		fmt.Fprintf(os.Stderr, "expected %d numbers, got %d\n", len(cases), len(fields))
+		os.Exit(1)
+	}
+	for i, tc := range cases {
+		v, err := strconv.ParseInt(fields[i], 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid integer on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expect := solve(tc.arr)
+		if v != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput: %v\nexpected: %d got: %d\n", i+1, tc.arr, expect, v)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- create `verifierA.go` for problem A
- create `verifierB.go` for problem B

Both tools generate 100+ tests and can validate any solution binary.

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `./va ./correctA.go` → `All 100 tests passed`
- `./vb ./1405B.go` → `All 100 tests passed`


------
https://chatgpt.com/codex/tasks/task_e_6885fae73b1c83248d5a1e277ef084eb