### PR TITLE
Add verifier for 573B

### DIFF
--- a/0-999/500-599/570-579/573/verifierB.go
+++ b/0-999/500-599/570-579/573/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rand.Seed(2)
+	var tests []string
+	tests = append(tests, "1\n1\n")
+	tests = append(tests, "3\n1 2 3\n")
+	tests = append(tests, "3\n3 2 1\n")
+	tests = append(tests, "5\n3 4 5 4 3\n")
+	for len(tests) < 120 {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rand.Intn(1000) + 1
+			sb.WriteString(strconv.Itoa(val))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "573B.go")
+	refPath, err := prepareBinary(refSrc, "refB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	tests := genTests()
+	for i, input := range tests {
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add `verifierB.go` for contest 573 problem B
- generator creates 120 test cases with deterministic seed
- verify against `573B.go`

## Testing
- `go build -o verifierB 0-999/500-599/570-579/573/verifierB.go`
- `./verifierB 0-999/500-599/570-579/573/573B.go`

------
https://chatgpt.com/codex/tasks/task_e_688609efd9fc83248d1d190b3136a20b