### PR TITLE
Add Go verifiers for contest 1447

### DIFF
--- a/1000-1999/1400-1499/1440-1449/1447/verifierA.go
+++ b/1000-1999/1400-1499/1440-1449/1447/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+
+    binary := os.Args[1]
+    rand.Seed(1)
+    const t = 100
+    ns := make([]int, t)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d\n", t))
+    for i := 0; i < t; i++ {
+        n := rand.Intn(99) + 2 // 2..100
+        ns[i] = n
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+    }
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(sb.String())
+    output, err := cmd.CombinedOutput()
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "binary execution error: %v\n", err)
+        os.Exit(1)
+    }
+    reader := bufio.NewReader(bytes.NewReader(output))
+    for idx, n := range ns {
+        var m int
+        if _, err := fmt.Fscan(reader, &m); err != nil {
+            fmt.Printf("test %d: failed to read m: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if m < 1 || m > 1000 {
+            fmt.Printf("test %d: invalid m=%d\n", idx+1, m)
+            os.Exit(1)
+        }
+        ops := make([]int, m)
+        for j := 0; j < m; j++ {
+            if _, err := fmt.Fscan(reader, &ops[j]); err != nil {
+                fmt.Printf("test %d: failed to read op %d: %v\n", idx+1, j+1, err)
+                os.Exit(1)
+            }
+            if ops[j] < 1 || ops[j] > n {
+                fmt.Printf("test %d: invalid bag index %d\n", idx+1, ops[j])
+                os.Exit(1)
+            }
+        }
+        candies := make([]int, n)
+        for i := range candies {
+            candies[i] = i + 1
+        }
+        for opIdx, bag := range ops {
+            add := opIdx + 1
+            for i := 0; i < n; i++ {
+                if i+1 != bag {
+                    candies[i] += add
+                }
+            }
+        }
+        expected := candies[0]
+        for _, c := range candies {
+            if c != expected {
+                fmt.Printf("test %d: candies not equal\n", idx+1)
+                os.Exit(1)
+            }
+        }
+    }
+    // ensure no extra output
+    var extra string
+    if _, err := fmt.Fscan(reader, &extra); err == nil {
+        fmt.Println("extra output detected")
+        os.Exit(1)
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1400-1499/1440-1449/1447/verifierB.go
+++ b/1000-1999/1400-1499/1440-1449/1447/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func expected(grid [][]int64) int64 {
+    var sumAbs int64
+    countNeg := 0
+    countZero := 0
+    minAbs := int64(1<<62)
+    for _, row := range grid {
+        for _, v := range row {
+            if v < 0 {
+                countNeg++
+            }
+            if v == 0 {
+                countZero++
+            }
+            if v < 0 {
+                v = -v
+            }
+            if v < minAbs {
+                minAbs = v
+            }
+            sumAbs += v
+        }
+    }
+    if countNeg%2 != 0 && countZero == 0 {
+        sumAbs -= 2 * minAbs
+    }
+    return sumAbs
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    binary := os.Args[1]
+    rand.Seed(1)
+    const t = 100
+    type test struct {
+        n, m int
+        grid [][]int64
+    }
+    tests := make([]test, t)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d\n", t))
+    for i := 0; i < t; i++ {
+        n := rand.Intn(9) + 2   //2..10
+        m := rand.Intn(9) + 2
+        g := make([][]int64, n)
+        sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+        for r := 0; r < n; r++ {
+            g[r] = make([]int64, m)
+            for c := 0; c < m; c++ {
+                val := int64(rand.Intn(201) - 100)
+                g[r][c] = val
+                sb.WriteString(fmt.Sprintf("%d ", val))
+            }
+            sb.WriteString("\n")
+        }
+        tests[i] = test{n: n, m: m, grid: g}
+    }
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(sb.String())
+    output, err := cmd.CombinedOutput()
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "binary execution error: %v\n", err)
+        os.Exit(1)
+    }
+    reader := bufio.NewReader(bytes.NewReader(output))
+    for i, tst := range tests {
+        var got int64
+        if _, err := fmt.Fscan(reader, &got); err != nil {
+            fmt.Printf("test %d: failed to read output: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        exp := expected(tst.grid)
+        if got != exp {
+            fmt.Printf("test %d: expected %d, got %d\n", i+1, exp, got)
+            os.Exit(1)
+        }
+    }
+    var extra string
+    if _, err := fmt.Fscan(reader, &extra); err == nil {
+        fmt.Println("extra output detected")
+        os.Exit(1)
+    }
+    fmt.Println("All tests passed")
+}
+


### PR DESCRIPTION
## Summary
- add `verifierA.go` to validate solutions for problem A
- add `verifierB.go` to validate solutions for problem B

These verifiers generate 100 random test cases and check the output of a given binary.

## Testing
- `go run 1000-1999/1400-1499/1440-1449/1447/verifierA.go /tmp/binA`
- `go run 1000-1999/1400-1499/1440-1449/1447/verifierB.go /tmp/binB`


------
https://chatgpt.com/codex/tasks/task_e_688611e2aeec83248f9acab16e6a9cac