### PR TITLE
Add Go verifiers for contest 1404

### DIFF
--- a/1000-1999/1400-1499/1400-1409/1404/verifierA.go
+++ b/1000-1999/1400-1499/1400-1409/1404/verifierA.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(reader *bufio.Reader) string {
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for ; t > 0; t-- {
+		var n, k int
+		var s string
+		fmt.Fscan(reader, &n, &k)
+		fmt.Fscan(reader, &s)
+		tarr := make([]byte, k)
+		for i := 0; i < k; i++ {
+			tarr[i] = '?'
+		}
+		ok := true
+		for i := 0; i < n; i++ {
+			c := s[i]
+			if c == '?' {
+				continue
+			}
+			pos := i % k
+			if tarr[pos] == '?' {
+				tarr[pos] = c
+			} else if tarr[pos] != c {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			sb.WriteString("NO\n")
+			continue
+		}
+		cnt0, cnt1 := 0, 0
+		for i := 0; i < k; i++ {
+			if tarr[i] == '0' {
+				cnt0++
+			} else if tarr[i] == '1' {
+				cnt1++
+			}
+		}
+		if cnt0 > k/2 || cnt1 > k/2 {
+			sb.WriteString("NO\n")
+		} else {
+			sb.WriteString("YES\n")
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for ; t > 0; t-- {
+		n := rng.Intn(30) + 2
+		if n%2 == 1 {
+			n++ // make even sometimes? not necessary, k even only
+		}
+		k := rng.Intn(n/2)*2 + 2 // ensure even and <=n
+		if k > n {
+			k = n
+			if k%2 == 1 {
+				k--
+			}
+		}
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		// generate random string of 0/1/?
+		data := make([]byte, n)
+		for i := 0; i < n; i++ {
+			r := rng.Intn(3)
+			if r == 0 {
+				data[i] = '0'
+			} else if r == 1 {
+				data[i] = '1'
+			} else {
+				data[i] = '?'
+			}
+		}
+		fmt.Fprintf(&sb, "%s\n", string(data))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1404/verifierB.go
+++ b/1000-1999/1400-1499/1400-1409/1404/verifierB.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func bfsDist(src, tgt int, adj [][]int, n int) int {
+	dist := make([]int, n)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := make([]int, 0, n)
+	dist[src] = 0
+	q = append(q, src)
+	for i := 0; i < len(q); i++ {
+		u := q[i]
+		if u == tgt {
+			break
+		}
+		for _, v := range adj[u] {
+			if dist[v] == -1 {
+				dist[v] = dist[u] + 1
+				q = append(q, v)
+			}
+		}
+	}
+	return dist[tgt]
+}
+
+func bfsFarthest(start int, adj [][]int, n int) (node, dist int) {
+	d := make([]int, n)
+	for i := range d {
+		d[i] = -1
+	}
+	q := make([]int, 0, n)
+	d[start] = 0
+	q = append(q, start)
+	node = start
+	dist = 0
+	for i := 0; i < len(q); i++ {
+		u := q[i]
+		for _, v := range adj[u] {
+			if d[v] == -1 {
+				d[v] = d[u] + 1
+				q = append(q, v)
+				if d[v] > dist {
+					dist = d[v]
+					node = v
+				}
+			}
+		}
+	}
+	return
+}
+
+func solve(reader *bufio.Reader) string {
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for ; t > 0; t-- {
+		var n, a, b, da, db int
+		fmt.Fscan(reader, &n, &a, &b, &da, &db)
+		a--
+		b--
+		adj := make([][]int, n)
+		for i := 0; i < n-1; i++ {
+			var u, v int
+			fmt.Fscan(reader, &u, &v)
+			u--
+			v--
+			adj[u] = append(adj[u], v)
+			adj[v] = append(adj[v], u)
+		}
+		distAB := bfsDist(a, b, adj, n)
+		if distAB <= da {
+			sb.WriteString("Alice\n")
+			continue
+		}
+		far, _ := bfsFarthest(0, adj, n)
+		_, diam := bfsFarthest(far, adj, n)
+		if db <= 2*da || diam <= 2*da {
+			sb.WriteString("Alice\n")
+		} else {
+			sb.WriteString("Bob\n")
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for ; t > 0; t-- {
+		n := rng.Intn(10) + 2
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		da := rng.Intn(n) + 1
+		db := rng.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d %d %d %d\n", n, a, b, da, db)
+		// generate tree
+		parents := make([]int, n)
+		for i := 1; i < n; i++ {
+			p := rng.Intn(i)
+			parents[i] = p
+			fmt.Fprintf(&sb, "%d %d\n", i+1, p+1)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1404/verifierC.go
+++ b/1000-1999/1400-1499/1400-1409/1404/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func maxRem(arr []int) int {
+	best := 0
+	for i := 0; i < len(arr); i++ {
+		if arr[i] == i+1 {
+			tmp := make([]int, len(arr)-1)
+			copy(tmp, arr[:i])
+			copy(tmp[i:], arr[i+1:])
+			if val := 1 + maxRem(tmp); val > best {
+				best = val
+			}
+		}
+	}
+	return best
+}
+
+func solve(reader *bufio.Reader) string {
+	var n, q int
+	if _, err := fmt.Fscan(reader, &n, &q); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	var sb strings.Builder
+	for ; q > 0; q-- {
+		var x, y int
+		fmt.Fscan(reader, &x, &y)
+		b := append([]int(nil), a...)
+		for i := 0; i < x; i++ {
+			b[i] = n + 1
+		}
+		for i := 0; i < y; i++ {
+			b[len(b)-1-i] = n + 1
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", maxRem(b)))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(7) + 1
+	q := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(n)+1)
+	}
+	sb.WriteByte('\n')
+	for j := 0; j < q; j++ {
+		x := rng.Intn(n)
+		y := rng.Intn(n - x)
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1404/verifierD.go
+++ b/1000-1999/1400-1499/1400-1409/1404/verifierD.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(reader *bufio.Reader) string {
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return ""
+	}
+	if n%2 == 0 {
+		var sb strings.Builder
+		sb.WriteString("First\n")
+		for i := 1; i <= n; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", i, i+n)
+		}
+		return strings.TrimSpace(sb.String())
+	}
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i], &b[i])
+	}
+	classA := make([]int, n)
+	classB := make([]int, n)
+	graph := make([][]struct{ to, idx int }, n)
+	for i := 0; i < n; i++ {
+		u := (a[i] - 1) % n
+		v := (b[i] - 1) % n
+		classA[i] = u
+		classB[i] = v
+		graph[u] = append(graph[u], struct{ to, idx int }{v, i})
+		graph[v] = append(graph[v], struct{ to, idx int }{u, i})
+	}
+	dir := make([]bool, n)
+	used := make([]bool, n)
+	cycles := make([][]int, 0)
+	for start := 0; start < n; start++ {
+		if len(graph[start]) == 0 {
+			continue
+		}
+		for _, e0 := range graph[start] {
+			if used[e0.idx] {
+				continue
+			}
+			var cycle []int
+			curr := start
+			prev := -1
+			for {
+				var e struct{ to, idx int }
+				for _, ee := range graph[curr] {
+					if ee.idx != prev {
+						e = ee
+						break
+					}
+				}
+				if used[e.idx] {
+					break
+				}
+				used[e.idx] = true
+				cycle = append(cycle, e.idx)
+				p := e.idx
+				if classA[p] == curr && classB[p] == e.to {
+					dir[p] = true
+				} else if classB[p] == curr && classA[p] == e.to {
+					dir[p] = false
+				}
+				prev = e.idx
+				curr = e.to
+				if curr == start {
+					break
+				}
+			}
+			if len(cycle) > 0 {
+				cycles = append(cycles, cycle)
+			}
+		}
+	}
+	t := 0
+	for i := 0; i < n; i++ {
+		if dir[i] {
+			if b[i] > n {
+				t++
+			}
+		} else {
+			if a[i] > n {
+				t++
+			}
+		}
+	}
+	kp := ((n + 1) / 2) & 1
+	if (t & 1) != kp {
+		for _, cycle := range cycles {
+			if len(cycle)%2 == 1 {
+				for _, p := range cycle {
+					dir[p] = !dir[p]
+				}
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("Second\n")
+	for i := 0; i < n; i++ {
+		if dir[i] {
+			fmt.Fprintf(&sb, "%d", b[i])
+		} else {
+			fmt.Fprintf(&sb, "%d", a[i])
+		}
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	even := rng.Intn(2) == 0
+	if even {
+		n := 2 * (rng.Intn(4) + 1)
+		return fmt.Sprintf("%d\n", n)
+	}
+	n := 2*(rng.Intn(3)+1) + 1
+	vals := make([]int, 2*n)
+	for i := 1; i <= 2*n; i++ {
+		vals[i-1] = i
+	}
+	rng.Shuffle(2*n, func(i, j int) { vals[i], vals[j] = vals[j], vals[i] })
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", vals[2*i], vals[2*i+1])
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1404/verifierE.go
+++ b/1000-1999/1400-1499/1400-1409/1404/verifierE.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(reader *bufio.Reader) string {
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return ""
+	}
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &grid[i])
+	}
+	hID := make([][]int, n)
+	vID := make([][]int, n)
+	for i := 0; i < n; i++ {
+		hID[i] = make([]int, m)
+		vID[i] = make([]int, m)
+	}
+	hCount := 0
+	for i := 0; i < n; i++ {
+		j := 0
+		for j < m {
+			if grid[i][j] == '#' {
+				hCount++
+				k := j
+				for k < m && grid[i][k] == '#' {
+					hID[i][k] = hCount
+					k++
+				}
+				j = k
+			} else {
+				j++
+			}
+		}
+	}
+	vCount := 0
+	for j := 0; j < m; j++ {
+		i := 0
+		for i < n {
+			if grid[i][j] == '#' {
+				vCount++
+				k := i
+				for k < n && grid[k][j] == '#' {
+					vID[k][j] = vCount
+					k++
+				}
+				i = k
+			} else {
+				i++
+			}
+		}
+	}
+	graph := make([][]int, hCount+1)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '#' {
+				u := hID[i][j]
+				v := vID[i][j]
+				graph[u] = append(graph[u], v)
+			}
+		}
+	}
+	hk := NewHopcroftKarp(hCount, vCount, graph)
+	ans := hk.MaxMatching()
+	return fmt.Sprint(ans)
+}
+
+type HopcroftKarp struct {
+	n, m  int
+	graph [][]int
+	pairU []int
+	pairV []int
+	dist  []int
+}
+
+func NewHopcroftKarp(n, m int, graph [][]int) *HopcroftKarp {
+	return &HopcroftKarp{n: n, m: m, graph: graph, pairU: make([]int, n+1), pairV: make([]int, m+1), dist: make([]int, n+1)}
+}
+
+func (hk *HopcroftKarp) bfs() bool {
+	const inf = 1 << 30
+	queue := make([]int, 0, hk.n)
+	for u := 1; u <= hk.n; u++ {
+		if hk.pairU[u] == 0 {
+			hk.dist[u] = 0
+			queue = append(queue, u)
+		} else {
+			hk.dist[u] = inf
+		}
+	}
+	found := false
+	for qi := 0; qi < len(queue); qi++ {
+		u := queue[qi]
+		for _, v := range hk.graph[u] {
+			if hk.pairV[v] == 0 {
+				found = true
+			} else if hk.dist[hk.pairV[v]] == inf {
+				hk.dist[hk.pairV[v]] = hk.dist[u] + 1
+				queue = append(queue, hk.pairV[v])
+			}
+		}
+	}
+	return found
+}
+
+func (hk *HopcroftKarp) dfs(u int) bool {
+	const inf = 1 << 30
+	for _, v := range hk.graph[u] {
+		if hk.pairV[v] == 0 || (hk.dist[hk.pairV[v]] == hk.dist[u]+1 && hk.dfs(hk.pairV[v])) {
+			hk.pairU[u] = v
+			hk.pairV[v] = u
+			return true
+		}
+	}
+	hk.dist[u] = inf
+	return false
+}
+
+func (hk *HopcroftKarp) MaxMatching() int {
+	result := 0
+	for hk.bfs() {
+		for u := 1; u <= hk.n; u++ {
+			if hk.pairU[u] == 0 && hk.dfs(u) {
+				result++
+			}
+		}
+	}
+	return result
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('.')
+			} else {
+				sb.WriteByte('#')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E

## Testing
- `go build 1000-1999/1400-1499/1400-1409/1404/verifierA.go`
- `go build 1000-1999/1400-1499/1400-1409/1404/verifierB.go`
- `go build 1000-1999/1400-1499/1400-1409/1404/verifierC.go`
- `go build 1000-1999/1400-1499/1400-1409/1404/verifierD.go`
- `go build 1000-1999/1400-1499/1400-1409/1404/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6885fa5b1eb08324aee6fa8b9f4335ed