### PR TITLE
Add verifiers for contest 1426

### DIFF
--- a/1000-1999/1400-1499/1420-1429/1426/verifierA.go
+++ b/1000-1999/1400-1499/1420-1429/1426/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1426A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1426))
+	cases := make([]Case, 100)
+	// include some edge cases first
+	preset := []struct{ n, x int }{
+		{1, 1}, {2, 3}, {3, 1}, {1000, 1}, {1000, 1000},
+	}
+	idx := 0
+	for ; idx < len(preset); idx++ {
+		p := preset[idx]
+		cases[idx] = Case{fmt.Sprintf("1\n%d %d\n", p.n, p.x)}
+	}
+	for idx < 100 {
+		n := rng.Intn(1000) + 1
+		x := rng.Intn(1000) + 1
+		cases[idx] = Case{fmt.Sprintf("1\n%d %d\n", n, x)}
+		idx++
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1420-1429/1426/verifierB.go
+++ b/1000-1999/1400-1499/1420-1429/1426/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1426B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1426))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(10) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "1\n%d %d\n", n, m)
+		for j := 0; j < n; j++ {
+			a := rng.Intn(100) + 1
+			b := rng.Intn(100) + 1
+			c := rng.Intn(100) + 1
+			d := rng.Intn(100) + 1
+			fmt.Fprintf(&sb, "%d %d\n%d %d\n", a, b, c, d)
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1420-1429/1426/verifierC.go
+++ b/1000-1999/1400-1499/1420-1429/1426/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1426C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1426))
+	cases := make([]Case, 100)
+	cases[0] = Case{"1\n1\n"}
+	cases[1] = Case{"1\n2\n"}
+	cases[2] = Case{"1\n3\n"}
+	for i := 3; i < 100; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		cases[i] = Case{fmt.Sprintf("1\n%d\n", n)}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1420-1429/1426/verifierD.go
+++ b/1000-1999/1400-1499/1420-1429/1426/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1426D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1426))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(100) + 2
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rng.Intn(2001) - 1000
+			if val == 0 {
+				val = 1
+			}
+			fmt.Fprintf(&sb, "%d", val)
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1420-1429/1426/verifierE.go
+++ b/1000-1999/1400-1499/1420-1429/1426/verifierE.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1426E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1426))
+	cases := make([]Case, 100)
+	cases[0] = Case{"1\n1 0 0\n0 0 1\n"}
+	for i := 1; i < 100; i++ {
+		n := int64(rng.Intn(1000) + 1)
+		var a [3]int64
+		var b [3]int64
+		remain := n
+		for j := 0; j < 2; j++ {
+			a[j] = int64(rng.Intn(int(remain + 1)))
+			remain -= a[j]
+		}
+		a[2] = remain
+		remain = n
+		for j := 0; j < 2; j++ {
+			b[j] = int64(rng.Intn(int(remain + 1)))
+			remain -= b[j]
+		}
+		b[2] = remain
+		cases[i] = Case{fmt.Sprintf("%d\n%d %d %d\n%d %d %d\n", n, a[0], a[1], a[2], b[0], b[1], b[2])}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1420-1429/1426/verifierF.go
+++ b/1000-1999/1400-1499/1420-1429/1426/verifierF.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1426F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1426))
+	cases := make([]Case, 100)
+	letters := []byte{'a', 'b', 'c', '?'}
+	for i := range cases {
+		n := rng.Intn(100) + 3
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			b[j] = letters[rng.Intn(len(letters))]
+		}
+		s := string(b)
+		cases[i] = Case{fmt.Sprintf("%d\n%s\n", n, s)}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` – verify solutions for problem A with random cases
- add `verifierB.go` – verify solutions for problem B
- add `verifierC.go` – verify solutions for problem C
- add `verifierD.go` – verify solutions for problem D
- add `verifierE.go` – verify solutions for problem E
- add `verifierF.go` – verify solutions for problem F

## Testing
- `go vet ./...` *(fails: pattern ./...: directory prefix . does not contain main module)*


------
https://chatgpt.com/codex/tasks/task_e_68860665019883249368b7f3085b6b61