### PR TITLE
Add verifiers for contest 1446

### DIFF
--- a/1000-1999/1400-1499/1440-1449/1446/verifierA.go
+++ b/1000-1999/1400-1499/1440-1449/1446/verifierA.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	W int64
+	w []int64
+}
+
+func expected(n int, W int64, w []int64) []int {
+	half := (W + 1) / 2
+	for i := 0; i < n; i++ {
+		if w[i] >= half && w[i] <= W {
+			return []int{i + 1}
+		}
+	}
+	type pair struct {
+		w   int64
+		idx int
+	}
+	arr := make([]pair, n)
+	for i := range arr {
+		arr[i] = pair{w[i], i + 1}
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i].w < arr[j].w })
+	var sum int64
+	var res []int
+	for _, p := range arr {
+		if sum+p.w <= W {
+			sum += p.w
+			res = append(res, p.idx)
+			if sum >= half {
+				return res
+			}
+		}
+	}
+	return nil
+}
+
+func runBin(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCase {
+	tests := []testCase{
+		{n: 1, W: 10, w: []int64{5}},
+		{n: 3, W: 10, w: []int64{1, 2, 8}},
+		{n: 4, W: 7, w: []int64{1, 2, 3, 4}},
+		{n: 5, W: 100, w: []int64{60, 70, 80, 90, 95}},
+		{n: 2, W: 1, w: []int64{2, 3}},
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := r.Intn(10) + 1
+		W := r.Int63n(1000) + 1
+		w := make([]int64, n)
+		for j := 0; j < n; j++ {
+			w[j] = r.Int63n(1000) + 1
+		}
+		tests = append(tests, testCase{n: n, W: W, w: w})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("1\n%d %d\n", t.n, t.W)
+		for j, v := range t.w {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+		exp := expected(t.n, t.W, t.w)
+		out, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 0 {
+			fmt.Fprintf(os.Stderr, "test %d: no output\n", i+1)
+			os.Exit(1)
+		}
+		k, err := strconv.Atoi(fields[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: cannot parse k\n", i+1)
+			os.Exit(1)
+		}
+		half := (t.W + 1) / 2
+		if k == -1 {
+			if exp != nil {
+				fmt.Fprintf(os.Stderr, "test %d: expected solution but got -1\n", i+1)
+				os.Exit(1)
+			}
+			continue
+		}
+		if len(fields) != k+1 {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d indices, got %d\n", i+1, k, len(fields)-1)
+			os.Exit(1)
+		}
+		used := make(map[int]bool)
+		var sum int64
+		for j := 0; j < k; j++ {
+			idx, err := strconv.Atoi(fields[j+1])
+			if err != nil || idx < 1 || idx > t.n || used[idx] {
+				fmt.Fprintf(os.Stderr, "test %d: invalid index %q\n", i+1, fields[j+1])
+				os.Exit(1)
+			}
+			used[idx] = true
+			sum += t.w[idx-1]
+		}
+		if sum < half || sum > t.W {
+			fmt.Fprintf(os.Stderr, "test %d: invalid subset sum %d\n", i+1, sum)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1440-1449/1446/verifierB.go
+++ b/1000-1999/1400-1499/1440-1449/1446/verifierB.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	A string
+	B string
+}
+
+func expectedScore(a, b string) int {
+	n, m := len(a), len(b)
+	dpPrev := make([]int, m+1)
+	dpCur := make([]int, m+1)
+	maxScore := 0
+	for i := 1; i <= n; i++ {
+		dpCur[0] = 0
+		for j := 1; j <= m; j++ {
+			best := dpPrev[j] - 1
+			if v := dpCur[j-1] - 1; v > best {
+				best = v
+			}
+			if a[i-1] == b[j-1] {
+				if v := dpPrev[j-1] + 2; v > best {
+					best = v
+				}
+			}
+			if best < 0 {
+				best = 0
+			}
+			dpCur[j] = best
+			if best > maxScore {
+				maxScore = best
+			}
+		}
+		dpPrev, dpCur = dpCur, dpPrev
+	}
+	return maxScore
+}
+
+func runBin(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCase {
+	tests := []testCase{
+		{A: "abc", B: "abc"},
+		{A: "abacaba", B: "acababa"},
+		{A: "aaa", B: "bbb"},
+		{A: "abcd", B: "bc"},
+		{A: "a", B: "a"},
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := r.Intn(10) + 1
+		m := r.Intn(10) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteByte(byte('a' + r.Intn(4)))
+		}
+		A := sb.String()
+		sb.Reset()
+		for j := 0; j < m; j++ {
+			sb.WriteByte(byte('a' + r.Intn(4)))
+		}
+		B := sb.String()
+		tests = append(tests, testCase{A: A, B: B})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n%s\n%s\n", len(t.A), len(t.B), t.A, t.B)
+		want := expectedScore(t.A, t.B)
+		out, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: cannot parse output\n", i+1)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %d got %d\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1440-1449/1446/verifierC.go
+++ b/1000-1999/1400-1499/1440-1449/1446/verifierC.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	a []int
+}
+
+type node struct {
+	ch  [2]int
+	cnt int
+}
+
+var nodes []node
+var tot int
+
+func insert(x int) {
+	idx := 1
+	nodes[idx].cnt++
+	for b := 30; b >= 0; b-- {
+		bit := (x >> b) & 1
+		nxt := nodes[idx].ch[bit]
+		if nxt == 0 {
+			tot++
+			nodes = append(nodes, node{})
+			nxt = tot
+			nodes[idx].ch[bit] = nxt
+		}
+		idx = nxt
+		nodes[idx].cnt++
+	}
+}
+
+func f(idx, b int) int {
+	if idx == 0 || nodes[idx].cnt == 0 {
+		return 0
+	}
+	if nodes[idx].cnt == 1 || b < 0 {
+		return 1
+	}
+	l := nodes[idx].ch[0]
+	r := nodes[idx].ch[1]
+	if l == 0 {
+		return f(r, b-1)
+	}
+	if r == 0 {
+		return f(l, b-1)
+	}
+	left := f(l, b-1)
+	right := f(r, b-1)
+	if left > right {
+		return left + 1
+	}
+	return right + 1
+}
+
+func expected(a []int) int {
+	nodes = make([]node, 2)
+	tot = 1
+	for _, x := range a {
+		insert(x)
+	}
+	best := f(1, 30)
+	if best < 2 {
+		best = 2
+	}
+	return len(a) - best
+}
+
+func runBin(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCase {
+	tests := []testCase{
+		{a: []int{0, 1}},
+		{a: []int{0, 1, 5, 2}},
+		{a: []int{1, 2, 4, 8}},
+		{a: []int{7, 3, 5, 1}},
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := r.Intn(10) + 2
+		m := make(map[int]bool)
+		arr := make([]int, 0, n)
+		for len(arr) < n {
+			v := r.Intn(1024)
+			if !m[v] {
+				m[v] = true
+				arr = append(arr, v)
+			}
+		}
+		tests = append(tests, testCase{a: arr})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(t.a)))
+		for j, v := range t.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		want := expected(append([]int(nil), t.a...))
+		out, err := runBin(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: cannot parse output\n", i+1)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %d got %d\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1440-1449/1446/verifierD1.go
+++ b/1000-1999/1400-1499/1440-1449/1446/verifierD1.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	a []int
+}
+
+func expected(a []int) int {
+	n := len(a)
+	maxVal := 0
+	for _, v := range a {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	counts := make([]int, maxVal+1)
+	freqCount := make([]int, n+2)
+	check := func(L int) bool {
+		if L < 2 {
+			return false
+		}
+		for i := range counts {
+			counts[i] = 0
+		}
+		for i := range freqCount {
+			freqCount[i] = 0
+		}
+		fmax := 0
+		for i := 0; i < L; i++ {
+			v := a[i]
+			old := counts[v]
+			if old > 0 {
+				freqCount[old]--
+			}
+			counts[v] = old + 1
+			freqCount[old+1]++
+			if old+1 > fmax {
+				fmax = old + 1
+			}
+		}
+		if freqCount[fmax] >= 2 {
+			return true
+		}
+		for i := L; i < n; i++ {
+			v := a[i]
+			old := counts[v]
+			if old > 0 {
+				freqCount[old]--
+			}
+			counts[v] = old + 1
+			freqCount[old+1]++
+			if old+1 > fmax {
+				fmax = old + 1
+			}
+			u := a[i-L]
+			old2 := counts[u]
+			freqCount[old2]--
+			counts[u] = old2 - 1
+			if old2-1 > 0 {
+				freqCount[old2-1]++
+			}
+			if old2 == fmax && freqCount[old2] == 0 {
+				for fmax > 0 && freqCount[fmax] == 0 {
+					fmax--
+				}
+			}
+			if freqCount[fmax] >= 2 {
+				return true
+			}
+		}
+		return false
+	}
+	lo, hi := 0, n+1
+	for lo+1 < hi {
+		mid := (lo + hi) / 2
+		if check(mid) {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	return lo
+}
+
+func runBin(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCase {
+	tests := []testCase{
+		{a: []int{1, 1, 2, 2}},
+		{a: []int{1, 2, 3, 4}},
+		{a: []int{1, 1, 1, 2, 2, 2}},
+		{a: []int{5, 5, 5, 5}},
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := r.Intn(20) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = r.Intn(10) + 1
+		}
+		tests = append(tests, testCase{a: arr})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(t.a)))
+		for j, v := range t.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		want := expected(t.a)
+		out, err := runBin(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: cannot parse output\n", i+1)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %d got %d\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1440-1449/1446/verifierD2.go
+++ b/1000-1999/1400-1499/1440-1449/1446/verifierD2.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	a []int
+}
+
+func expected(a []int) int {
+	n := len(a)
+	pos := make([][]int, n+1)
+	for i, v := range a {
+		if v >= 1 && v <= n {
+			pos[v] = append(pos[v], i)
+		}
+	}
+	maxf := 0
+	for v := 1; v <= n; v++ {
+		if len(pos[v]) > maxf {
+			maxf = len(pos[v])
+		}
+	}
+	if maxf < 2 {
+		return 0
+	}
+	cnt := make([]int, maxf+2)
+	L := make([]int, maxf+2)
+	R := make([]int, maxf+2)
+	A := make([]int, maxf+2)
+	for k := 1; k <= maxf; k++ {
+		L[k] = n
+		R[k] = -1
+		A[k] = n
+	}
+	for v := 1; v <= n; v++ {
+		pv := pos[v]
+		m := len(pv)
+		if m == 0 {
+			continue
+		}
+		first := pv[0]
+		for k := 1; k <= m; k++ {
+			cnt[k]++
+			if first < L[k] {
+				L[k] = first
+			}
+			idx := pv[k-1]
+			if idx > R[k] {
+				R[k] = idx
+			}
+		}
+		for k := 1; k < m; k++ {
+			nxt := pv[k]
+			if nxt < A[k] {
+				A[k] = nxt
+			}
+		}
+	}
+	ans := 0
+	for k := 1; k <= maxf; k++ {
+		if cnt[k] < 2 {
+			continue
+		}
+		if A[k] <= R[k] {
+			continue
+		}
+		length := R[k] - L[k] + 1
+		if length > ans {
+			ans = length
+		}
+	}
+	return ans
+}
+
+func runBin(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCase {
+	tests := []testCase{
+		{a: []int{1, 1, 2, 2}},
+		{a: []int{1, 2, 3, 4}},
+		{a: []int{1, 1, 1, 2, 2, 2}},
+		{a: []int{5, 5, 5, 5}},
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := r.Intn(20) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = r.Intn(n) + 1
+		}
+		tests = append(tests, testCase{a: arr})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(t.a)))
+		for j, v := range t.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		want := expected(t.a)
+		out, err := runBin(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: cannot parse output\n", i+1)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %d got %d\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1440-1449/1446/verifierE.go
+++ b/1000-1999/1400-1499/1440-1449/1446/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	pts [][2]int
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(t testCase) (string, error) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.pts)))
+	for _, p := range t.pts {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+	}
+	return runProg("1446E.go", sb.String())
+}
+
+func generateTests() []testCase {
+	tests := []testCase{
+		{pts: [][2]int{{0, 0}, {1, 0}}},
+		{pts: [][2]int{{0, 0}, {1, 0}, {0, 1}}},
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := r.Intn(5) + 1
+		m := make(map[[2]int]bool)
+		pts := make([][2]int, 0, n)
+		for len(pts) < n {
+			x := r.Intn(20)
+			y := r.Intn(20)
+			p := [2]int{x, y}
+			if !m[p] {
+				m[p] = true
+				pts = append(pts, p)
+			}
+		}
+		tests = append(tests, testCase{pts: pts})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(t.pts)))
+		for _, p := range t.pts {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+		}
+		want, err := expected(t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %q got %q\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1440-1449/1446/verifierF.go
+++ b/1000-1999/1400-1499/1440-1449/1446/verifierF.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	k   int64
+	pts [][2]float64
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(t testCase) (string, error) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.k))
+	for _, p := range t.pts {
+		sb.WriteString(fmt.Sprintf("%f %f\n", p[0], p[1]))
+	}
+	return runProg("1446F.go", sb.String())
+}
+
+func generateTests() []testCase {
+	tests := []testCase{}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 105; i++ {
+		n := r.Intn(5) + 2
+		totalPairs := int64(n * (n - 1) / 2)
+		k := int64(r.Intn(int(totalPairs)) + 1)
+		pts := make([][2]float64, n)
+		for j := 0; j < n; j++ {
+			pts[j][0] = r.Float64()*20 - 10
+			pts[j][1] = r.Float64()*20 - 10
+		}
+		tests = append(tests, testCase{n: n, k: k, pts: pts})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.k))
+		for _, p := range t.pts {
+			sb.WriteString(fmt.Sprintf("%f %f\n", p[0], p[1]))
+		}
+		want, err := expected(t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		wantVal := strings.TrimSpace(want)
+		gotVal := strings.TrimSpace(got)
+		if v1, err1 := strconv.ParseFloat(gotVal, 64); err1 == nil {
+			if v2, err2 := strconv.ParseFloat(wantVal, 64); err2 == nil {
+				diff := v1 - v2
+				if diff < 0 {
+					diff = -diff
+				}
+				if diff > 1e-6 {
+					fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\n", i+1, wantVal, gotVal)
+					os.Exit(1)
+				}
+				continue
+			}
+		}
+		if gotVal != wantVal {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %q got %q\n", i+1, wantVal, gotVal)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all 1446 problems (A–F)
- each verifier generates 100+ random tests
- verifiers validate any binary via `go run verifierX.go /path/to/binary`

## Testing
- `go run verifierA.go ./refA`
- `go run verifierB.go ./refB`
- `go run verifierC.go ./refC`
- `go run verifierD1.go ./refD1`
- `go run verifierD2.go ./refD2`
- `go run verifierE.go ./refE`
- `go run verifierF.go ./refF`


------
https://chatgpt.com/codex/tasks/task_e_68861156a97483249ae25203291a7e58