### PR TITLE
Add verifier programs for contest 1444

### DIFF
--- a/1000-1999/1400-1499/1440-1449/1444/verifierA.go
+++ b/1000-1999/1400-1499/1440-1449/1444/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1444A.go")
+	refBin := filepath.Join(os.TempDir(), "1444A_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	t := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		p := rand.Int63n(1000000) + 1
+		q := rand.Int63n(1000000) + 2
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, q))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1444/verifierB.go
+++ b/1000-1999/1400-1499/1440-1449/1444/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1444B.go")
+	refBin := filepath.Join(os.TempDir(), "1444B_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < 2*n; i++ {
+		val := rand.Int63n(100) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", val))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1444/verifierC.go
+++ b/1000-1999/1400-1499/1440-1449/1444/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1444C.go")
+	refBin := filepath.Join(os.TempDir(), "1444C_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(6) + 1
+	k := rand.Intn(4) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rand.Intn(maxEdges + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(k)+1))
+	}
+	sb.WriteByte('\n')
+	edges := make(map[[2]int]bool)
+	for i := 0; i < m; {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if edges[key] {
+			continue
+		}
+		edges[key] = true
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+		i++
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1444/verifierD.go
+++ b/1000-1999/1400-1499/1440-1449/1444/verifierD.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1444D.go")
+	refBin := filepath.Join(os.TempDir(), "1444D_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genCase() []byte {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		h := rand.Intn(4) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", h))
+		for j := 0; j < h; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(5)+1))
+		}
+		sb.WriteByte('\n')
+		v := rand.Intn(4) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", v))
+		for j := 0; j < v; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(5)+1))
+		}
+		sb.WriteByte('\n')
+		if i != t-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genCase()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1444/verifierE.go
+++ b/1000-1999/1400-1499/1440-1449/1444/verifierE.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+type caseE struct {
+	n     int
+	edges []edge
+	root  int
+	dist  [][]int
+}
+
+func genCase() caseE {
+	n := rand.Intn(7) + 2 // 2..8
+	edges := make([]edge, 0, n-1)
+	parent := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, edge{p, i})
+		parent[i] = p
+	}
+	root := rand.Intn(n) + 1
+	// compute distances via BFS from root
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	dist := make([]int, n+1)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := []int{root}
+	dist[root] = 0
+	for len(q) > 0 {
+		u := q[0]
+		q = q[1:]
+		for _, v := range adj[u] {
+			if dist[v] == -1 {
+				dist[v] = dist[u] + 1
+				q = append(q, v)
+			}
+		}
+	}
+	return caseE{n: n, edges: edges, root: root, dist: [][]int{dist}}
+}
+
+func runCase(bin string, c caseE) error {
+	cmd := exec.Command(bin)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	inW := bufio.NewWriter(stdin)
+	outR := bufio.NewReader(stdout)
+
+	fmt.Fprintln(inW, c.n)
+	for _, e := range c.edges {
+		fmt.Fprintf(inW, "%d %d\n", e.u, e.v)
+	}
+	inW.Flush()
+
+	dist := c.dist[0]
+	queries := 0
+	for {
+		line, err := outR.ReadString('\n')
+		if err != nil {
+			cmd.Process.Kill()
+			return fmt.Errorf("read error: %v", err)
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "?") {
+			queries++
+			if queries > 2*c.n {
+				cmd.Process.Kill()
+				return fmt.Errorf("too many queries")
+			}
+			parts := strings.Fields(line)
+			if len(parts) != 3 {
+				cmd.Process.Kill()
+				return fmt.Errorf("invalid query: %s", line)
+			}
+			u, _ := strconv.Atoi(parts[1])
+			v, _ := strconv.Atoi(parts[2])
+			if u < 1 || u > c.n || v < 1 || v > c.n {
+				cmd.Process.Kill()
+				return fmt.Errorf("query out of range")
+			}
+			du := dist[u]
+			dv := dist[v]
+			ans := u
+			if dv < du {
+				ans = v
+			}
+			fmt.Fprintln(inW, ans)
+			inW.Flush()
+		} else if strings.HasPrefix(line, "!") {
+			parts := strings.Fields(line)
+			if len(parts) != 2 {
+				cmd.Process.Kill()
+				return fmt.Errorf("invalid answer: %s", line)
+			}
+			guess, _ := strconv.Atoi(parts[1])
+			if guess != c.root {
+				cmd.Process.Kill()
+				return fmt.Errorf("wrong answer: expected %d got %d", c.root, guess)
+			}
+			stdin.Close()
+			cmd.Wait()
+			return nil
+		} else {
+			cmd.Process.Kill()
+			return fmt.Errorf("invalid output: %s", line)
+		}
+	}
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 1; i <= 100; i++ {
+		c := genCase()
+		if err := runCase(bin, c); err != nil {
+			fmt.Printf("case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1444 problems A–E
- verifiers build the reference solution and run 100 random tests
- interactive verifierE.go simulates the judge for the tree search

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`
- `git commit -m "Add Go verifiers for contest 1444"`


------
https://chatgpt.com/codex/tasks/task_e_6886103e7a0483248e7843b10fe51383