### PR TITLE
Add contest 1445 solution verifiers

### DIFF
--- a/1000-1999/1400-1499/1440-1449/1445/verifierA.go
+++ b/1000-1999/1400-1499/1440-1449/1445/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n int
+	x int
+	a []int
+	b []int
+}
+
+func generateA(rng *rand.Rand) testCaseA {
+	n := rng.Intn(50) + 1   // 1..50
+	x := rng.Intn(1000) + 1 // 1..1000
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(x) + 1
+	}
+	for i := 0; i < n; i++ {
+		b[i] = rng.Intn(x) + 1
+	}
+	sort.Ints(a)
+	sort.Ints(b)
+	return testCaseA{n: n, x: x, a: a, b: b}
+}
+
+func expectedA(tc testCaseA) string {
+	for i := 0; i < tc.n; i++ {
+		if tc.a[i]+tc.b[tc.n-1-i] > tc.x {
+			return "No"
+		}
+	}
+	return "Yes"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCaseA) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "1\n%d %d\n", tc.n, tc.x)
+	for i, v := range tc.a {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, v)
+	}
+	b.WriteByte('\n')
+	for i, v := range tc.b {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, v)
+	}
+	b.WriteByte('\n')
+	expected := strings.ToLower(expectedA(tc))
+	got, err := run(bin, b.String())
+	if err != nil {
+		return err
+	}
+	if strings.ToLower(strings.TrimSpace(got)) != expected {
+		return fmt.Errorf("expected %s got %s", expected, strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateA(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1445/verifierB.go
+++ b/1000-1999/1400-1499/1440-1449/1445/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	a int
+	b int
+	c int
+	d int
+}
+
+func generateB(rng *rand.Rand) testCaseB {
+	a := rng.Intn(10)    // 0..9
+	d := rng.Intn(a + 1) // 0..a
+	c := rng.Intn(10)    // 0..9
+	if c < d {           // ensure b <= c after generation
+		c = d
+	}
+	b := rng.Intn(c-d+1) + d // b in [d, c]
+	return testCaseB{a: a, b: b, c: c, d: d}
+}
+
+func expectedB(tc testCaseB) string {
+	sum1 := tc.a + tc.b
+	sum2 := tc.c + tc.d
+	if sum2 > sum1 {
+		sum1 = sum2
+	}
+	return fmt.Sprintf("%d", sum1)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCaseB) error {
+	input := fmt.Sprintf("1\n%d %d %d %d\n", tc.a, tc.b, tc.c, tc.d)
+	expected := expectedB(tc)
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %s got %s", expected, strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateB(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces contest 1445 problems A and B
- each verifier runs 100 randomized test cases and checks outputs

## Testing
- `go run 1000-1999/1400-1499/1440-1449/1445/verifierA.go 1000-1999/1400-1499/1440-1449/1445/solA`
- `go run 1000-1999/1400-1499/1440-1449/1445/verifierB.go 1000-1999/1400-1499/1440-1449/1445/solB`

------
https://chatgpt.com/codex/tasks/task_e_688610ca772c83249ebb14a58e60e815