### PR TITLE
Add verifiers for CF 1428

### DIFF
--- a/1000-1999/1400-1499/1420-1429/1428/verifierA.go
+++ b/1000-1999/1400-1499/1420-1429/1428/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type testA struct{ x1, y1, x2, y2 int }
+
+func genTestsA() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		x1 := rand.Intn(1000) + 1
+		y1 := rand.Intn(1000) + 1
+		x2 := rand.Intn(1000) + 1
+		y2 := rand.Intn(1000) + 1
+		tests[i] = fmt.Sprintf("1\n%d %d %d %d\n", x1, y1, x2, y2)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "1428A.go"
+	tests := genTestsA()
+	for i, input := range tests {
+		expect, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1420-1429/1428/verifierB.go
+++ b/1000-1999/1400-1499/1420-1429/1428/verifierB.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTestsB() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 2
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			r := rand.Intn(3)
+			if r == 0 {
+				sb.WriteByte('<')
+			} else if r == 1 {
+				sb.WriteByte('>')
+			} else {
+				sb.WriteByte('-')
+			}
+		}
+		s := sb.String()
+		tests[i] = fmt.Sprintf("1\n%d\n%s\n", n, s)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "1428B.go"
+	tests := genTestsB()
+	for i, input := range tests {
+		expect, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1420-1429/1428/verifierC.go
+++ b/1000-1999/1400-1499/1420-1429/1428/verifierC.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTestsC() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('A')
+			} else {
+				sb.WriteByte('B')
+			}
+		}
+		s := sb.String()
+		tests[i] = fmt.Sprintf("1\n%s\n", s)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "1428C.go"
+	tests := genTestsC()
+	for i, input := range tests {
+		expect, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1420-1429/1428/verifierD.go
+++ b/1000-1999/1400-1499/1420-1429/1428/verifierD.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTestsD() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rand.Intn(4))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "1428D.go"
+	tests := genTestsD()
+	for i, input := range tests {
+		expect, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d: expected %q got %q\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1420-1429/1428/verifierE.go
+++ b/1000-1999/1400-1499/1420-1429/1428/verifierE.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTestsE() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 1
+		k := n + rand.Intn(4)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rand.Intn(9)+1)
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "1428E.go"
+	tests := genTestsE()
+	for i, input := range tests {
+		expect, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d: expected %q got %q\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1420-1429/1428/verifierF.go
+++ b/1000-1999/1400-1499/1420-1429/1428/verifierF.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTestsF() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "1428F.go"
+	tests := genTestsF()
+	for i, input := range tests {
+		expect, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d: expected %q got %q\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1420-1429/1428/verifierG1.go
+++ b/1000-1999/1400-1499/1420-1429/1428/verifierG1.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTestsG1() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		k := rand.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", k)
+		for j := 0; j < 6; j++ {
+			fmt.Fprintf(&sb, "%d ", rand.Intn(10))
+		}
+		sb.WriteByte('\n')
+		fmt.Fprintf(&sb, "1\n")
+		fmt.Fprintf(&sb, "%d\n", rand.Intn(200))
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "1428G1.go"
+	tests := genTestsG1()
+	for i, input := range tests {
+		expect, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d: expected %q got %q\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1420-1429/1428/verifierG2.go
+++ b/1000-1999/1400-1499/1420-1429/1428/verifierG2.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTestsG2() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		k := rand.Intn(5) + 1
+		q := 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", k)
+		for j := 0; j < 6; j++ {
+			fmt.Fprintf(&sb, "%d ", rand.Intn(10))
+		}
+		sb.WriteByte('\n')
+		fmt.Fprintf(&sb, "%d\n", q)
+		for j := 0; j < q; j++ {
+			fmt.Fprintf(&sb, "%d ", rand.Intn(200))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "1428G2.go"
+	tests := genTestsG2()
+	for i, input := range tests {
+		expect, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d: expected %q got %q\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for each problem in contest 1428
- each verifier runs the official solution and compares with the target binary on 100 random tests

## Testing
- `go build 1000-1999/1400-1499/1420-1429/1428/verifierA.go`
- `go build 1000-1999/1400-1499/1420-1429/1428/verifierB.go`
- `go build 1000-1999/1400-1499/1420-1429/1428/verifierC.go`
- `go build 1000-1999/1400-1499/1420-1429/1428/verifierD.go`
- `go build 1000-1999/1400-1499/1420-1429/1428/verifierE.go`
- `go build 1000-1999/1400-1499/1420-1429/1428/verifierF.go`
- `go build 1000-1999/1400-1499/1420-1429/1428/verifierG1.go`
- `go build 1000-1999/1400-1499/1420-1429/1428/verifierG2.go`


------
https://chatgpt.com/codex/tasks/task_e_6886077d3e188324af7e275e740eab5c