### PR TITLE
Add Go solution for 1527A

### DIFF
--- a/1000-1999/1500-1599/1520-1529/1527/1527A.go
+++ b/1000-1999/1500-1599/1520-1529/1527/1527A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/bits"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	for ; t > 0; t-- {
+		var n uint
+		fmt.Fscan(in, &n)
+		// Find the highest power of two <= n
+		if n == 0 {
+			fmt.Fprintln(out, 0)
+			continue
+		}
+		pow := uint(1) << (bits.Len(n) - 1)
+		fmt.Fprintln(out, pow-1)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1527A.go` for the problem "And Then There Were K"

## Testing
- `go build 1527A.go`
- `go vet 1527A.go`

------
https://chatgpt.com/codex/tasks/task_e_688612b4c60483248fccb3c048e11c4b