### PR TITLE
Add verifiers for contest 1415

### DIFF
--- a/1000-1999/1400-1499/1410-1419/1415/verifierA.go
+++ b/1000-1999/1400-1499/1410-1419/1415/verifierA.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solveA(n, m, r, c int64) int64 {
+	d1 := abs(1-r) + abs(1-c)
+	d2 := abs(1-r) + abs(m-c)
+	d3 := abs(n-r) + abs(1-c)
+	d4 := abs(n-r) + abs(m-c)
+	ans := d1
+	if d2 > ans {
+		ans = d2
+	}
+	if d3 > ans {
+		ans = d3
+	}
+	if d4 > ans {
+		ans = d4
+	}
+	return ans
+}
+
+func runCase(bin string, n, m, r, c int64) error {
+	input := fmt.Sprintf("1\n%d %d %d %d\n", n, m, r, c)
+	expect := fmt.Sprintf("%d", solveA(n, m, r, c))
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if out != expect {
+		return fmt.Errorf("expected %s got %s", expect, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	total := 0
+
+	// some edge cases
+	edges := [][4]int64{
+		{1, 1, 1, 1},
+		{1, 5, 1, 3},
+		{5, 1, 2, 1},
+		{5, 5, 5, 5},
+		{10, 10, 1, 10},
+	}
+	for _, e := range edges {
+		if err := runCase(bin, e[0], e[1], e[2], e[3]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+			os.Exit(1)
+		}
+		total++
+	}
+
+	for total < 100 {
+		n := rng.Int63n(1000) + 1
+		m := rng.Int63n(1000) + 1
+		r := rng.Int63n(n) + 1
+		c := rng.Int63n(m) + 1
+		if err := runCase(bin, n, m, r, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (n=%d m=%d r=%d c=%d)\n", total+1, err, n, m, r, c)
+			os.Exit(1)
+		}
+		total++
+	}
+	fmt.Printf("All %d tests passed\n", total)
+}

--- a/1000-1999/1400-1499/1410-1419/1415/verifierB.go
+++ b/1000-1999/1400-1499/1410-1419/1415/verifierB.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveB(n, k int, c []int) int {
+	present := make(map[int]struct{})
+	for _, v := range c {
+		present[v] = struct{}{}
+	}
+	ans := n + 1
+	for color := range present {
+		days := 0
+		for i := 0; i < n; {
+			if c[i] == color {
+				i++
+			} else {
+				days++
+				i += k
+			}
+		}
+		if days < ans {
+			ans = days
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, n, k int, c []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c[i]))
+	}
+	sb.WriteByte('\n')
+	expect := fmt.Sprintf("%d", solveB(n, k, c))
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	if out != expect {
+		return fmt.Errorf("expected %s got %s", expect, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	total := 0
+	// some edge cases
+	edgeCases := []struct {
+		n, k int
+		c    []int
+	}{
+		{1, 1, []int{1}},
+		{3, 2, []int{1, 1, 1}},
+		{5, 1, []int{1, 2, 3, 4, 5}},
+		{4, 4, []int{2, 2, 2, 2}},
+	}
+	for _, ec := range edgeCases {
+		if err := runCase(bin, ec.n, ec.k, ec.c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+			os.Exit(1)
+		}
+		total++
+	}
+	for total < 100 {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(n) + 1
+		c := make([]int, n)
+		for i := 0; i < n; i++ {
+			c[i] = rng.Intn(5) + 1
+		}
+		if err := runCase(bin, n, k, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+			os.Exit(1)
+		}
+		total++
+	}
+	fmt.Printf("All %d tests passed\n", total)
+}

--- a/1000-1999/1400-1499/1410-1419/1415/verifierC.go
+++ b/1000-1999/1400-1499/1410-1419/1415/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(n, p, k int, s string, x, y int64) int64 {
+	a := []byte(s)
+	dp := make([]int64, n)
+	for i := n - 1; i >= 0; i-- {
+		add := int64(0)
+		if a[i] == '0' {
+			add = 1
+		}
+		if i+k < n {
+			dp[i] = add + dp[i+k]
+		} else {
+			dp[i] = add
+		}
+	}
+	ans := int64(1 << 62)
+	for d := 0; p-1+d < n; d++ {
+		idx := p - 1 + d
+		cost := int64(d)*y + dp[idx]*x
+		if cost < ans {
+			ans = cost
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, n, p, k int, s string, x, y int64) error {
+	input := fmt.Sprintf("1\n%d %d %d\n%s\n%d %d\n", n, p, k, s, x, y)
+	expect := fmt.Sprintf("%d", solveC(n, p, k, s, x, y))
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if out != expect {
+		return fmt.Errorf("expected %s got %s", expect, out)
+	}
+	return nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	total := 0
+	// edge cases
+	if err := runCase(bin, 1, 1, 1, "0", 1, 1); err != nil {
+		fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+		os.Exit(1)
+	}
+	total++
+	if err := runCase(bin, 5, 2, 2, "11001", 3, 4); err != nil {
+		fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+		os.Exit(1)
+	}
+	total++
+	for total < 100 {
+		n := rng.Intn(20) + 1
+		p := rng.Intn(n) + 1
+		k := rng.Intn(n) + 1
+		s := randString(rng, n)
+		x := int64(rng.Intn(10) + 1)
+		y := int64(rng.Intn(10) + 1)
+		if err := runCase(bin, n, p, k, s, x, y); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+			os.Exit(1)
+		}
+		total++
+	}
+	fmt.Printf("All %d tests passed\n", total)
+}

--- a/1000-1999/1400-1499/1410-1419/1415/verifierD.go
+++ b/1000-1999/1400-1499/1410-1419/1415/verifierD.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(a []int) int {
+	n := len(a)
+	if n > 130 {
+		return 1
+	}
+	px := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		px[i] = px[i-1] ^ a[i-1]
+	}
+	const INF = int(1e9)
+	ans := INF
+	for l := 1; l <= n; l++ {
+		for r := l + 1; r <= n; r++ {
+			for i := l; i < r; i++ {
+				left := px[i] ^ px[l-1]
+				right := px[r] ^ px[i]
+				if left > right {
+					ops := r - l - 1
+					if ops < ans {
+						ans = ops
+					}
+				}
+			}
+		}
+	}
+	if ans == INF {
+		return -1
+	}
+	return ans
+}
+
+func runCase(bin string, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i := 0; i < len(arr); i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	expect := fmt.Sprintf("%d", solveD(arr))
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	if out != expect {
+		return fmt.Errorf("expected %s got %s", expect, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	total := 0
+	// edge cases
+	if err := runCase(bin, []int{1, 2}); err != nil {
+		fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+		os.Exit(1)
+	}
+	total++
+	if err := runCase(bin, []int{1, 1, 1}); err != nil {
+		fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+		os.Exit(1)
+	}
+	total++
+	for total < 100 {
+		n := rng.Intn(20) + 2
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rng.Intn(1000)
+		}
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+			os.Exit(1)
+		}
+		total++
+	}
+	fmt.Printf("All %d tests passed\n", total)
+}

--- a/1000-1999/1400-1499/1410-1419/1415/verifierE.go
+++ b/1000-1999/1400-1499/1410-1419/1415/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(n, k int, a []int) int64 {
+	sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+	cntNeg := 0
+	for _, v := range a {
+		if v < 0 {
+			cntNeg++
+		}
+	}
+	p := k
+	if p > cntNeg {
+		p = cntNeg
+	}
+	mainSize := n - p
+	var ans int64
+	for i := 0; i < mainSize; i++ {
+		mult := mainSize - i - 1
+		ans += int64(a[i]) * int64(mult)
+	}
+	return ans
+}
+
+func runCase(bin string, n, k int, a []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	expect := fmt.Sprintf("%d", solveE(n, k, append([]int(nil), a...)))
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	if out != expect {
+		return fmt.Errorf("expected %s got %s", expect, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	total := 0
+	// edge cases
+	if err := runCase(bin, 1, 0, []int{5}); err != nil {
+		fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+		os.Exit(1)
+	}
+	total++
+	if err := runCase(bin, 3, 1, []int{-1, 2, -3}); err != nil {
+		fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+		os.Exit(1)
+	}
+	total++
+	for total < 100 {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(n + 1)
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rng.Intn(21) - 10
+		}
+		if err := runCase(bin, n, k, a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+			os.Exit(1)
+		}
+		total++
+	}
+	fmt.Printf("All %d tests passed\n", total)
+}

--- a/1000-1999/1400-1499/1410-1419/1415/verifierF.go
+++ b/1000-1999/1400-1499/1410-1419/1415/verifierF.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solveF(n int, tVals, xVals []int64) bool {
+	for c := 0; c <= n; c++ {
+		p := make([]int, 0, n+1)
+		p = append(p, 0)
+		for i := 1; i <= n; i++ {
+			if i == c {
+				continue
+			}
+			p = append(p, i)
+		}
+		ok := true
+		for k := 0; k+1 < len(p); k++ {
+			i := p[k]
+			j := p[k+1]
+			dt := tVals[j] - tVals[i]
+			if c != 0 && i < c && c < j {
+				need := abs(xVals[c]-xVals[i]) + abs(xVals[j]-xVals[c])
+				if dt < need {
+					ok = false
+					break
+				}
+			} else {
+				if dt < abs(xVals[j]-xVals[i]) {
+					ok = false
+					break
+				}
+			}
+		}
+		if !ok {
+			continue
+		}
+		if c > 0 {
+			prev := 0
+			for i := 1; i < c; i++ {
+				if i != c {
+					prev = i
+				}
+			}
+			if prev == p[len(p)-1] {
+				if tVals[c]-tVals[prev] < abs(xVals[c]-xVals[prev]) {
+					ok = false
+				}
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+func runCase(bin string, n int, tVals, xVals []int64) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", tVals[i], xVals[i]))
+	}
+	expect := "NO"
+	if solveF(n, tVals, xVals) {
+		expect = "YES"
+	}
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	if out != expect {
+		return fmt.Errorf("expected %s got %s", expect, out)
+	}
+	return nil
+}
+
+func uniqueRandInts(rng *rand.Rand, n int, low, high int64) []int64 {
+	m := make(map[int64]struct{})
+	res := make([]int64, 0, n)
+	for len(res) < n {
+		v := rng.Int63n(high-low+1) + low
+		if _, ok := m[v]; ok {
+			continue
+		}
+		m[v] = struct{}{}
+		res = append(res, v)
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	total := 0
+	// edge case
+	tVals := []int64{0, 1}
+	xVals := []int64{0, 0}
+	if err := runCase(bin, 1, tVals, xVals); err != nil {
+		fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+		os.Exit(1)
+	}
+	total++
+	for total < 100 {
+		n := rng.Intn(6) + 1
+		tVals = make([]int64, n+1)
+		xVals = make([]int64, n+1)
+		curT := int64(0)
+		for i := 1; i <= n; i++ {
+			curT += int64(rng.Intn(5) + 1)
+			tVals[i] = curT
+		}
+		coords := uniqueRandInts(rng, n, -10, 10)
+		for i := 1; i <= n; i++ {
+			xVals[i] = coords[i-1]
+		}
+		if err := runCase(bin, n, tVals, xVals); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
+			os.Exit(1)
+		}
+		total++
+	}
+	fmt.Printf("All %d tests passed\n", total)
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for contest 1415 problems A–F
- each verifier runs the provided binary (or Go source via `go run`)
- verifiers generate at least 100 test cases with some edge cases

## Testing
- `go build 1000-1999/1400-1499/1410-1419/1415/verifierA.go`
- `go build 1000-1999/1400-1499/1410-1419/1415/verifierB.go`
- `go build 1000-1999/1400-1499/1410-1419/1415/verifierC.go`
- `go build 1000-1999/1400-1499/1410-1419/1415/verifierD.go`
- `go build 1000-1999/1400-1499/1410-1419/1415/verifierE.go`
- `go build 1000-1999/1400-1499/1410-1419/1415/verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_688600603db08324be9225b808bb9a51