### PR TITLE
Add verifiers for CF 1416

### DIFF
--- a/1000-1999/1400-1499/1410-1419/1416/verifierA.go
+++ b/1000-1999/1400-1499/1410-1419/1416/verifierA.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func kAmazing(a []int) []int {
+	n := len(a)
+	lastPos := make([]int, n+1)
+	maxGap := make([]int, n+1)
+	seen := make([]bool, n+1)
+	for i := 1; i <= n; i++ {
+		x := a[i-1]
+		gap := i - lastPos[x]
+		if gap > maxGap[x] {
+			maxGap[x] = gap
+		}
+		lastPos[x] = i
+		seen[x] = true
+	}
+	for x := 1; x <= n; x++ {
+		if !seen[x] {
+			continue
+		}
+		gap := (n + 1) - lastPos[x]
+		if gap > maxGap[x] {
+			maxGap[x] = gap
+		}
+	}
+	const inf = int(1e9)
+	best := make([]int, n+2)
+	for i := range best {
+		best[i] = inf
+	}
+	for x := 1; x <= n; x++ {
+		if !seen[x] {
+			continue
+		}
+		k := maxGap[x]
+		if x < best[k] {
+			best[k] = x
+		}
+	}
+	res := make([]int, n)
+	curr := inf
+	for k := 1; k <= n; k++ {
+		if best[k] < curr {
+			curr = best[k]
+		}
+		if curr == inf {
+			res[k-1] = -1
+		} else {
+			res[k-1] = curr
+		}
+	}
+	return res
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(20) + 1
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rand.Intn(n) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		got, err := runBinary(binary, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		expectArr := kAmazing(a)
+		expectFields := make([]string, len(expectArr))
+		for i, v := range expectArr {
+			expectFields[i] = fmt.Sprintf("%d", v)
+		}
+		expectStr := strings.Join(expectFields, " ")
+		if got != expectStr {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\nexpected: %s\ngot: %s\n", t, expectStr, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1416/verifierB.go
+++ b/1000-1999/1400-1499/1410-1419/1416/verifierB.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = nil
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(2)
+	for tcase := 1; tcase <= 100; tcase++ {
+		n := rand.Intn(4) + 2 // 2..5
+		a := make([]int64, n+1)
+		for i := 1; i <= n; i++ {
+			a[i] = int64(rand.Intn(20) + 1)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		out, err := runBinary(binary, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", tcase, err)
+			os.Exit(1)
+		}
+		sum := int64(0)
+		for i := 1; i <= n; i++ {
+			sum += a[i]
+		}
+		scanner := bufio.NewScanner(strings.NewReader(out))
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "invalid output on test %d\n", tcase)
+			os.Exit(1)
+		}
+		firstFields := strings.Fields(scanner.Text())
+		if sum%int64(n) != 0 {
+			if len(firstFields) != 1 || firstFields[0] != "-1" {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected -1\n", tcase)
+				os.Exit(1)
+			}
+			continue
+		}
+		if len(firstFields) != 1 {
+			fmt.Fprintf(os.Stderr, "invalid output on test %d\n", tcase)
+			os.Exit(1)
+		}
+		k, err := strconv.Atoi(firstFields[0])
+		if err != nil || k < 0 || k > 3*n {
+			fmt.Fprintf(os.Stderr, "invalid k on test %d\n", tcase)
+			os.Exit(1)
+		}
+		for op := 0; op < k; op++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "not enough operations on test %d\n", tcase)
+				os.Exit(1)
+			}
+			f := strings.Fields(scanner.Text())
+			if len(f) != 3 {
+				fmt.Fprintf(os.Stderr, "invalid operation format on test %d\n", tcase)
+				os.Exit(1)
+			}
+			i, _ := strconv.Atoi(f[0])
+			j, _ := strconv.Atoi(f[1])
+			x, _ := strconv.Atoi(f[2])
+			if i < 1 || i > n || j < 1 || j > n || x < 0 {
+				fmt.Fprintf(os.Stderr, "operation out of range on test %d\n", tcase)
+				os.Exit(1)
+			}
+			val := int64(x) * int64(i)
+			if a[i] < val {
+				fmt.Fprintf(os.Stderr, "negative value on test %d\n", tcase)
+				os.Exit(1)
+			}
+			a[i] -= val
+			a[j] += val
+		}
+		if scanner.Scan() {
+			extra := strings.TrimSpace(scanner.Text())
+			if extra != "" {
+				fmt.Fprintf(os.Stderr, "extra output on test %d\n", tcase)
+				os.Exit(1)
+			}
+		}
+		avg := a[1]
+		for i := 2; i <= n; i++ {
+			if a[i] != avg {
+				fmt.Fprintf(os.Stderr, "array not equal on test %d\n", tcase)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1416/verifierC.go
+++ b/1000-1999/1400-1499/1410-1419/1416/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const maxBit = 30
+
+func dfsC(a []int, bit int, cnt01, cnt10 []int64) {
+	if bit < 0 || len(a) < 2 {
+		return
+	}
+	v0 := make([]int, 0, len(a))
+	v1 := make([]int, 0, len(a))
+	var zeros, ones int64
+	for _, v := range a {
+		if (v>>bit)&1 == 1 {
+			cnt01[bit] += zeros
+			ones++
+			v1 = append(v1, v)
+		} else {
+			cnt10[bit] += ones
+			zeros++
+			v0 = append(v0, v)
+		}
+	}
+	dfsC(v0, bit-1, cnt01, cnt10)
+	dfsC(v1, bit-1, cnt01, cnt10)
+}
+
+func solveC(a []int) (int64, int64) {
+	cnt01 := make([]int64, maxBit+1)
+	cnt10 := make([]int64, maxBit+1)
+	dfsC(a, maxBit, cnt01, cnt10)
+	var x, inv int64
+	for b := 0; b <= maxBit; b++ {
+		if cnt10[b] <= cnt01[b] {
+			inv += cnt10[b]
+		} else {
+			inv += cnt01[b]
+			x |= 1 << b
+		}
+	}
+	return inv, x
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(3)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(20) + 1
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rand.Intn(1000)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		got, err := runBinary(binary, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		inv, x := solveC(a)
+		expected := fmt.Sprintf("%d %d", inv, x)
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\nexpected: %s\ngot: %s\n", t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1416/verifierD.go
+++ b/1000-1999/1400-1499/1410-1419/1416/verifierD.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Edge struct {
+	a int
+	b int
+}
+
+type Query struct {
+	typ int
+	arg int
+}
+
+func runProg(prog string, args []string, input string) (string, error) {
+	cmd := exec.Command(prog, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(4)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(4) + 1
+		maxEdges := n * (n - 1) / 2
+		m := rand.Intn(maxEdges) + 1
+		perm := rand.Perm(n)
+		p := make([]int, n+1)
+		for i := 0; i < n; i++ {
+			p[i+1] = perm[i] + 1
+		}
+		edges := make([]Edge, 0, m)
+		seen := make(map[[2]int]bool)
+		for len(edges) < m {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			key := [2]int{u, v}
+			if !seen[key] {
+				seen[key] = true
+				edges = append(edges, Edge{u, v})
+			}
+		}
+		q := rand.Intn(m+3) + 1
+		queries := make([]Query, 0, q)
+		remaining := make([]int, m)
+		for i := 0; i < m; i++ {
+			remaining[i] = i + 1
+		}
+		for len(queries) < q {
+			if len(remaining) == 0 || rand.Intn(2) == 0 {
+				v := rand.Intn(n) + 1
+				queries = append(queries, Query{1, v})
+			} else {
+				idx := rand.Intn(len(remaining))
+				e := remaining[idx]
+				remaining = append(remaining[:idx], remaining[idx+1:]...)
+				queries = append(queries, Query{2, e})
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", p[i]))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e.a, e.b))
+		}
+		for _, qq := range queries {
+			sb.WriteString(fmt.Sprintf("%d %d\n", qq.typ, qq.arg))
+		}
+		input := sb.String()
+		candOut, err := runProg(binary, nil, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		refOut, err := runProg("go", []string{"run", "1416D.go"}, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\nexpected: %s\ngot: %s\n", t, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1416/verifierE.go
+++ b/1000-1999/1400-1499/1410-1419/1416/verifierE.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveE(a []int) int {
+	M := 0
+	r := 0
+	for _, x := range a {
+		if r > 0 && r < x {
+			v := x - r
+			if v == r {
+				M += 2
+			} else {
+				M++
+			}
+			r = v
+		} else {
+			if x%2 == 0 {
+				M++
+				r = x / 2
+			} else {
+				r = 1
+			}
+		}
+	}
+	return 2*len(a) - M
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(5)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(20) + 1
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rand.Intn(100) + 2
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		out, err := runBinary(binary, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		expected := fmt.Sprintf("%d", solveE(a))
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\nexpected: %s\ngot: %s\n", t, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1416/verifierF.go
+++ b/1000-1999/1400-1499/1410-1419/1416/verifierF.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(prog string, args []string, input string) (string, error) {
+	cmd := exec.Command(prog, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(6)
+	for tcase := 1; tcase <= 100; tcase++ {
+		n := rand.Intn(3) + 1
+		m := rand.Intn(3) + 1
+		size := n * m
+		a := make([]int, size)
+		for i := range a {
+			a[i] = rand.Intn(50) + 2
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", a[i*m+j]))
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		candOut, err := runProg(binary, nil, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", tcase, err)
+			os.Exit(1)
+		}
+		refOut, err := runProg("go", []string{"run", "1416F.go"}, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", tcase, err)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\nexpected: %s\ngot: %s\n", tcase, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of Codeforces Round 1416
- each verifier generates 100 random tests
- results are compared with reference solutions (or validated directly)

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688600ec334883248378b738d16b8e8a