### PR TITLE
Add Go verifiers for contest 1441

### DIFF
--- a/1000-1999/1400-1499/1440-1449/1441/1441B.go
+++ b/1000-1999/1400-1499/1440-1449/1441/1441B.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-   "bufio"
-   "container/heap"
-   "fmt"
-   "os"
+	"bufio"
+	"container/heap"
+	"fmt"
+	"os"
 )
 
 const INF = 1e9
@@ -12,7 +12,7 @@ const MOD = 998244353
 
 // Item for priority queue: state (node u, parity p) with cost (flips f, moves m)
 type Item struct {
-   u, p, f, m int
+	u, p, f, m int
 }
 
 // A PriorityQueue implements heap.Interface and holds Items.
@@ -20,105 +20,105 @@ type PriorityQueue []*Item
 
 func (pq PriorityQueue) Len() int { return len(pq) }
 func (pq PriorityQueue) Less(i, j int) bool {
-   if pq[i].f != pq[j].f {
-       return pq[i].f < pq[j].f
-   }
-   return pq[i].m < pq[j].m
+	if pq[i].f != pq[j].f {
+		return pq[i].f < pq[j].f
+	}
+	return pq[i].m < pq[j].m
 }
 func (pq PriorityQueue) Swap(i, j int) { pq[i], pq[j] = pq[j], pq[i] }
 func (pq *PriorityQueue) Push(x interface{}) {
-   *pq = append(*pq, x.(*Item))
+	*pq = append(*pq, x.(*Item))
 }
 func (pq *PriorityQueue) Pop() interface{} {
-   old := *pq
-   n := len(old)
-   item := old[n-1]
-   *pq = old[0 : n-1]
-   return item
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[0 : n-1]
+	return item
 }
 
 func powmod(a, e int) int {
-   res := 1
-   base := a % MOD
-   for e > 0 {
-       if e&1 != 0 {
-           res = int((int64(res) * base) % MOD)
-       }
-       base = int((int64(base) * base) % MOD)
-       e >>= 1
-   }
-   return res
+	res := 1
+	base := a % MOD
+	for e > 0 {
+		if e&1 != 0 {
+			res = int((int64(res) * int64(base)) % MOD)
+		}
+		base = int((int64(base) * int64(base)) % MOD)
+		e >>= 1
+	}
+	return res
 }
 
 func main() {
-   in := bufio.NewReader(os.Stdin)
-   var n, m int
-   fmt.Fscan(in, &n, &m)
-   // graph: original and reversed adjacency lists
-   g0 := make([][]int, n+1)
-   g1 := make([][]int, n+1)
-   for i := 0; i < m; i++ {
-       var u, v int
-       fmt.Fscan(in, &u, &v)
-       g0[u] = append(g0[u], v)
-       g1[v] = append(g1[v], u)
-   }
-   // dist flips and moves
-   flips := make([][2]int, n+1)
-   moves := make([][2]int, n+1)
-   for i := 1; i <= n; i++ {
-       flips[i][0], flips[i][1] = INF, INF
-       moves[i][0], moves[i][1] = INF, INF
-   }
-   // initial state
-   pq := &PriorityQueue{}
-   heap.Init(pq)
-   flips[1][0] = 0
-   moves[1][0] = 0
-   heap.Push(pq, &Item{u: 1, p: 0, f: 0, m: 0})
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	fmt.Fscan(in, &n, &m)
+	// graph: original and reversed adjacency lists
+	g0 := make([][]int, n+1)
+	g1 := make([][]int, n+1)
+	for i := 0; i < m; i++ {
+		var u, v int
+		fmt.Fscan(in, &u, &v)
+		g0[u] = append(g0[u], v)
+		g1[v] = append(g1[v], u)
+	}
+	// dist flips and moves
+	flips := make([][2]int, n+1)
+	moves := make([][2]int, n+1)
+	for i := 1; i <= n; i++ {
+		flips[i][0], flips[i][1] = INF, INF
+		moves[i][0], moves[i][1] = INF, INF
+	}
+	// initial state
+	pq := &PriorityQueue{}
+	heap.Init(pq)
+	flips[1][0] = 0
+	moves[1][0] = 0
+	heap.Push(pq, &Item{u: 1, p: 0, f: 0, m: 0})
 
-   for pq.Len() > 0 {
-       it := heap.Pop(pq).(*Item)
-       u, p, f, mm := it.u, it.p, it.f, it.m
-       // skip if outdated
-       if f != flips[u][p] || mm != moves[u][p] {
-           continue
-       }
-       // try flip
-       np := 1 - p
-       nf := f + 1
-       nm := mm
-       if nf < flips[u][np] || (nf == flips[u][np] && nm < moves[u][np]) {
-           flips[u][np] = nf
-           moves[u][np] = nm
-           heap.Push(pq, &Item{u: u, p: np, f: nf, m: nm})
-       }
-       // try movements
-       var adj [][]int
-       if p == 0 {
-           adj = g0
-       } else {
-           adj = g1
-       }
-       for _, v := range adj[u] {
-           nf = f
-           nm = mm + 1
-           if nf < flips[v][p] || (nf == flips[v][p] && nm < moves[v][p]) {
-               flips[v][p] = nf
-               moves[v][p] = nm
-               heap.Push(pq, &Item{u: v, p: p, f: nf, m: nm})
-           }
-       }
-   }
-   // choose best at n
-   f0, m0 := flips[n][0], moves[n][0]
-   f1, m1 := flips[n][1], moves[n][1]
-   bf, bm := f0, m0
-   if f1 < bf || (f1 == bf && m1 < bm) {
-       bf, bm = f1, m1
-   }
-   // ans = (2^bf -1 + bm) mod MOD
-   t := powmod(2, bf)
-   ans := (int((t-1+MOD)%MOD) + bm) % MOD
-   fmt.Println(ans)
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(*Item)
+		u, p, f, mm := it.u, it.p, it.f, it.m
+		// skip if outdated
+		if f != flips[u][p] || mm != moves[u][p] {
+			continue
+		}
+		// try flip
+		np := 1 - p
+		nf := f + 1
+		nm := mm
+		if nf < flips[u][np] || (nf == flips[u][np] && nm < moves[u][np]) {
+			flips[u][np] = nf
+			moves[u][np] = nm
+			heap.Push(pq, &Item{u: u, p: np, f: nf, m: nm})
+		}
+		// try movements
+		var adj [][]int
+		if p == 0 {
+			adj = g0
+		} else {
+			adj = g1
+		}
+		for _, v := range adj[u] {
+			nf = f
+			nm = mm + 1
+			if nf < flips[v][p] || (nf == flips[v][p] && nm < moves[v][p]) {
+				flips[v][p] = nf
+				moves[v][p] = nm
+				heap.Push(pq, &Item{u: v, p: p, f: nf, m: nm})
+			}
+		}
+	}
+	// choose best at n
+	f0, m0 := flips[n][0], moves[n][0]
+	f1, m1 := flips[n][1], moves[n][1]
+	bf, bm := f0, m0
+	if f1 < bf || (f1 == bf && m1 < bm) {
+		bf, bm = f1, m1
+	}
+	// ans = (2^bf -1 + bm) mod MOD
+	t := powmod(2, bf)
+	ans := (int((t-1+MOD)%MOD) + bm) % MOD
+	fmt.Println(ans)
 }

