### PR TITLE
Add solution verifiers for contest 1408

### DIFF
--- a/1000-1999/1400-1499/1400-1409/1408/verifierA.go
+++ b/1000-1999/1400-1499/1400-1409/1408/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 3
+	a := make([]int, n)
+	b := make([]int, n)
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(100) + 1
+		b[i] = rng.Intn(100) + 1
+		for b[i] == a[i] {
+			b[i] = rng.Intn(100) + 1
+		}
+		c[i] = rng.Intn(100) + 1
+		for c[i] == a[i] || c[i] == b[i] {
+			c[i] = rng.Intn(100) + 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range c {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1408A.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1408A.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1408/verifierB.go
+++ b/1000-1999/1400-1499/1400-1409/1408/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	a := make([]int, n)
+	cur := 0
+	for i := 0; i < n; i++ {
+		cur += rng.Intn(3)
+		a[i] = cur
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1408B.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1408B.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1408/verifierC.go
+++ b/1000-1999/1400-1499/1400-1409/1408/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	l := rng.Intn(50) + 1
+	pos := make([]int, n)
+	prev := 0
+	for i := 0; i < n; i++ {
+		prev += rng.Intn(max(1, (l-prev-1)/(n-i))) + 1
+		if prev >= l {
+			prev = l - 1
+		}
+		pos[i] = prev
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, l))
+	for i, v := range pos {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1408C.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1408C.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1408/verifierD.go
+++ b/1000-1999/1400-1499/1400-1409/1408/verifierD.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	type pt struct{ x, y int }
+	a := make([]pt, n)
+	b := make([]pt, m)
+	for i := 0; i < n; i++ {
+		a[i] = pt{rng.Intn(6), rng.Intn(6)}
+	}
+	for j := 0; j < m; j++ {
+		b[j] = pt{rng.Intn(6), rng.Intn(6)}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", a[i].x, a[i].y)
+	}
+	for j := 0; j < m; j++ {
+		fmt.Fprintf(&sb, "%d %d\n", b[j].x, b[j].y)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1408D.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1408D.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1408/verifierE.go
+++ b/1000-1999/1400-1499/1400-1409/1408/verifierE.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	m := rng.Intn(3) + 1
+	n := rng.Intn(3) + 1
+	a := make([]int, m)
+	b := make([]int, n)
+	for i := 0; i < m; i++ {
+		a[i] = rng.Intn(10) + 1
+	}
+	for j := 0; j < n; j++ {
+		b[j] = rng.Intn(10) + 1
+	}
+	sets := make([][]int, m)
+	for i := 0; i < m; i++ {
+		sz := rng.Intn(n + 1)
+		perm := rand.Perm(n)
+		sets[i] = make([]int, sz)
+		for j := 0; j < sz; j++ {
+			sets[i][j] = perm[j] + 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", m, n))
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	for j := 0; j < n; j++ {
+		if j > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(b[j]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprint(len(sets[i])))
+		for _, v := range sets[i] {
+			sb.WriteByte(' ')
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1408E.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1408E.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1408/verifierF.go
+++ b/1000-1999/1400-1499/1400-1409/1408/verifierF.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1408F.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1408F.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1408/verifierG.go
+++ b/1000-1999/1400-1499/1400-1409/1408/verifierG.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	mat := make([][]int, n)
+	for i := 0; i < n; i++ {
+		mat[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			if i == j {
+				mat[i][j] = 0
+			} else {
+				mat[i][j] = rng.Intn(5)
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(mat[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1408G.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1408G.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1408/verifierH.go
+++ b/1000-1999/1400-1499/1400-1409/1408/verifierH.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(4)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1408H.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1408H.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1400-1409/1408/verifierI.go
+++ b/1000-1999/1400-1499/1400-1409/1408/verifierI.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func expected(n, k, c int, arr []int) string {
+	maxVal := 1 << c
+	counts := make([]int, maxVal)
+	var dfs func(int)
+	dfs = func(step int) {
+		if step == k {
+			xor := 0
+			for _, v := range arr {
+				xor ^= v
+			}
+			counts[xor]++
+			return
+		}
+		for i := 0; i < n; i++ {
+			arr[i]--
+			dfs(step + 1)
+			arr[i]++
+		}
+	}
+	dfs(0)
+	denom := modPow(int64(n), int64(k))
+	invDenom := modPow(denom, mod-2)
+	res := make([]string, maxVal)
+	for x := 0; x < maxVal; x++ {
+		val := int64(counts[x]) * invDenom % mod
+		res[x] = fmt.Sprint(val)
+	}
+	return strings.Join(res, " ")
+}
+
+func runProgram(bin, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) (string, int, int, int, []int) {
+	c := rng.Intn(3) + 1
+	maxVal := 1 << c
+	n := rng.Intn(3) + 1
+	k := rng.Intn(3) + 1
+	for n > maxVal-k {
+		n = rng.Intn(3) + 1
+	}
+	arr := make([]int, n)
+	used := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		v := rng.Intn(maxVal-k+1) + k
+		for used[v] {
+			v = rng.Intn(maxVal-k+1) + k
+		}
+		used[v] = true
+		arr[i] = v
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, c))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), n, k, c, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, n, k, c, arr := randomCase(rng)
+		want := expected(n, k, c, append([]int{}, arr...))
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, want, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier scripts for Codeforces contest 1408 problems A–I
- each verifier builds the reference solution, generates 100 random tests and checks another binary
- includes simple implementation of expected output for problem I

## Testing
- `go build verifierA.go`
- `./verifyA 1408A.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`

------
https://chatgpt.com/codex/tasks/task_e_6885fc8b86d883249dab0894b7d686fd