### PR TITLE
Add Go solution for 1525A

### DIFF
--- a/1000-1999/1500-1599/1520-1529/1525/1525A.go
+++ b/1000-1999/1500-1599/1520-1529/1525/1525A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// This program solves problemA from contest 1525.
+// To obtain a potion with exactly k percent magic essence,
+// the ratio of essence to water must be k:(100-k).
+// The minimal total volume is 100 divided by gcd(k,100).
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var k int
+		fmt.Fscan(in, &k)
+		g := gcd(k, 100)
+		fmt.Fprintln(out, 100/g)
+	}
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problemA of contest 1525

## Testing
- `go build 1000-1999/1500-1599/1520-1529/1525/1525A.go`
- `go run 1000-1999/1500-1599/1520-1529/1525/1525A.go <<EOF
3
3
100
25
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68860f6c4350832490c9cfe287a5aa15