### PR TITLE
Add Go verifiers for contest 1438

### DIFF
--- a/1000-1999/1400-1499/1430-1439/1438/verifierA.go
+++ b/1000-1999/1400-1499/1430-1439/1438/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int) string {
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteByte('1')
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(100) + 1
+	var in strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	expLines := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(100) + 1
+		in.WriteString(fmt.Sprintf("%d\n", n))
+		expLines[i] = solveCase(n)
+	}
+	return in.String(), strings.Join(expLines, "\n")
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	outLines := strings.FieldsFunc(strings.TrimSpace(out.String()), func(r rune) bool { return r == '\n' || r == '\r' })
+	expLines := strings.FieldsFunc(strings.TrimSpace(expected), func(r rune) bool { return r == '\n' || r == '\r' })
+	if len(outLines) != len(expLines) {
+		return fmt.Errorf("expected %d lines got %d", len(expLines), len(outLines))
+	}
+	for i := range expLines {
+		if strings.TrimSpace(outLines[i]) != expLines[i] {
+			return fmt.Errorf("line %d expected %q got %q", i+1, expLines[i], strings.TrimSpace(outLines[i]))
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1438/verifierB.go
+++ b/1000-1999/1400-1499/1430-1439/1438/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(b []int) string {
+	seen := make(map[int]bool)
+	for _, v := range b {
+		if seen[v] {
+			return "YES"
+		}
+		seen[v] = true
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(50) + 1
+	var in strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	expLines := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(50) + 2
+		in.WriteString(fmt.Sprintf("%d\n", n))
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				in.WriteByte(' ')
+			}
+			if rng.Intn(5) == 0 && j > 0 {
+				arr[j] = arr[rng.Intn(j)]
+			} else {
+				arr[j] = rng.Intn(1_000_000_000)
+			}
+			in.WriteString(fmt.Sprint(arr[j]))
+		}
+		in.WriteByte('\n')
+		expLines[i] = solveCase(arr)
+	}
+	return in.String(), strings.Join(expLines, "\n")
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	outLines := strings.Fields(strings.TrimSpace(out.String()))
+	expLines := strings.Fields(strings.TrimSpace(expected))
+	if len(outLines) != len(expLines) {
+		return fmt.Errorf("expected %d lines got %d", len(expLines), len(outLines))
+	}
+	for i := range expLines {
+		if strings.ToUpper(outLines[i]) != expLines[i] {
+			return fmt.Errorf("line %d expected %q got %q", i+1, expLines[i], outLines[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1438/verifierC.go
+++ b/1000-1999/1400-1499/1430-1439/1438/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(a [][]int) string {
+	n := len(a)
+	m := len(a[0])
+	for i := 0; i < n; i++ {
+		z := (i + 1) % 2
+		for j := 0; j < m; j++ {
+			if a[i][j]%2 == z {
+				z = 1 - z
+				continue
+			}
+			a[i][j]++
+			z = 1 - z
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(a[i][j]))
+		}
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(10) + 1
+	var in strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	var exp strings.Builder
+	for c := 0; c < t; c++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		in.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		mat := make([][]int, n)
+		for i := 0; i < n; i++ {
+			mat[i] = make([]int, m)
+			for j := 0; j < m; j++ {
+				val := rng.Intn(1000) + 1
+				mat[i][j] = val
+				in.WriteString(fmt.Sprintf("%d", val))
+				if j+1 < m {
+					in.WriteByte(' ')
+				}
+			}
+			in.WriteByte('\n')
+		}
+		exp.WriteString(solveCase(mat))
+		if c+1 < t {
+			exp.WriteByte('\n')
+		}
+	}
+	return in.String(), exp.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\n--- got:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1438/verifierD.go
+++ b/1000-1999/1400-1499/1430-1439/1438/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(a []int) string {
+	n := len(a)
+	sum := 0
+	for _, v := range a {
+		sum ^= v
+	}
+	var sb strings.Builder
+	if n%2 == 1 {
+		sb.WriteString("YES\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n-2))
+		for i := 0; i+2 < n; i += 2 {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", i+1, i+2, i+3))
+		}
+		for i := n - 3; i-2 >= 0; i -= 2 {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", i+1, i, i-1))
+		}
+	} else {
+		if sum == 0 {
+			sb.WriteString("YES\n")
+			sb.WriteString(fmt.Sprintf("%d\n", n-3))
+			n--
+			for i := 0; i+2 < n; i += 2 {
+				sb.WriteString(fmt.Sprintf("%d %d %d\n", i+1, i+2, i+3))
+			}
+			for i := n - 3; i-2 >= 0; i -= 2 {
+				sb.WriteString(fmt.Sprintf("%d %d %d\n", i+1, i, i-1))
+			}
+		} else {
+			sb.WriteString("NO")
+			return sb.String()
+		}
+	}
+	res := sb.String()
+	res = strings.TrimRight(res, "\n")
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 3
+	var in strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", n))
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) + 1
+		in.WriteString(fmt.Sprintf("%d", arr[i]))
+		if i+1 < n {
+			in.WriteByte(' ')
+		}
+	}
+	in.WriteByte('\n')
+	exp := solveCase(append([]int(nil), arr...))
+	return in.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\n--- got:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1438/verifierE.go
+++ b/1000-1999/1400-1499/1430-1439/1438/verifierE.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(a []int) string {
+	n := len(a)
+	pref := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		pref[i+1] = pref[i] + a[i]
+	}
+	cnt := 0
+	for l := 0; l < n; l++ {
+		for r := l + 2; r < n; r++ {
+			sum := pref[r] - pref[l+1]
+			if (a[l] ^ a[r]) == sum {
+				cnt++
+			}
+		}
+	}
+	return fmt.Sprint(cnt)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(40) + 3
+	var in strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", n))
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(1<<15) + 1
+		in.WriteString(fmt.Sprintf("%d", arr[i]))
+		if i+1 < n {
+			in.WriteByte(' ')
+		}
+	}
+	in.WriteByte('\n')
+	exp := solveCase(arr)
+	return in.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1438/verifierF.go
+++ b/1000-1999/1400-1499/1430-1439/1438/verifierF.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem F is interactive and cannot be automatically verified.")
+}


### PR DESCRIPTION
## Summary
- implement verifierA.go to check 1438A solutions
- implement verifierB.go to check 1438B solutions
- implement verifierC.go to check 1438C solutions
- implement verifierD.go to check 1438D solutions
- implement verifierE.go to check 1438E solutions
- add stub verifierF.go for interactive problem

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68860cf687008324a408ad3960e192d4