### PR TITLE
Add Go verifiers for contest 1439

### DIFF
--- a/1000-1999/1400-1499/1430-1439/1439/verifierA.go
+++ b/1000-1999/1400-1499/1430-1439/1439/verifierA.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func copyGrid(g [][]int) [][]int {
+	res := make([][]int, len(g))
+	for i := range g {
+		res[i] = append([]int(nil), g[i]...)
+	}
+	return res
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func check(bin string, n, m int, grid [][]int, limit int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 1 {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('0')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return fmt.Errorf("exec error: %v output=%s", err, out)
+	}
+	sc := bufio.NewScanner(strings.NewReader(out))
+	sc.Split(bufio.ScanWords)
+	if !sc.Scan() {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(sc.Text())
+	if err != nil {
+		return fmt.Errorf("invalid k")
+	}
+	if k < 0 || k > limit {
+		return fmt.Errorf("k out of range")
+	}
+	for t := 0; t < k; t++ {
+		xs := make([]int, 3)
+		ys := make([]int, 3)
+		for i := 0; i < 3; i++ {
+			if !sc.Scan() {
+				return fmt.Errorf("not enough numbers")
+			}
+			xi, err := strconv.Atoi(sc.Text())
+			if err != nil {
+				return fmt.Errorf("invalid int")
+			}
+			if !sc.Scan() {
+				return fmt.Errorf("not enough numbers")
+			}
+			yi, err := strconv.Atoi(sc.Text())
+			if err != nil {
+				return fmt.Errorf("invalid int")
+			}
+			xi--
+			yi--
+			if xi < 0 || xi >= n || yi < 0 || yi >= m {
+				return fmt.Errorf("coord out")
+			}
+			xs[i], ys[i] = xi, yi
+		}
+		// distinct
+		if xs[0] == xs[1] && ys[0] == ys[1] || xs[0] == xs[2] && ys[0] == ys[2] || xs[1] == xs[2] && ys[1] == ys[2] {
+			return fmt.Errorf("duplicate cells")
+		}
+		// same 2x2
+		xmn, xmx := xs[0], xs[0]
+		ymn, ymx := ys[0], ys[0]
+		for i := 1; i < 3; i++ {
+			xmn = min(xmn, xs[i])
+			xmx = max(xmx, xs[i])
+			ymn = min(ymn, ys[i])
+			ymx = max(ymx, ys[i])
+		}
+		if xmx-xmn > 1 || ymx-ymn > 1 {
+			return fmt.Errorf("not in one 2x2")
+		}
+		for i := 0; i < 3; i++ {
+			grid[xs[i]][ys[i]] ^= 1
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] != 0 {
+				return fmt.Errorf("not zero")
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/bin")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(3) + 2
+		m := rand.Intn(3) + 2
+		g := make([][]int, n)
+		for i := 0; i < n; i++ {
+			g[i] = make([]int, m)
+			for j := 0; j < m; j++ {
+				g[i][j] = rand.Intn(2)
+			}
+		}
+		if err := check(bin, n, m, copyGrid(g), 3*n*m); err != nil {
+			fmt.Printf("test %d failed: %v\n", t, err)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1439/verifierA2.go
+++ b/1000-1999/1400-1499/1430-1439/1439/verifierA2.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func copyGrid(g [][]int) [][]int {
+	res := make([][]int, len(g))
+	for i := range g {
+		res[i] = append([]int(nil), g[i]...)
+	}
+	return res
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func check(bin string, n, m int, grid [][]int, limit int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 1 {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('0')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return fmt.Errorf("exec error: %v output=%s", err, out)
+	}
+	sc := bufio.NewScanner(strings.NewReader(out))
+	sc.Split(bufio.ScanWords)
+	if !sc.Scan() {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(sc.Text())
+	if err != nil {
+		return fmt.Errorf("invalid k")
+	}
+	if k < 0 || k > limit {
+		return fmt.Errorf("k out of range")
+	}
+	for t := 0; t < k; t++ {
+		xs := make([]int, 3)
+		ys := make([]int, 3)
+		for i := 0; i < 3; i++ {
+			if !sc.Scan() {
+				return fmt.Errorf("not enough numbers")
+			}
+			xi, err := strconv.Atoi(sc.Text())
+			if err != nil {
+				return fmt.Errorf("invalid int")
+			}
+			if !sc.Scan() {
+				return fmt.Errorf("not enough numbers")
+			}
+			yi, err := strconv.Atoi(sc.Text())
+			if err != nil {
+				return fmt.Errorf("invalid int")
+			}
+			xi--
+			yi--
+			if xi < 0 || xi >= n || yi < 0 || yi >= m {
+				return fmt.Errorf("coord out")
+			}
+			xs[i], ys[i] = xi, yi
+		}
+		// distinct
+		if xs[0] == xs[1] && ys[0] == ys[1] || xs[0] == xs[2] && ys[0] == ys[2] || xs[1] == xs[2] && ys[1] == ys[2] {
+			return fmt.Errorf("duplicate cells")
+		}
+		// same 2x2
+		xmn, xmx := xs[0], xs[0]
+		ymn, ymx := ys[0], ys[0]
+		for i := 1; i < 3; i++ {
+			xmn = min(xmn, xs[i])
+			xmx = max(xmx, xs[i])
+			ymn = min(ymn, ys[i])
+			ymx = max(ymx, ys[i])
+		}
+		if xmx-xmn > 1 || ymx-ymn > 1 {
+			return fmt.Errorf("not in one 2x2")
+		}
+		for i := 0; i < 3; i++ {
+			grid[xs[i]][ys[i]] ^= 1
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] != 0 {
+				return fmt.Errorf("not zero")
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA2.go /path/to/bin")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(3) + 2
+		m := rand.Intn(3) + 2
+		g := make([][]int, n)
+		for i := 0; i < n; i++ {
+			g[i] = make([]int, m)
+			for j := 0; j < m; j++ {
+				g[i][j] = rand.Intn(2)
+			}
+		}
+		if err := check(bin, n, m, copyGrid(g), n*m); err != nil {
+			fmt.Printf("test %d failed: %v\n", t, err)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1439/verifierB.go
+++ b/1000-1999/1400-1499/1430-1439/1439/verifierB.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Edge struct{ u, v int }
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func brute(n int, edges []Edge, k int) (hasClique bool, cliques [][]int, subsets [][]int) {
+	adj := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		adj[i] = make([]bool, n)
+	}
+	for _, e := range edges {
+		adj[e.u][e.v] = true
+		adj[e.v][e.u] = true
+	}
+	for mask := 1; mask < (1 << n); mask++ {
+		verts := []int{}
+		for i := 0; i < n; i++ {
+			if mask>>i&1 == 1 {
+				verts = append(verts, i)
+			}
+		}
+		if len(verts) == k {
+			ok := true
+			for i := 0; i < k && ok; i++ {
+				for j := i + 1; j < k; j++ {
+					if !adj[verts[i]][verts[j]] {
+						ok = false
+						break
+					}
+				}
+			}
+			if ok {
+				hasClique = true
+				cliques = append(cliques, append([]int(nil), verts...))
+			}
+		}
+		good := len(verts) > 0
+		if good {
+			for _, v := range verts {
+				deg := 0
+				for _, u := range verts {
+					if u != v && adj[v][u] {
+						deg++
+					}
+				}
+				if deg < k {
+					good = false
+					break
+				}
+			}
+		}
+		if good {
+			subsets = append(subsets, append([]int(nil), verts...))
+		}
+	}
+	return
+}
+
+func parseOutput(out string, n int, edges []Edge, k int) error {
+	sc := bufio.NewScanner(strings.NewReader(out))
+	sc.Split(bufio.ScanWords)
+	if !sc.Scan() {
+		return fmt.Errorf("no output")
+	}
+	t := sc.Text()
+	if t == "-1" {
+		// verify none exists
+		hasC, _, sub := brute(n, edges, k)
+		if hasC || len(sub) > 0 {
+			return fmt.Errorf("answer exists but got -1")
+		}
+		return nil
+	}
+	tp, err := strconv.Atoi(t)
+	if err != nil {
+		return fmt.Errorf("invalid first token")
+	}
+	switch tp {
+	case 1:
+		if !sc.Scan() {
+			return fmt.Errorf("missing size")
+		}
+		sz, _ := strconv.Atoi(sc.Text())
+		verts := make([]int, sz)
+		for i := 0; i < sz; i++ {
+			if !sc.Scan() {
+				return fmt.Errorf("missing vertex")
+			}
+			v, _ := strconv.Atoi(sc.Text())
+			if v < 1 || v > n {
+				return fmt.Errorf("vertex out of range")
+			}
+			verts[i] = v - 1
+		}
+		// check subset property
+		for _, v := range verts {
+			deg := 0
+			for _, u := range verts {
+				if u != v && isEdge(edges, v, u) {
+					deg++
+				}
+			}
+			if deg < k {
+				return fmt.Errorf("subset property fail")
+			}
+		}
+	case 2:
+		verts := make([]int, k)
+		for i := 0; i < k; i++ {
+			if !sc.Scan() {
+				return fmt.Errorf("missing vertex")
+			}
+			v, _ := strconv.Atoi(sc.Text())
+			if v < 1 || v > n {
+				return fmt.Errorf("vertex out of range")
+			}
+			verts[i] = v - 1
+		}
+		// check clique
+		for i := 0; i < k; i++ {
+			for j := i + 1; j < k; j++ {
+				if !isEdge(edges, verts[i], verts[j]) {
+					return fmt.Errorf("not clique")
+				}
+			}
+		}
+	default:
+		return fmt.Errorf("invalid type %v", tp)
+	}
+	return nil
+}
+
+func isEdge(edges []Edge, a, b int) bool {
+	if a > b {
+		a, b = b, a
+	}
+	for _, e := range edges {
+		if e.u == a && e.v == b {
+			return true
+		}
+	}
+	return false
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/bin")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(4) + 2 //2..5
+		maxEdges := n * (n - 1) / 2
+		m := rand.Intn(maxEdges)
+		k := rand.Intn(n) + 1
+		edgeMap := make(map[[2]int]bool)
+		edges := make([]Edge, 0, m)
+		for len(edges) < m {
+			a := rand.Intn(n)
+			b := rand.Intn(n)
+			if a == b {
+				continue
+			}
+			if a > b {
+				a, b = b, a
+			}
+			if edgeMap[[2]int{a, b}] {
+				continue
+			}
+			edgeMap[[2]int{a, b}] = true
+			edges = append(edges, Edge{a, b})
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(edges), k))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e.u+1, e.v+1))
+		}
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d exec error %v\n", tcase, err)
+			return
+		}
+		if err := parseOutput(out, n, edges, k); err != nil {
+			fmt.Printf("test %d failed: %v\n", tcase, err)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1439/verifierC.go
+++ b/1000-1999/1400-1499/1430-1439/1439/verifierC.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func simulate(n int, a []int, queries [][3]int) []int {
+	res := []int{}
+	arr := append([]int(nil), a...)
+	for _, q := range queries {
+		t, x, y := q[0], q[1], q[2]
+		if t == 1 {
+			for i := 0; i < x; i++ {
+				if y > arr[i] {
+					arr[i] = y
+				}
+			}
+		} else {
+			money := y
+			cnt := 0
+			for i := x - 1; i < n; i++ {
+				if money >= arr[i] {
+					money -= arr[i]
+					cnt++
+				}
+			}
+			res = append(res, cnt)
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/bin")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(5) + 2
+		q := rand.Intn(5) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(10) + 1
+		}
+		queries := make([][3]int, q)
+		for i := 0; i < q; i++ {
+			t := rand.Intn(2) + 1
+			x := rand.Intn(n) + 1
+			y := rand.Intn(10) + 1
+			queries[i] = [3]int{t, x, y}
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d ", a[i]))
+		}
+		sb.WriteString("\n")
+		for _, qq := range queries {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", qq[0], qq[1], qq[2]))
+		}
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d exec err %v\n", tcase, err)
+			return
+		}
+		sc := bufio.NewScanner(strings.NewReader(out))
+		sc.Split(bufio.ScanWords)
+		sim := simulate(n, a, queries)
+		for i, ans := range sim {
+			if !sc.Scan() {
+				fmt.Printf("test %d output missing\n", tcase)
+				return
+			}
+			got, err := strconv.Atoi(sc.Text())
+			if err != nil {
+				fmt.Printf("test %d invalid int\n", tcase)
+				return
+			}
+			if got != ans {
+				fmt.Printf("test %d query %d expected %d got %d\n", tcase, i, ans, got)
+				return
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1439/verifierD.go
+++ b/1000-1999/1400-1499/1430-1439/1439/verifierD.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func brute(n, m, p int) int {
+	res := 0
+	a := make([]int, m)
+	b := make([]int, m)
+	var dfs func(int)
+	dfs = func(idx int) {
+		if idx == m {
+			seats := make([]bool, n)
+			sum := 0
+			for i := 0; i < m; i++ {
+				pos := a[i]
+				if b[i] == 0 { // L
+					seat := -1
+					for j := pos; j >= 0; j-- {
+						if !seats[j] {
+							seat = j
+							break
+						}
+					}
+					if seat == -1 {
+						return
+					}
+					seats[seat] = true
+					if seat != pos {
+						if seat > pos {
+							sum += seat - pos
+						} else {
+							sum += pos - seat
+						}
+					}
+				} else {
+					seat := -1
+					for j := pos; j < n; j++ {
+						if !seats[j] {
+							seat = j
+							break
+						}
+					}
+					if seat == -1 {
+						return
+					}
+					seats[seat] = true
+					if seat != pos {
+						if seat > pos {
+							sum += seat - pos
+						} else {
+							sum += pos - seat
+						}
+					}
+				}
+			}
+			res = (res + sum) % p
+			return
+		}
+		for i := 0; i < n; i++ {
+			a[idx] = i
+			for t := 0; t < 2; t++ {
+				b[idx] = t
+				dfs(idx + 1)
+			}
+		}
+	}
+	dfs(0)
+	return res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/bin")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(3) + 1
+		m := rand.Intn(n) + 1
+		p := 1000000007
+		input := fmt.Sprintf("%d %d %d\n", n, m, p)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec err %v\n", tcase, err)
+			return
+		}
+		sc := bufio.NewScanner(strings.NewReader(out))
+		sc.Split(bufio.ScanWords)
+		if !sc.Scan() {
+			fmt.Printf("test %d no output\n", tcase)
+			return
+		}
+		got, err := strconv.Atoi(sc.Text())
+		if err != nil {
+			fmt.Printf("test %d bad int\n", tcase)
+			return
+		}
+		expect := brute(n, m, p)
+		if got != expect {
+			fmt.Printf("test %d expected %d got %d\n", tcase, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1430-1439/1439/verifierE.go
+++ b/1000-1999/1400-1499/1430-1439/1439/verifierE.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func compileRef() (string, error) {
+	ref := "1439E.go"
+	tmp := "refE_bin"
+	cmd := exec.Command("go", "build", "-o", tmp, ref)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/bin")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("compile reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for tcase := 0; tcase < 100; tcase++ {
+		m := rand.Intn(3) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for i := 0; i < m; i++ {
+			x1 := rand.Intn(8)
+			y1 := rand.Intn(8)
+			x2 := rand.Intn(8)
+			y2 := rand.Intn(8)
+			x1 &= ^y1
+			x2 &= ^y2 // ensure good cells (x&y==0)
+			sb.WriteString(fmt.Sprintf("%d %d %d %d\n", x1, y1, x2, y2))
+		}
+		inp := sb.String()
+		outRef, _ := run(ref, inp)
+		outCand, err := run(bin, inp)
+		if err != nil {
+			fmt.Printf("test %d exec err %v\n", tcase, err)
+			return
+		}
+		if strings.TrimSpace(outRef) != strings.TrimSpace(outCand) {
+			fmt.Printf("test %d mismatch expected %s got %s\n", tcase, strings.TrimSpace(outRef), strings.TrimSpace(outCand))
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierA2.go` for Binary Table (easy/hard)
- add `verifierB.go` for Graph Subset Problem
- add `verifierC.go` for Greedy Shopping
- add `verifierD.go` naive checker for INOI Final Contests
- add `verifierE.go` using reference solver for Cheat and Win

## Testing
- `go build verifierA.go`
- `go build verifierA2.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68860d821658832481ebc11f2bbc33d2