### PR TITLE
Add Go solution for 1527C

### DIFF
--- a/1000-1999/1500-1599/1520-1529/1527/1527C.go
+++ b/1000-1999/1500-1599/1520-1529/1527/1527C.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		// map from value to sum of indices of previous occurrences (1-indexed)
+		sumIdx := make(map[int]int64)
+		var ans int64
+		for i := 1; i <= n; i++ {
+			v := a[i-1]
+			if prevSum, ok := sumIdx[v]; ok {
+				ans += prevSum * int64(n-i+1)
+			}
+			sumIdx[v] += int64(i)
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1527C (Sequence Pair Weight)

## Testing
- `gofmt -w 1000-1999/1500-1599/1520-1529/1527/1527C.go`


------
https://chatgpt.com/codex/tasks/task_e_6886119cbbe88324acdb12823feb8d1d