### PR TITLE
Add Go solution for 1594E1

### DIFF
--- a/1000-1999/1500-1599/1590-1599/1594/1594E1.go
+++ b/1000-1999/1500-1599/1590-1599/1594/1594E1.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 1e9 + 7
+
+func powMod(base, exp int64) int64 {
+	base %= mod
+	res := int64(1)
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res * base % mod
+		}
+		base = base * base % mod
+		exp >>= 1
+	}
+	return res
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var k int64
+	fmt.Fscan(reader, &k)
+
+	exp := (int64(1) << (k + 1)) - 3
+	ans := powMod(2, exp) * 3 % mod
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem E1 of contest 1594
- compute the total number of valid colorings via a closed form

## Testing
- `gofmt -w 1000-1999/1500-1599/1590-1599/1594/1594E1.go`


------
https://chatgpt.com/codex/tasks/task_e_688603ee9ed08324befc58cdf4cdb360