### PR TITLE
Add verifiers for contest 1409

### DIFF
--- a/1000-1999/1400-1499/1400-1409/1409/verifierA.go
+++ b/1000-1999/1400-1499/1400-1409/1409/verifierA.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(a, b int64) int64 {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	moves := d / 10
+	if d%10 != 0 {
+		moves++
+	}
+	return moves
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	a := rng.Int63n(1_000_000_000) + 1
+	b := rng.Int63n(1_000_000_000) + 1
+	input := fmt.Sprintf("1\n%d %d\n", a, b)
+	expected := solve(a, b)
+	return input, expected
+}
+
+func runCase(exe string, input string, expected int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(outStr, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1409/verifierB.go
+++ b/1000-1999/1400-1499/1400-1409/1409/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solve(a, b, x, y, n int64) int64 {
+	decA := min64(n, a-x)
+	a1 := a - decA
+	rem1 := n - decA
+	decB := min64(rem1, b-y)
+	b1 := b - decB
+
+	decB2 := min64(n, b-y)
+	b2 := b - decB2
+	rem2 := n - decB2
+	decA2 := min64(rem2, a-x)
+	a2 := a - decA2
+
+	prod1 := a1 * b1
+	prod2 := a2 * b2
+	if prod1 < prod2 {
+		return prod1
+	}
+	return prod2
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	x := rng.Int63n(1_000_000_000) + 1
+	y := rng.Int63n(1_000_000_000) + 1
+	a := x + rng.Int63n(1_000_000_000-x+1)
+	b := y + rng.Int63n(1_000_000_000-y+1)
+	n := rng.Int63n(1_000_000_000) + 1
+	input := fmt.Sprintf("1\n%d %d %d %d %d\n", a, b, x, y, n)
+	expected := solve(a, b, x, y, n)
+	return input, expected
+}
+
+func runCase(exe, input string, expected int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(outStr, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1409/verifierC.go
+++ b/1000-1999/1400-1499/1400-1409/1409/verifierC.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n int, x, y int64) []int64 {
+	diff := y - x
+	var step int64
+	for i := n - 1; i >= 1; i-- {
+		if diff%int64(i) == 0 {
+			step = diff / int64(i)
+			break
+		}
+	}
+	bestMax := int64(1 << 62)
+	var start int64
+	for i := 0; i < n; i++ {
+		cand := y - int64(i)*step
+		if cand <= 0 {
+			continue
+		}
+		maxTerm := cand + int64(n-1)*step
+		if maxTerm < bestMax {
+			bestMax = maxTerm
+			start = cand
+		}
+	}
+	res := make([]int64, n)
+	for i := 0; i < n; i++ {
+		res[i] = start + int64(i)*step
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(49) + 2
+	x := int64(rng.Intn(49) + 1)
+	y := int64(rng.Intn(50-int(x)) + int(x) + 1)
+	ans := solve(n, x, y)
+	input := fmt.Sprintf("1\n%d %d %d\n", n, x, y)
+	var sb strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return input, sb.String()
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1409/verifierD.go
+++ b/1000-1999/1400-1499/1400-1409/1409/verifierD.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func digitSum(n uint64) uint64 {
+	var s uint64
+	for n > 0 {
+		s += n % 10
+		n /= 10
+	}
+	return s
+}
+
+func solve(n, s uint64) uint64 {
+	if digitSum(n) <= s {
+		return 0
+	}
+	var add uint64
+	var pow10 uint64 = 1
+	for i := 0; i < 19; i++ {
+		digit := (n / pow10) % 10
+		delta := (10 - digit) * pow10
+		if delta > 0 {
+			add += delta
+			n += delta
+		}
+		if digitSum(n) <= s {
+			break
+		}
+		pow10 *= 10
+	}
+	return add
+}
+
+func generateCase(rng *rand.Rand) (string, uint64) {
+	n := uint64(rng.Int63n(1_000_000_000_000)) + 1
+	s := uint64(rng.Intn(162) + 1)
+	input := fmt.Sprintf("1\n%d %d\n", n, s)
+	expected := solve(n, s)
+	return input, expected
+}
+
+func runCase(exe, input string, expected uint64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	var got uint64
+	if _, err := fmt.Sscan(outStr, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1409/verifierE.go
+++ b/1000-1999/1400-1499/1400-1409/1409/verifierE.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solve(xs []int64, k int64) int {
+	n := len(xs)
+	sort.Slice(xs, func(i, j int) bool { return xs[i] < xs[j] })
+	cnt := make([]int, n)
+	r := 0
+	for i := 0; i < n; i++ {
+		for r < n && xs[r] <= xs[i]+k {
+			r++
+		}
+		cnt[i] = r - i
+	}
+	suff := make([]int, n+1)
+	for i := n - 1; i >= 0; i-- {
+		if cnt[i] > suff[i+1] {
+			suff[i] = cnt[i]
+		} else {
+			suff[i] = suff[i+1]
+		}
+	}
+	ans := 0
+	for i := 0; i < n; i++ {
+		j := i + cnt[i]
+		if j > n {
+			j = n
+		}
+		total := cnt[i] + suff[j]
+		if total > ans {
+			ans = total
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	k := int64(rng.Intn(50) + 1)
+	xs := make([]int64, n)
+	ys := make([]int64, n)
+	for i := 0; i < n; i++ {
+		xs[i] = int64(rng.Intn(100)) + 1
+		ys[i] = int64(rng.Intn(100)) + 1
+	}
+	input := fmt.Sprintf("1\n%d %d\n", n, k)
+	for i, v := range xs {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	for i, v := range ys {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	ans := solve(append([]int64(nil), xs...), k)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1409/verifierF.go
+++ b/1000-1999/1400-1499/1400-1409/1409/verifierF.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solve(n, k int, s, t string) int {
+	t0 := t[0]
+	t1 := t[1]
+	if t0 == t1 {
+		cnt := 0
+		for i := 0; i < n; i++ {
+			if s[i] == t0 {
+				cnt++
+			}
+		}
+		cnt = cnt + min(k, n-cnt)
+		return cnt * (cnt - 1) / 2
+	}
+	const INF = -1_000_000_000
+	dp := make([][]int, k+1)
+	for i := 0; i <= k; i++ {
+		dp[i] = make([]int, n+1)
+		for j := 0; j <= n; j++ {
+			dp[i][j] = INF
+		}
+	}
+	dp[0][0] = 0
+	for pos := 0; pos < n; pos++ {
+		c := s[pos]
+		ndp := make([][]int, k+1)
+		for i := 0; i <= k; i++ {
+			ndp[i] = make([]int, n+1)
+			for j := 0; j <= n; j++ {
+				ndp[i][j] = INF
+			}
+		}
+		for used := 0; used <= k; used++ {
+			for cnt0 := 0; cnt0 <= n; cnt0++ {
+				cur := dp[used][cnt0]
+				if cur < 0 {
+					continue
+				}
+				newUsed := used
+				newCnt0 := cnt0
+				add := 0
+				if c == t0 {
+					newCnt0 = cnt0 + 1
+				} else if c == t1 {
+					add = cnt0
+				}
+				if cur+add > ndp[newUsed][newCnt0] {
+					ndp[newUsed][newCnt0] = cur + add
+				}
+				if used < k {
+					newUsed2 := used + 1
+					newCnt02 := cnt0 + 1
+					if cur > ndp[newUsed2][newCnt02] {
+						ndp[newUsed2][newCnt02] = cur
+					}
+					add1 := cnt0
+					if cur+add1 > ndp[newUsed2][cnt0] {
+						ndp[newUsed2][cnt0] = cur + add1
+					}
+				}
+			}
+		}
+		dp = ndp
+	}
+	best := 0
+	for used := 0; used <= k; used++ {
+		for cnt0 := 0; cnt0 <= n; cnt0++ {
+			if dp[used][cnt0] > best {
+				best = dp[used][cnt0]
+			}
+		}
+	}
+	return best
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte(rng.Intn(26) + 'a')
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 2
+	k := rng.Intn(n + 1)
+	s := randString(rng, n)
+	t := randString(rng, 2)
+	ans := solve(n, k, s, t)
+	input := fmt.Sprintf("%d %d\n%s\n%s\n", n, k, s, t)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A-F of contest 1409
- each verifier generates 100 random test cases and checks a given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `./verifierA ./1409A`
- `./verifierB ./1409B`
- `./verifierC ./1409C`
- `./verifierD ./1409D`
- `./verifierE ./1409E`
- `./verifierF ./1409F`


------
https://chatgpt.com/codex/tasks/task_e_6885fd178d248324a883a9b064485268