### PR TITLE
Fix reference for contest 573B

### DIFF
--- a/0-999/500-599/570-579/573/573B.go
+++ b/0-999/500-599/570-579/573/573B.go
@@ -14,10 +14,12 @@ func main() {
 	for i := 0; i < n; i++ {
 		fmt.Fscan(in, &h[i])
 	}
-	if n == 1 {
-		fmt.Println(h[0])
-		return
-	}
+       if n == 1 {
+               // When there's only one tower all blocks disappear in a single
+               // operation, regardless of its height.
+               fmt.Println(1)
+               return
+       }
 	left := make([]int, n)
 	right := make([]int, n)
 	left[0] = 1


### PR DESCRIPTION
## Summary
- fix corner case in contest 573 problem B reference solution

## Testing
- `go vet 0-999/500-599/570-579/573/573B.go`
- `go build 0-999/500-599/570-579/573/573B.go`
- `go run verifierB.go ./candBin`

------
https://chatgpt.com/codex/tasks/task_e_6886065c9b6483248dc3273e50582ab9