### PR TITLE
Add Go verifiers for contest 1411

### DIFF
--- a/1000-1999/1400-1499/1410-1419/1411/verifierA.go
+++ b/1000-1999/1400-1499/1410-1419/1411/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+"_"+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(100) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if rng.Intn(4) == 0 {
+				sb.WriteByte(')')
+			} else {
+				sb.WriteByte(byte('a' + rng.Intn(26)))
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candA")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1411A.go")
+	refPath, err := prepareBinary(refSrc, "refA")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1411/verifierB.go
+++ b/1000-1999/1400-1499/1410-1419/1411/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+"_"+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Int63n(1_000_000_000_000) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1411B.go")
+	refPath, err := prepareBinary(refSrc, "refB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1411/verifierC.go
+++ b/1000-1999/1400-1499/1410-1419/1411/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+"_"+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for caseNum := 0; caseNum < t; caseNum++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(n)
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		rows := rng.Perm(n)
+		cols := rng.Perm(n)
+		for i := 0; i < m; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", rows[i]+1, cols[i]+1))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candC")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1411C.go")
+	refPath, err := prepareBinary(refSrc, "refC")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1411/verifierD.go
+++ b/1000-1999/1400-1499/1410-1419/1411/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+"_"+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		r := rng.Intn(3)
+		switch r {
+		case 0:
+			sb.WriteByte('0')
+		case 1:
+			sb.WriteByte('1')
+		default:
+			sb.WriteByte('?')
+		}
+	}
+	x := rng.Intn(10)
+	y := rng.Intn(10)
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candD")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1411D.go")
+	refPath, err := prepareBinary(refSrc, "refD")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1411/verifierE.go
+++ b/1000-1999/1400-1499/1410-1419/1411/verifierE.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+"_"+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 2
+	var sb strings.Builder
+	T := rng.Int63n(1 << 20)
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, T))
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + rng.Intn(26)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1411E.go")
+	refPath, err := prepareBinary(refSrc, "refE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1411/verifierF.go
+++ b/1000-1999/1400-1499/1410-1419/1411/verifierF.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+"_"+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for caseNum := 0; caseNum < t; caseNum++ {
+		n := rng.Intn(8) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		p := rng.Perm(n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", p[i]+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candF")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1411F.go")
+	refPath, err := prepareBinary(refSrc, "refF")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1411/verifierG.go
+++ b/1000-1999/1400-1499/1410-1419/1411/verifierG.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+"_"+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var edges [][2]int
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			if rng.Intn(2) == 0 {
+				continue
+			}
+			edges = append(edges, [2]int{i, j})
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candG")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1411G.go")
+	refPath, err := prepareBinary(refSrc, "refG")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go – G implementation for problem 1411A
- add verifierB.go – verifier for problem 1411B
- add verifierC.go – verifier for problem 1411C
- add verifierD.go – verifier for problem 1411D
- add verifierE.go – verifier for problem 1411E
- add verifierF.go – verifier for problem 1411F
- add verifierG.go – verifier for problem 1411G

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6885fe2fd8048324ae6d48acac2204f5