### PR TITLE
Add Go verifiers for CF 1413

### DIFF
--- a/1000-1999/1400-1499/1410-1419/1413/verifierA.go
+++ b/1000-1999/1400-1499/1410-1419/1413/verifierA.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveA(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	var sb strings.Builder
+	nextInt := func() int64 {
+		if !in.Scan() {
+			return 0
+		}
+		v, _ := strconv.ParseInt(in.Text(), 10, 64)
+		return v
+	}
+	t := nextInt()
+	for ; t > 0; t-- {
+		n := int(nextInt())
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			a[i] = nextInt()
+		}
+		// reverse a
+		for i, j := 0, n-1; i < j; i, j = i+1, j-1 {
+			a[i], a[j] = a[j], a[i]
+		}
+		res := make([]int64, n)
+		for i := 0; i < n; i++ {
+			if 2*i < n {
+				res[i] = -a[i]
+			} else {
+				res[i] = a[i]
+			}
+		}
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(res[i], 10))
+		}
+		if t > 1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8/2)*2 + 2 // even between 2 and 10
+		a := make([]int64, n)
+		for j := 0; j < n; j++ {
+			v := int64(rng.Intn(200) - 100)
+			if v == 0 {
+				v = 1
+			}
+			a[j] = v
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(a[j], 10))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := solveA(input)
+		tests[i] = testCase{input: input, expect: expect}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			return
+		}
+		if out != tc.expect {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expect, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1413/verifierB.go
+++ b/1000-1999/1400-1499/1410-1419/1413/verifierB.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// testCase structure
+type testCase struct {
+	input  string
+	expect string
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveB(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	var sb strings.Builder
+	nextInt := func() int {
+		if !in.Scan() {
+			return 0
+		}
+		v, _ := strconv.Atoi(in.Text())
+		return v
+	}
+	t := nextInt()
+	for ; t > 0; t-- {
+		n, m := nextInt(), nextInt()
+		rows := make([][]int, n)
+		elemToRow := make(map[int]int)
+		for i := 0; i < n; i++ {
+			row := make([]int, m)
+			for j := 0; j < m; j++ {
+				row[j] = nextInt()
+				elemToRow[row[j]] = i
+			}
+			rows[i] = row
+		}
+		cols := make([][]int, m)
+		for j := 0; j < m; j++ {
+			col := make([]int, n)
+			for i := 0; i < n; i++ {
+				col[i] = nextInt()
+			}
+			cols[j] = col
+		}
+		order := make([]int, n)
+		for i := 0; i < n; i++ {
+			order[i] = elemToRow[cols[0][i]]
+		}
+		for _, idx := range order {
+			row := rows[idx]
+			for j, v := range row {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(strconv.Itoa(v))
+			}
+			if t > 1 || idx != order[len(order)-1] {
+				sb.WriteByte('\n')
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(3) + 1
+		matrix := make([][]int, n)
+		val := 1
+		for r := 0; r < n; r++ {
+			row := make([]int, m)
+			for c := 0; c < m; c++ {
+				row[c] = val
+				val++
+			}
+			matrix[r] = row
+		}
+		rows := make([][]int, n)
+		permRows := rand.Perm(n)
+		for i2, pr := range permRows {
+			rows[i2] = matrix[pr]
+		}
+		cols := make([][]int, m)
+		// build columns
+		baseCols := make([][]int, m)
+		for c := 0; c < m; c++ {
+			col := make([]int, n)
+			for r := 0; r < n; r++ {
+				col[r] = matrix[r][c]
+			}
+			baseCols[c] = col
+		}
+		permCols := rand.Perm(m)
+		for i2, pc := range permCols {
+			cols[i2] = baseCols[pc]
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for r := 0; r < n; r++ {
+			for c := 0; c < m; c++ {
+				if c > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(strconv.Itoa(rows[r][c]))
+			}
+			sb.WriteByte('\n')
+		}
+		for c := 0; c < m; c++ {
+			for r := 0; r < n; r++ {
+				if r > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(strconv.Itoa(cols[c][r]))
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expect := solveB(input)
+		tests[i] = testCase{input: input, expect: expect}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			return
+		}
+		if out != tc.expect {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expect, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1413/verifierC.go
+++ b/1000-1999/1400-1499/1410-1419/1413/verifierC.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveC(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	nextInt64 := func() int64 {
+		if !in.Scan() {
+			return 0
+		}
+		v, _ := strconv.ParseInt(in.Text(), 10, 64)
+		return v
+	}
+	var a [6]int64
+	for i := 0; i < 6; i++ {
+		a[i] = nextInt64()
+	}
+	var n int
+	if in.Scan() {
+		n, _ = strconv.Atoi(in.Text())
+	}
+	b := make([]int64, n)
+	for i := 0; i < n; i++ {
+		if !in.Scan() {
+			break
+		}
+		val, _ := strconv.ParseInt(in.Text(), 10, 64)
+		b[i] = val
+	}
+	type pair struct {
+		v   int64
+		idx int
+	}
+	arr := make([]pair, 0, n*6)
+	for i := 0; i < n; i++ {
+		for j := 0; j < 6; j++ {
+			arr = append(arr, pair{b[i] - a[j], i})
+		}
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i].v < arr[j].v })
+	cnt := make([]int, n)
+	missing := n
+	ans := int64(1<<63 - 1)
+	l := 0
+	for r := 0; r < len(arr); r++ {
+		p := arr[r]
+		if cnt[p.idx] == 0 {
+			missing--
+		}
+		cnt[p.idx]++
+		for missing == 0 && l <= r {
+			diff := arr[r].v - arr[l].v
+			if diff < ans {
+				ans = diff
+			}
+			li := arr[l].idx
+			cnt[li]--
+			if cnt[li] == 0 {
+				missing++
+			}
+			l++
+		}
+	}
+	return strconv.FormatInt(ans, 10)
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(3))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		var a [6]int64
+		for j := 0; j < 6; j++ {
+			a[j] = int64(rng.Intn(20) + 1)
+		}
+		n := rng.Intn(4) + 2
+		b := make([]int64, n)
+		for j := 0; j < n; j++ {
+			b[j] = int64(rng.Intn(30) + 1)
+		}
+		var sb strings.Builder
+		for j := 0; j < 6; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(a[j], 10))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(b[j], 10))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := solveC(input)
+		tests[i] = testCase{input: input, expect: expect}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			return
+		}
+		if out != tc.expect {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expect, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1413/verifierD.go
+++ b/1000-1999/1400-1499/1410-1419/1413/verifierD.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveD(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	var n int
+	if in.Scan() {
+		n, _ = strconv.Atoi(in.Text())
+	}
+	total := 2 * n
+	opsType := make([]bool, total)
+	opsVal := make([]int, total)
+	for i := 0; i < total; i++ {
+		in.Scan()
+		s := in.Text()
+		if s == "+" {
+			opsType[i] = true
+		} else {
+			opsType[i] = false
+			in.Scan()
+			x, _ := strconv.Atoi(in.Text())
+			opsVal[i] = x
+		}
+	}
+	res := make([]int, n)
+	stack := make([]int, 0, n)
+	pi := n - 1
+	for i := total - 1; i >= 0; i-- {
+		if !opsType[i] {
+			x := opsVal[i]
+			if len(stack) > 0 && x > stack[len(stack)-1] {
+				return "NO"
+			}
+			stack = append(stack, x)
+		} else {
+			if len(stack) == 0 {
+				return "NO"
+			}
+			x := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			res[pi] = x
+			pi--
+		}
+	}
+	if pi != -1 {
+		return "NO"
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(res[i]))
+	}
+	return sb.String()
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(4))
+	tests := make([]testCase, 100)
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(4) + 1
+		total := 2 * n
+		plusCount := 0
+		minusCount := 0
+		ops := make([]string, total)
+		for i := 0; i < total; i++ {
+			if plusCount == n {
+				val := rng.Intn(n) + 1
+				ops[i] = fmt.Sprintf("- %d", val)
+				minusCount++
+			} else if minusCount == n {
+				ops[i] = "+"
+				plusCount++
+			} else if rng.Intn(2) == 0 {
+				ops[i] = "+"
+				plusCount++
+			} else {
+				val := rng.Intn(n) + 1
+				ops[i] = fmt.Sprintf("- %d", val)
+				minusCount++
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for i := 0; i < total; i++ {
+			sb.WriteString(ops[i])
+			if i+1 < total {
+				sb.WriteByte('\n')
+			}
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := solveD(input)
+		tests[t] = testCase{input: input, expect: expect}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			return
+		}
+		if out != tc.expect {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expect, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1413/verifierE.go
+++ b/1000-1999/1400-1499/1410-1419/1413/verifierE.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveE(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	nextInt64 := func() int64 {
+		if !in.Scan() {
+			return 0
+		}
+		v, _ := strconv.ParseInt(in.Text(), 10, 64)
+		return v
+	}
+	t := nextInt64()
+	var sb strings.Builder
+	for ; t > 0; t-- {
+		a := nextInt64()
+		b := nextInt64()
+		c := nextInt64()
+		d := nextInt64()
+		if a > b*c {
+			sb.WriteString("-1")
+			if t > 1 {
+				sb.WriteByte('\n')
+			}
+			continue
+		}
+		w := c / d
+		u := c - w*d
+		compute := func(n, r int64) int64 {
+			tval := n*d + r
+			m := (tval - c) / d
+			if tval < c {
+				m = -1
+			}
+			if m > n {
+				m = n
+			}
+			full := m + 1
+			if full < 0 {
+				full = 0
+			}
+			K := n - m
+			heal := full*c + (K-1)*K/2*d + r*K
+			heal *= b
+			dmg := (n + 1) * a
+			return dmg - heal
+		}
+		best := a
+		n1 := a / (b * d)
+		candidates := []int64{0, n1 - 1, n1, w}
+		for _, n := range candidates {
+			if n < 0 || n > w {
+				continue
+			}
+			s := compute(n, 0)
+			if s > best {
+				best = s
+			}
+		}
+		if u > 0 {
+			s := compute(w, u)
+			if s > best {
+				best = s
+			}
+		}
+		sb.WriteString(strconv.FormatInt(best, 10))
+		if t > 1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(5))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		a := int64(rng.Intn(10) + 1)
+		b := int64(rng.Intn(10) + 1)
+		c := int64(rng.Intn(10) + 1)
+		d := int64(rng.Intn(10) + 1)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", a, b, c, d))
+		input := sb.String()
+		expect := solveE(input)
+		tests[i] = testCase{input: input, expect: expect}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			return
+		}
+		if out != tc.expect {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expect, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1410-1419/1413/verifierF.go
+++ b/1000-1999/1400-1499/1410-1419/1413/verifierF.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+type edge struct {
+	u, v int
+	t    int
+}
+
+type pair struct {
+	to int
+	t  int
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func pathInfo(start, end int, adj [][]pair, visited []bool) (length int, stones int, ok bool) {
+	if start == end {
+		return 0, 0, true
+	}
+	visited[start] = true
+	for _, e := range adj[start] {
+		if visited[e.to] {
+			continue
+		}
+		if l, s, f := pathInfo(e.to, end, adj, visited); f {
+			return l + 1, s + e.t, true
+		}
+	}
+	return 0, 0, false
+}
+
+func maxEvenPath(n int, edges []edge) int {
+	adj := make([][]pair, n+1)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], pair{e.v, e.t})
+		adj[e.v] = append(adj[e.v], pair{e.u, e.t})
+	}
+	best := 0
+	visited := make([]bool, n+1)
+	for i := 1; i <= n; i++ {
+		for j := i; j <= n; j++ {
+			for k := range visited {
+				visited[k] = false
+			}
+			l, s, ok := pathInfo(i, j, adj, visited)
+			if ok && s%2 == 0 && l > best {
+				best = l
+			}
+		}
+	}
+	return best
+}
+
+func solveF(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	nextInt := func() int {
+		if !in.Scan() {
+			return 0
+		}
+		v, _ := strconv.Atoi(in.Text())
+		return v
+	}
+	n := nextInt()
+	edges := make([]edge, n-1)
+	for i := 0; i < n-1; i++ {
+		u := nextInt()
+		v := nextInt()
+		t := nextInt()
+		edges[i] = edge{u, v, t}
+	}
+	m := nextInt()
+	var sb strings.Builder
+	for i := 0; i < m; i++ {
+		id := nextInt() - 1
+		edges[id].t ^= 1
+		ans := maxEvenPath(n, edges)
+		sb.WriteString(strconv.Itoa(ans))
+		if i+1 < m {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(6))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 2
+		edges := make([]edge, n-1)
+		for v := 2; v <= n; v++ {
+			p := rng.Intn(v-1) + 1
+			t := rng.Intn(2)
+			edges[v-2] = edge{p, v, t}
+		}
+		m := rng.Intn(3) + 1
+		queries := make([]int, m)
+		for j := 0; j < m; j++ {
+			queries[j] = rng.Intn(n-1) + 1
+			edges[queries[j]-1].t ^= 0 // no flip yet
+		}
+		// build input
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u, e.v, e.t))
+		}
+		sb.WriteString(strconv.Itoa(m))
+		sb.WriteByte('\n')
+		// We also need to recompute initial edge states for solver
+		edgeCopy := make([]edge, len(edges))
+		copy(edgeCopy, edges)
+		for j := 0; j < m; j++ {
+			sb.WriteString(strconv.Itoa(queries[j]))
+			if j+1 < m {
+				sb.WriteByte('\n')
+			}
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := solveF(input)
+		tests[i] = testCase{input: input, expect: expect}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			return
+		}
+		if out != tc.expect {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expect, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for contest 1413 problems A–F
- each verifier generates 100 random test cases and runs a supplied binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6885ff47f24883249cf62bbc412c75da