### PR TITLE
Add Go verifiers for contest 1433

### DIFF
--- a/1000-1999/1400-1499/1430-1439/1433/verifierA.go
+++ b/1000-1999/1400-1499/1430-1439/1433/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(x string) int {
+	d := int(x[0] - '0')
+	k := len(x)
+	return 10*(d-1) + k*(k+1)/2
+}
+
+type Case string
+
+func genCase(rng *rand.Rand) Case {
+	digit := rng.Intn(9) + 1
+	length := rng.Intn(4) + 1
+	return Case(strings.Repeat(strconv.Itoa(digit), length))
+}
+
+func runCase(bin string, c Case) error {
+	input := fmt.Sprintf("1\n%s\n", string(c))
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	want := expected(string(c))
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := genCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1433/verifierB.go
+++ b/1000-1999/1400-1499/1430-1439/1433/verifierB.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct {
+	n   int
+	arr []int
+}
+
+func genCase(rng *rand.Rand) Case {
+	n := rng.Intn(50) + 1
+	arr := make([]int, n)
+	ones := 0
+	for i := range arr {
+		if rng.Intn(2) == 1 {
+			arr[i] = 1
+			ones++
+		}
+	}
+	if ones == 0 {
+		idx := rng.Intn(n)
+		arr[idx] = 1
+	}
+	return Case{n: n, arr: arr}
+}
+
+func expected(c Case) int {
+	first := -1
+	last := -1
+	for i, v := range c.arr {
+		if v == 1 {
+			if first == -1 {
+				first = i
+			}
+			last = i
+		}
+	}
+	zeros := 0
+	for i := first; i <= last; i++ {
+		if c.arr[i] == 0 {
+			zeros++
+		}
+	}
+	return zeros
+}
+
+func runCase(bin string, c Case) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", c.n))
+	for i, v := range c.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	want := expected(c)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := genCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1433/verifierC.go
+++ b/1000-1999/1400-1499/1430-1439/1433/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct {
+	n   int
+	arr []int
+}
+
+func genCase(rng *rand.Rand) Case {
+	n := rng.Intn(20) + 2
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(10) + 1
+	}
+	return Case{n: n, arr: arr}
+}
+
+func dominantIndices(c Case) []int {
+	mx := c.arr[0]
+	for _, v := range c.arr {
+		if v > mx {
+			mx = v
+		}
+	}
+	res := []int{}
+	for i, v := range c.arr {
+		if v == mx {
+			if (i > 0 && c.arr[i-1] < v) || (i+1 < len(c.arr) && c.arr[i+1] < v) {
+				res = append(res, i+1)
+			}
+		}
+	}
+	return res
+}
+
+func runCase(bin string, c Case) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", c.n))
+	for i, v := range c.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	choices := dominantIndices(c)
+	if len(choices) == 0 {
+		if got != -1 {
+			return fmt.Errorf("expected -1 got %d", got)
+		}
+		return nil
+	}
+	for _, idx := range choices {
+		if got == idx {
+			return nil
+		}
+	}
+	return fmt.Errorf("output %d not one of valid indices %v", got, choices)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := genCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1433/verifierD.go
+++ b/1000-1999/1400-1499/1430-1439/1433/verifierD.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct {
+	n   int
+	arr []int
+}
+
+func genCase(rng *rand.Rand) Case {
+	n := rng.Intn(8) + 2
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(3) + 1
+	}
+	return Case{n: n, arr: arr}
+}
+
+func isPossible(c Case) bool {
+	first := c.arr[0]
+	for _, v := range c.arr {
+		if v != first {
+			return true
+		}
+	}
+	return false
+}
+
+func checkOutput(c Case, out string) error {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	if !scanner.Scan() {
+		return fmt.Errorf("empty output")
+	}
+	ans := strings.ToUpper(strings.TrimSpace(scanner.Text()))
+	possible := isPossible(c)
+	if !possible {
+		if ans != "NO" {
+			return fmt.Errorf("expected NO")
+		}
+		return nil
+	}
+	if ans != "YES" {
+		return fmt.Errorf("expected YES")
+	}
+	edges := make([][2]int, 0, c.n-1)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 {
+			return fmt.Errorf("invalid edge line: %q", scanner.Text())
+		}
+		u, err1 := strconv.Atoi(fields[0])
+		v, err2 := strconv.Atoi(fields[1])
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("invalid integers")
+		}
+		if u < 1 || u > c.n || v < 1 || v > c.n || u == v {
+			return fmt.Errorf("edge out of range")
+		}
+		if c.arr[u-1] == c.arr[v-1] {
+			return fmt.Errorf("edge connects same gang")
+		}
+		edges = append(edges, [2]int{u - 1, v - 1})
+	}
+	if len(edges) != c.n-1 {
+		return fmt.Errorf("expected %d edges got %d", c.n-1, len(edges))
+	}
+	// check connectivity via DSU
+	parent := make([]int, c.n)
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(a, b int) {
+		fa, fb := find(a), find(b)
+		if fa != fb {
+			parent[fa] = fb
+		}
+	}
+	for _, e := range edges {
+		union(e[0], e[1])
+	}
+	root := find(0)
+	for i := 1; i < c.n; i++ {
+		if find(i) != root {
+			return fmt.Errorf("edges not connected")
+		}
+	}
+	return nil
+}
+
+func runCase(bin string, c Case) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", c.n))
+	for i, v := range c.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	return checkOutput(c, out)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := genCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1433/verifierE.go
+++ b/1000-1999/1400-1499/1430-1439/1433/verifierE.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int) uint64 {
+	k := n / 2
+	comb := uint64(1)
+	for i := 1; i <= k; i++ {
+		comb = comb * uint64(n-k+i) / uint64(i)
+	}
+	fact := uint64(1)
+	for i := 1; i <= k-1; i++ {
+		fact *= uint64(i)
+	}
+	return comb * fact * fact / 2
+}
+
+func genCase(rng *rand.Rand) int {
+	return 2 * (rng.Intn(10) + 1)
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	got, err := strconv.ParseUint(strings.TrimSpace(out), 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	want := expected(n)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := genCase(rng)
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1433/verifierF.go
+++ b/1000-1999/1400-1499/1430-1439/1433/verifierF.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	k := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(70)+1)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin, sol string, tc string) error {
+	want, err := run(sol, tc)
+	if err != nil {
+		return fmt.Errorf("internal error: %v", err)
+	}
+	got, err := run(bin, tc)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(want) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", strings.TrimSpace(want), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	sol := "./1433F.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, sol, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1433/verifierG.go
+++ b/1000-1999/1400-1499/1430-1439/1433/verifierG.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-n+2) + n - 1 // ensure at least n-1
+	if m > maxEdges {
+		m = maxEdges
+	}
+	k := rng.Intn(3) + 1
+	edges := make(map[[2]int]struct{})
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	count := 0
+	for count < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u >= v {
+			continue
+		}
+		key := [2]int{u + 1, v + 1}
+		if _, ok := edges[key]; ok {
+			continue
+		}
+		edges[key] = struct{}{}
+		fmt.Fprintf(&sb, "%d %d %d\n", key[0], key[1], rng.Intn(10)+1)
+		count++
+	}
+	for i := 0; i < k; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d\n", a, b)
+	}
+	return sb.String()
+}
+
+func runCase(bin, sol, tc string) error {
+	want, err := run(sol, tc)
+	if err != nil {
+		return fmt.Errorf("internal error: %v", err)
+	}
+	got, err := run(bin, tc)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(want) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", strings.TrimSpace(want), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	sol := "./1433G.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, sol, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 1433
- verifiers A through G generate 100 random test cases each and check a candidate program
- unique outputs checked directly; multi-answer problems validate the output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68860a3988348324ad7164bdae0942f4