### PR TITLE
Add Go verifiers for contest 1421

### DIFF
--- a/1000-1999/1400-1499/1420-1429/1421/verifierA.go
+++ b/1000-1999/1400-1499/1420-1429/1421/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	pairs [][2]int
+}
+
+func buildCase(pairs [][2]int) testCase {
+	return testCase{pairs: pairs}
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(10) + 1
+	pairs := make([][2]int, t)
+	for i := 0; i < t; i++ {
+		a := rng.Intn(1_000_000_000)
+		b := rng.Intn(1_000_000_000)
+		pairs[i] = [2]int{a, b}
+	}
+	return buildCase(pairs)
+}
+
+func expected(tc testCase) []int {
+	res := make([]int, len(tc.pairs))
+	for i, p := range tc.pairs {
+		res[i] = p[0] ^ p[1]
+	}
+	return res
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.pairs))
+	for _, p := range tc.pairs {
+		fmt.Fprintf(&sb, "%d %d\n", p[0], p[1])
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	exp := expected(tc)
+	if len(fields) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(fields))
+	}
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("expected %v got %v", exp, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase([][2]int{{6, 12}}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			var sb strings.Builder
+			fmt.Fprintf(&sb, "%d\n", len(tc.pairs))
+			for _, p := range tc.pairs {
+				fmt.Fprintf(&sb, "%d %d\n", p[0], p[1])
+			}
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1420-1429/1421/verifierB.go
+++ b/1000-1999/1400-1499/1420-1429/1421/verifierB.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	grid []string
+}
+
+func buildCase(grid []string) testCase {
+	return testCase{grid: grid}
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 3 // 3..7
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if i == 0 && j == 0 {
+				row[j] = 'S'
+			} else if i == n-1 && j == n-1 {
+				row[j] = 'F'
+			} else {
+				if rng.Intn(2) == 0 {
+					row[j] = '0'
+				} else {
+					row[j] = '1'
+				}
+			}
+		}
+		grid[i] = string(row)
+	}
+	return buildCase(grid)
+}
+
+func reachable(grid [][]byte, digit byte) bool {
+	n := len(grid)
+	type pair struct{ r, c int }
+	q := []pair{{0, 0}}
+	vis := make([][]bool, n)
+	for i := range vis {
+		vis[i] = make([]bool, n)
+	}
+	vis[0][0] = true
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		if cur.r == n-1 && cur.c == n-1 {
+			return true
+		}
+		for _, d := range dirs {
+			nr := cur.r + d[0]
+			nc := cur.c + d[1]
+			if nr >= 0 && nr < n && nc >= 0 && nc < n && !vis[nr][nc] {
+				ch := grid[nr][nc]
+				if nr == 0 && nc == 0 || nr == n-1 && nc == n-1 || ch == digit {
+					vis[nr][nc] = true
+					q = append(q, pair{nr, nc})
+				}
+			}
+		}
+	}
+	return false
+}
+
+func applyOps(grid [][]byte, ops [][2]int) error {
+	n := len(grid)
+	seen := make(map[[2]int]bool)
+	for _, op := range ops {
+		r, c := op[0], op[1]
+		if r <= 0 || r > n || c <= 0 || c > n {
+			return fmt.Errorf("invalid coordinates")
+		}
+		if (r == 1 && c == 1) || (r == n && c == n) {
+			return fmt.Errorf("cannot modify start or end")
+		}
+		key := [2]int{r, c}
+		if seen[key] {
+			return fmt.Errorf("duplicate cell")
+		}
+		seen[key] = true
+		r--
+		c--
+		if grid[r][c] == '0' {
+			grid[r][c] = '1'
+		} else if grid[r][c] == '1' {
+			grid[r][c] = '0'
+		} else {
+			return fmt.Errorf("invalid cell value")
+		}
+	}
+	return nil
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	n := len(tc.grid)
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, row := range tc.grid {
+		sb.WriteString(row + "\n")
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	c, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid first number: %v", err)
+	}
+	if c < 0 || c > 2 {
+		return fmt.Errorf("operations count out of range")
+	}
+	if len(fields) != 1+2*c {
+		return fmt.Errorf("expected %d coordinates got %d", 2*c, len(fields)-1)
+	}
+	ops := make([][2]int, c)
+	idx := 1
+	for i := 0; i < c; i++ {
+		r, err1 := strconv.Atoi(fields[idx])
+		s, err2 := strconv.Atoi(fields[idx+1])
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("bad coordinates")
+		}
+		ops[i] = [2]int{r, s}
+		idx += 2
+	}
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		grid[i] = []byte(tc.grid[i])
+	}
+	if err := applyOps(grid, ops); err != nil {
+		return err
+	}
+	if reachable(grid, '0') || reachable(grid, '1') {
+		return fmt.Errorf("path still exists")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	// simple deterministic case
+	cases = append(cases, buildCase([]string{"S0", "0F"}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			var sb strings.Builder
+			n := len(tc.grid)
+			sb.WriteString("1\n")
+			sb.WriteString(fmt.Sprintf("%d\n", n))
+			for _, row := range tc.grid {
+				sb.WriteString(row + "\n")
+			}
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1420-1429/1421/verifierC.go
+++ b/1000-1999/1400-1499/1420-1429/1421/verifierC.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	s string
+}
+
+func buildCase(s string) testCase { return testCase{s: s} }
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 3 // length 3..22
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return buildCase(string(b))
+}
+
+func reverseBytes(b []byte) []byte {
+	res := make([]byte, len(b))
+	for i := range b {
+		res[i] = b[len(b)-1-i]
+	}
+	return res
+}
+
+func applyOp(s []byte, opType string, idx int) ([]byte, error) {
+	if idx < 2 || idx > len(s)-1 {
+		return nil, fmt.Errorf("index out of range")
+	}
+	if opType == "L" {
+		prefix := reverseBytes(s[1:idx])
+		s = append(prefix, s...)
+	} else if opType == "R" {
+		suffix := reverseBytes(s[idx-1 : len(s)-1])
+		s = append(s, suffix...)
+	} else {
+		return nil, fmt.Errorf("bad op type")
+	}
+	if len(s) > 1_000_000 {
+		return nil, fmt.Errorf("length exceeds limit")
+	}
+	return s, nil
+}
+
+func isPalindrome(b []byte) bool {
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		if b[i] != b[j] {
+			return false
+		}
+	}
+	return true
+}
+
+func runCase(bin string, tc testCase) error {
+	input := tc.s + "\n"
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(scanner.Text())
+	if err != nil {
+		return fmt.Errorf("bad k: %v", err)
+	}
+	if k < 0 || k > 30 {
+		return fmt.Errorf("k out of range")
+	}
+	type operation struct {
+		typ string
+		idx int
+	}
+	ops := make([]operation, k)
+	for i := 0; i < k; i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("incomplete op type")
+		}
+		typ := scanner.Text()
+		if !scanner.Scan() {
+			return fmt.Errorf("incomplete op index")
+		}
+		idxStr := scanner.Text()
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil {
+			return fmt.Errorf("bad index: %v", err)
+		}
+		ops[i] = operation{typ: typ, idx: idx}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	b := []byte(tc.s)
+	for _, op := range ops {
+		typ := op.typ
+		idx := op.idx
+		var err error
+		b, err = applyOp(b, typ, idx)
+		if err != nil {
+			return err
+		}
+	}
+	if !isPalindrome(b) {
+		return fmt.Errorf("result is not palindrome")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase("abac"))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", idx+1, err, tc.s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1420-1429/1421/verifierD.go
+++ b/1000-1999/1400-1499/1420-1429/1421/verifierD.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	x, y int64
+	c    [7]int64
+}
+
+func buildCase(x, y int64, c [7]int64) testCase {
+	return testCase{x: x, y: y, c: c}
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	x := rng.Int63n(2_000_000_001) - 1_000_000_000
+	y := rng.Int63n(2_000_000_001) - 1_000_000_000
+	var c [7]int64
+	for i := 1; i <= 6; i++ {
+		c[i] = rng.Int63n(1_000_000_000) + 1
+	}
+	return buildCase(x, y, c)
+}
+
+func solve(tc testCase) int64 {
+	x := tc.x
+	y := tc.y
+	c := tc.c
+	for it := 0; it < 6; it++ {
+		for i := 1; i <= 6; i++ {
+			left := i - 1
+			if left == 0 {
+				left = 6
+			}
+			right := i + 1
+			if right == 7 {
+				right = 1
+			}
+			if c[i] > c[left]+c[right] {
+				c[i] = c[left] + c[right]
+			}
+		}
+	}
+	var ans int64
+	switch {
+	case x >= 0 && y >= 0:
+		k := x
+		if y < k {
+			k = y
+		}
+		ans += k * c[1]
+		x -= k
+		y -= k
+		if x > 0 {
+			ans += x * c[6]
+		} else if y > 0 {
+			ans += y * c[2]
+		}
+	case x <= 0 && y <= 0:
+		xx := -x
+		yy := -y
+		k := xx
+		if yy < k {
+			k = yy
+		}
+		ans += k * c[4]
+		xx -= k
+		yy -= k
+		if xx > 0 {
+			ans += xx * c[3]
+		} else if yy > 0 {
+			ans += yy * c[5]
+		}
+	case x >= 0 && y <= 0:
+		ans += x * c[6]
+		ans += -y * c[5]
+	case x <= 0 && y >= 0:
+		ans += y * c[2]
+		ans += -x * c[3]
+	}
+	return ans
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", tc.x, tc.y)
+	for i := 1; i <= 6; i++ {
+		fmt.Fprintf(&sb, "%d ", tc.c[i])
+	}
+	sb.WriteString("\n")
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(gotStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := solve(tc)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	c0 := [7]int64{}
+	for i := 1; i <= 6; i++ {
+		c0[i] = int64(i)
+	}
+	cases = append(cases, buildCase(1, 1, c0))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			var sb strings.Builder
+			sb.WriteString("1\n")
+			fmt.Fprintf(&sb, "%d %d\n", tc.x, tc.y)
+			for i := 1; i <= 6; i++ {
+				fmt.Fprintf(&sb, "%d ", tc.c[i])
+			}
+			sb.WriteString("\n")
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1420-1429/1421/verifierE.go
+++ b/1000-1999/1400-1499/1420-1429/1421/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	a []int64
+}
+
+func buildCase(a []int64) testCase { return testCase{a: a} }
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = rng.Int63n(2_000_000_001) - 1_000_000_000
+	}
+	return buildCase(arr)
+}
+
+func solve(tc testCase) int64 {
+	n := len(tc.a)
+	if n == 1 {
+		return tc.a[0]
+	}
+	if n == 2 {
+		return -(tc.a[0] + tc.a[1])
+	}
+	var sumAbs int64
+	minAbs := tc.a[0]
+	if minAbs < 0 {
+		minAbs = -minAbs
+	}
+	for _, v := range tc.a {
+		val := v
+		if val < 0 {
+			val = -val
+		}
+		sumAbs += val
+		if val < minAbs {
+			minAbs = val
+		}
+	}
+	if n%2 == 1 {
+		return sumAbs - 2*minAbs
+	}
+	return sumAbs
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.a))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteString("\n")
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(gotStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := solve(tc)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase([]int64{5, 6, 7, 8}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			var sb strings.Builder
+			fmt.Fprintf(&sb, "%d\n", len(tc.a))
+			for i, v := range tc.a {
+				if i > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprintf(&sb, "%d", v)
+			}
+			sb.WriteString("\n")
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new verifiers for problems A–E of contest 1421
- each verifier runs at least 100 randomized tests and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go run verifierA.go ./1421A`

------
https://chatgpt.com/codex/tasks/task_e_688603a898748324a2f8147ef0e99ea1