### PR TITLE
fix 573B verifier usage

### DIFF
--- a/0-999/500-599/570-579/573/verifierB.go
+++ b/0-999/500-599/570-579/573/verifierB.go
@@ -63,7 +63,8 @@ func genTests() []string {
 
 func main() {
 	if len(os.Args) != 2 {
-		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		fmt.Println("usage: go run verifierB.go -- /path/to/solution")
+		fmt.Println("       (pass a compiled binary or a .go file)")
 		os.Exit(1)
 	}
 	candPath, err := prepareBinary(os.Args[1], "candB")

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ All Go utilities build with the standard tooling. Example:
 
 ```bash
 cd 1000-1999/1900-1999/1990-1999/1994
-go run verifierA.go ./1994A
+go build -o solA 1994A.go
+go run verifierA.go ./solA
 ```
 
 This repository aims to provide a complete archive. We expect to have all solutions and verifiers within a week. Feel free to use the code or utilities as a reference for your own workflow.
@@ -32,8 +33,10 @@ example, contest 90 provides verifiers for problems A and B:
 
 ```bash
 cd 0-999/0-99/90-99/90
-go run verifierA.go ./mySolutionA
-go run verifierB.go ./mySolutionB
+go build -o myA mySolutionA.go
+go build -o myB mySolutionB.go
+go run verifierA.go ./myA
+go run verifierB.go ./myB
 ```
 
 ## Running the local webserver


### PR DESCRIPTION
## Summary
- clarify how to pass candidate programs to `verifierB.go`
- update README examples to build solutions before verification

## Testing
- `go build 0-999/500-599/570-579/573/verifierB.go`


------
https://chatgpt.com/codex/tasks/task_e_6886024ae4208324915fbe9e7a0babfb