### PR TITLE
Add verifiers for Codeforces contest 1443

### DIFF
--- a/1000-1999/1400-1499/1440-1449/1443/verifierA.go
+++ b/1000-1999/1400-1499/1440-1449/1443/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	input    string
+	expected []int
+}
+
+func genTest(rng *rand.Rand) Test {
+	t := rng.Intn(3) + 1 // number of cases
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	expected := make([]int, 0)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			expected = append(expected, 4*n-2*(j+1))
+		}
+	}
+	return Test{input: sb.String(), expected: expected}
+}
+
+func parseInts(s string) ([]int, error) {
+	fields := strings.Fields(strings.TrimSpace(s))
+	res := make([]int, len(fields))
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tcase := genTest(rng)
+		out, err := run(bin, tcase.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		nums, err := parseInts(out)
+		if err != nil {
+			fmt.Printf("test %d bad output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if len(nums) != len(tcase.expected) {
+			fmt.Printf("test %d expected %d numbers got %d\ninput:\n%s", i+1, len(tcase.expected), len(nums), tcase.input)
+			os.Exit(1)
+		}
+		for j, v := range tcase.expected {
+			if nums[j] != v {
+				fmt.Printf("test %d failed at position %d\ninput:\n%s\nexpected %d got %d\n", i+1, j+1, tcase.input, v, nums[j])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1443/verifierB.go
+++ b/1000-1999/1400-1499/1440-1449/1443/verifierB.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	input    string
+	expected []int
+}
+
+func solve(a, b int, s string) int {
+	cost := 0
+	inBlock := false
+	seen := false
+	zeros := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '1' {
+			if !inBlock {
+				if !seen {
+					cost += a
+					seen = true
+				} else {
+					if zeros*b < a {
+						cost += zeros * b
+					} else {
+						cost += a
+					}
+				}
+				inBlock = true
+			}
+			zeros = 0
+		} else {
+			if inBlock {
+				inBlock = false
+				zeros = 1
+			} else if seen {
+				zeros++
+			}
+		}
+	}
+	return cost
+}
+
+func genTest(rng *rand.Rand) Test {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	expected := make([]int, 0, t)
+	for i := 0; i < t; i++ {
+		a := rng.Intn(10) + 1
+		b := rng.Intn(10) + 1
+		n := rng.Intn(20) + 1
+		var s strings.Builder
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				s.WriteByte('0')
+			} else {
+				s.WriteByte('1')
+			}
+		}
+		str := s.String()
+		sb.WriteString(fmt.Sprintf("%d %d\n%s\n", a, b, str))
+		expected = append(expected, solve(a, b, str))
+	}
+	return Test{input: sb.String(), expected: expected}
+}
+
+func parseInts(s string) ([]int, error) {
+	fields := strings.Fields(strings.TrimSpace(s))
+	res := make([]int, len(fields))
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genTest(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		nums, err := parseInts(out)
+		if err != nil {
+			fmt.Printf("test %d bad output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if len(nums) != len(tc.expected) {
+			fmt.Printf("test %d expected %d numbers got %d\ninput:\n%s", i+1, len(tc.expected), len(nums), tc.input)
+			os.Exit(1)
+		}
+		for j, v := range tc.expected {
+			if nums[j] != v {
+				fmt.Printf("test %d failed at case %d\ninput:\n%s\nexpected %d got %d\n", i+1, j+1, tc.input, v, nums[j])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1443/verifierC.go
+++ b/1000-1999/1400-1499/1440-1449/1443/verifierC.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	input    string
+	expected []int
+}
+
+func solveCase(a, b []int) int {
+	n := len(a)
+	pairs := make([]struct{ a, b int }, n)
+	for i := 0; i < n; i++ {
+		pairs[i].a = a[i]
+		pairs[i].b = b[i]
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].a < pairs[j].a })
+	sumB := 0
+	for i := 0; i < n; i++ {
+		sumB += pairs[i].b
+	}
+	ans := sumB
+	for i := 0; i < n; i++ {
+		sumB -= pairs[i].b
+		time := sumB
+		if pairs[i].a > time {
+			time = pairs[i].a
+		}
+		if time < ans {
+			ans = time
+		}
+	}
+	return ans
+}
+
+func genTest(rng *rand.Rand) Test {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	expected := make([]int, 0, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(8) + 1
+		a := make([]int, n)
+		b := make([]int, n)
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			a[j] = rng.Intn(100)
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(a[j]))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			b[j] = rng.Intn(100)
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(b[j]))
+		}
+		sb.WriteByte('\n')
+		expected = append(expected, solveCase(a, b))
+	}
+	return Test{input: sb.String(), expected: expected}
+}
+
+func parseInts(s string) ([]int, error) {
+	fields := strings.Fields(strings.TrimSpace(s))
+	res := make([]int, len(fields))
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genTest(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		nums, err := parseInts(out)
+		if err != nil {
+			fmt.Printf("test %d bad output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if len(nums) != len(tc.expected) {
+			fmt.Printf("test %d expected %d numbers got %d\ninput:\n%s", i+1, len(tc.expected), len(nums), tc.input)
+			os.Exit(1)
+		}
+		for j, v := range tc.expected {
+			if nums[j] != v {
+				fmt.Printf("test %d failed at case %d\ninput:\n%s\nexpected %d got %d\n", i+1, j+1, tc.input, v, nums[j])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1443/verifierE.go
+++ b/1000-1999/1400-1499/1440-1449/1443/verifierE.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1443E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	input   string
+	answers int
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(4) + 2 // 2..5
+	q := rng.Intn(8) + 1 // 1..8
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	answers := 0
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", l, r))
+			answers++
+		} else {
+			x := rng.Intn(5) + 1
+			sb.WriteString(fmt.Sprintf("2 %d\n", x))
+		}
+	}
+	return Test{input: sb.String(), answers: answers}
+}
+
+func parseInts64(s string) ([]int64, error) {
+	fields := strings.Fields(strings.TrimSpace(s))
+	res := make([]int64, len(fields))
+	for i, f := range fields {
+		v, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genTest(rng)
+		exp, err := run(ref, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		expVals, err := parseInts64(exp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bad reference output on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		gotVals, err := parseInts64(got)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bad output on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if len(expVals) != tc.answers || len(gotVals) != tc.answers {
+			fmt.Printf("test %d expected %d numbers got %d\ninput:\n%s", i+1, tc.answers, len(gotVals), tc.input)
+			os.Exit(1)
+		}
+		for j := 0; j < tc.answers; j++ {
+			if expVals[j] != gotVals[j] {
+				fmt.Printf("test %d failed at answer %d\ninput:\n%s\nexpected %d got %d\n", i+1, j+1, tc.input, expVals[j], gotVals[j])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A, B, C and E of contest 1443
- each verifier generates 100 random tests and checks output
- verifier E builds `1443E.go` as reference

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierE.go`
- `go run verifierA.go ./A1443` (pass)
- `go run verifierB.go ./A1443` (fails as expected)


------
https://chatgpt.com/codex/tasks/task_e_68860fb256148324b6cbc849f2afcb69