--- a/1000-1999/1400-1499/1440-1449/1441/verifierA.go
+++ b/1000-1999/1400-1499/1440-1449/1441/verifierA.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input string
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1441A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 2 // at least 2
+	k := rng.Intn(n-1) + 1
+	perm := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v + 1))
+	}
+	sb.WriteByte('\n')
+	choose := rng.Perm(n)[:k]
+	for i, idx := range choose {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(idx + 1))
+	}
+	sb.WriteByte('\n')
+	return testCase{sb.String()}
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{"1\n2 1\n1 2\n1\n"},
+		{"1\n3 2\n1 2 3\n2 3\n"},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, tc := range cases {
+		exp, err := runExe(oracle, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1441/verifierB.go
+++ b/1000-1999/1400-1499/1440-1449/1441/verifierB.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+type testCase struct {
+	n     int
+	m     int
+	edges []edge
+}
+
+func (tc testCase) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for _, e := range tc.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1441B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 2
+	maxM := n * (n - 1)
+	m := rng.Intn(maxM) + 1
+	seen := make(map[[2]int]bool)
+	edges := make([]edge, 0, m)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		key := [2]int{u, v}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		edges = append(edges, edge{u, v})
+	}
+	return testCase{n, m, edges}
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{n: 2, m: 1, edges: []edge{{1, 2}}},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runExe(oracle, tc.Input())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.Input())
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, tc.Input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1441/verifierC.go
+++ b/1000-1999/1400-1499/1440-1449/1441/verifierC.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type arrCase struct {
+	len  int
+	vals []int64
+}
+
+type testCase struct {
+	n   int
+	k   int
+	arr []arrCase
+}
+
+func (tc testCase) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+	for _, a := range tc.arr {
+		sb.WriteString(strconv.Itoa(a.len))
+		for _, v := range a.vals {
+			sb.WriteByte(' ')
+			sb.WriteString(strconv.FormatInt(v, 10))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1441C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(5) + 1
+	arr := make([]arrCase, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(5) + 1
+		vals := make([]int64, l)
+		prev := int64(rng.Intn(3))
+		vals[0] = prev
+		for j := 1; j < l; j++ {
+			prev += int64(rng.Intn(3))
+			vals[j] = prev
+		}
+		arr[i] = arrCase{l, vals}
+	}
+	return testCase{n, k, arr}
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{n: 1, k: 1, arr: []arrCase{{len: 1, vals: []int64{5}}}},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runExe(oracle, tc.Input())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.Input())
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, tc.Input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1441/verifierD.go
+++ b/1000-1999/1400-1499/1440-1449/1441/verifierD.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+type testCase struct {
+	n      int
+	colors []int
+	edges  []edge
+}
+
+func (tc testCase) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(strconv.Itoa(tc.n) + "\n")
+	for i, c := range tc.colors {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(c))
+	}
+	sb.WriteByte('\n')
+	for _, e := range tc.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1441D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 1
+	colors := make([]int, n)
+	for i := 0; i < n; i++ {
+		colors[i] = rng.Intn(3)
+	}
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, edge{p, i})
+	}
+	return testCase{n, colors, edges}
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{n: 1, colors: []int{0}, edges: []edge{}}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runExe(oracle, tc.Input())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.Input())
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, tc.Input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1440-1449/1441/verifierE.go
+++ b/1000-1999/1400-1499/1440-1449/1441/verifierE.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem E is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1400-1499/1440-1449/1441/verifierF.go
+++ b/1000-1999/1400-1499/1440-1449/1441/verifierF.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+type testCase struct {
+	n      int
+	m      int
+	coords [][2]int
+	edges  []edge
+}
+
+func (tc testCase) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for _, c := range tc.coords {
+		sb.WriteString(fmt.Sprintf("%d %d\n", c[0], c[1]))
+	}
+	for _, e := range tc.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1441F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 2
+	if n%2 == 1 {
+		n++
+	}
+	coords := make([][2]int, n)
+	for i := 0; i < n; i++ {
+		coords[i] = [2]int{rng.Intn(11), rng.Intn(11)}
+	}
+	// build tree for connectivity
+	edges := make([]edge, 0)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, edge{p, i})
+	}
+	m := len(edges)
+	extra := rng.Intn(n)
+	seen := make(map[[2]int]bool)
+	for _, e := range edges {
+		seen[[2]int{e.u, e.v}] = true
+		seen[[2]int{e.v, e.u}] = true
+	}
+	for i := 0; i < extra; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if seen[[2]int{u, v}] {
+			continue
+		}
+		seen[[2]int{u, v}] = true
+		seen[[2]int{v, u}] = true
+		edges = append(edges, edge{u, v})
+	}
+	m = len(edges)
+	return testCase{n, m, coords, edges}
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{genCase(rng)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runExe(oracle, tc.Input())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.Input())
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, tc.Input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifier programs for contest 1441 problems A–F
- include small fix in `1441B.go` so the solution compiles

## Testing
- `go build 1000-1999/1400-1499/1440-1449/1441/verifierA.go`
- `go build 1000-1999/1400-1499/1440-1449/1441/verifierB.go`
- `go build 1000-1999/1400-1499/1440-1449/1441/verifierC.go`
- `go build 1000-1999/1400-1499/1440-1449/1441/verifierD.go`
- `go build 1000-1999/1400-1499/1440-1449/1441/verifierE.go`
- `go build 1000-1999/1400-1499/1440-1449/1441/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68860e9a2f2883248d1cafdbae9f3414