### PR TITLE
Add Go verifiers for contest 1450

### DIFF
--- a/1000-1999/1400-1499/1450-1459/1450/verifierA.go
+++ b/1000-1999/1400-1499/1450-1459/1450/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(s string) string {
+	bs := []byte(s)
+	sort.Slice(bs, func(i, j int) bool { return bs[i] < bs[j] })
+	return string(bs)
+}
+
+func buildCase(s string) testCase {
+	n := len(s)
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	return testCase{input: input, expected: solveCase(s)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return buildCase(string(b))
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %q got %q", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase("trygub"))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1450/verifierB.go
+++ b/1000-1999/1400-1499/1450-1459/1450/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solveCase(xs, ys []int, k int) int {
+	n := len(xs)
+	for i := 0; i < n; i++ {
+		ok := true
+		for j := 0; j < n; j++ {
+			if abs(xs[i]-xs[j])+abs(ys[i]-ys[j]) > k {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return 1
+		}
+	}
+	return -1
+}
+
+func buildCase(xs, ys []int, k int) testCase {
+	n := len(xs)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", xs[i], ys[i])
+	}
+	ans := solveCase(xs, ys, k)
+	return testCase{input: sb.String(), expected: fmt.Sprintf("%d", ans)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(20)
+	xs := make([]int, n)
+	ys := make([]int, n)
+	for i := 0; i < n; i++ {
+		xs[i] = rng.Intn(21)
+		ys[i] = rng.Intn(21)
+	}
+	return buildCase(xs, ys, k)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1450/verifierC1.go
+++ b/1000-1999/1400-1499/1450-1459/1450/verifierC1.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solve(grid []string) []string {
+	n := len(grid)
+	cnt := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if grid[i][j] == 'X' {
+				cnt++
+			}
+		}
+	}
+	for k := 0; k < 3; k++ {
+		c := 0
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if (i+j)%3 == k && grid[i][j] == 'X' {
+					c++
+				}
+			}
+		}
+		if c <= cnt/3 {
+			res := make([]string, n)
+			for i := 0; i < n; i++ {
+				row := []byte(grid[i])
+				for j := 0; j < n; j++ {
+					if (i+j)%3 == k && row[j] == 'X' {
+						row[j] = 'O'
+					}
+				}
+				res[i] = string(row)
+			}
+			return res
+		}
+	}
+	return grid
+}
+
+func buildCase(grid []string) testCase {
+	n := len(grid)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		sb.WriteString(grid[i])
+		sb.WriteByte('\n')
+	}
+	out := solve(grid)
+	expected := strings.Join(out, "\n")
+	return testCase{input: sb.String(), expected: expected}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = 'X'
+			} else {
+				b[j] = '.'
+			}
+		}
+		grid[i] = string(b)
+	}
+	return buildCase(grid)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected:\n%s\n----\ngot:\n%s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1450/verifierC2.go
+++ b/1000-1999/1400-1499/1450-1459/1450/verifierC2.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solve(grid []string) []string {
+	n := len(grid)
+	k := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if grid[i][j] != '.' {
+				k++
+			}
+		}
+	}
+	limit := k / 3
+	choices := [][3]byte{{'*', 'O', 'X'}, {'*', 'X', 'O'}, {'O', '*', 'X'}, {'X', '*', 'O'}, {'O', 'X', '*'}, {'X', 'O', '*'}}
+	var use [3]byte
+	for _, ch := range choices {
+		cnt := 0
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				c := grid[i][j]
+				if c == '.' {
+					continue
+				}
+				d := (i + j) % 3
+				if ch[d] != '*' && c != ch[d] {
+					cnt++
+				}
+			}
+		}
+		if cnt <= limit {
+			use = ch
+			break
+		}
+	}
+	res := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := []byte(grid[i])
+		for j := 0; j < n; j++ {
+			c := row[j]
+			if c == '.' {
+				continue
+			}
+			d := (i + j) % 3
+			if use[d] != '*' {
+				row[j] = use[d]
+			}
+		}
+		res[i] = string(row)
+	}
+	return res
+}
+
+func buildCase(grid []string) testCase {
+	n := len(grid)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		sb.WriteString(grid[i])
+		sb.WriteByte('\n')
+	}
+	expected := strings.Join(solve(grid), "\n")
+	return testCase{input: sb.String(), expected: expected}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			r := rng.Intn(3)
+			switch r {
+			case 0:
+				b[j] = '.'
+			case 1:
+				b[j] = 'X'
+			default:
+				b[j] = 'O'
+			}
+		}
+		grid[i] = string(b)
+	}
+	return buildCase(grid)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected:\n%s\n----\ngot:\n%s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1450/verifierD.go
+++ b/1000-1999/1400-1499/1450-1459/1450/verifierD.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solve(a []int) string {
+	n := len(a)
+	pos := make([]int, n+1)
+	for i, v := range a {
+		pos[v] = i
+	}
+	L := make([]int, n)
+	R := make([]int, n)
+	stack := []int{}
+	for i := 0; i < n; i++ {
+		for len(stack) > 0 && a[stack[len(stack)-1]] >= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			L[i] = -1
+		} else {
+			L[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	stack = stack[:0]
+	for i := n - 1; i >= 0; i-- {
+		for len(stack) > 0 && a[stack[len(stack)-1]] >= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			R[i] = n
+		} else {
+			R[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	span := make([]int, n+1)
+	for x := 1; x <= n; x++ {
+		idx := pos[x]
+		span[x] = R[idx] - L[idx] - 1
+	}
+	minSpan := make([]int, n+2)
+	minSpan[0] = n + 1
+	for i := 1; i <= n; i++ {
+		if span[i] < minSpan[i-1] {
+			minSpan[i] = span[i]
+		} else {
+			minSpan[i] = minSpan[i-1]
+		}
+	}
+	res := make([]byte, n)
+	for k := 1; k <= n; k++ {
+		m := n - k + 1
+		if minSpan[m] >= k {
+			res[k-1] = '1'
+		} else {
+			res[k-1] = '0'
+		}
+	}
+	return string(res)
+}
+
+func buildCase(a []int) testCase {
+	n := len(a)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	expected := solve(a)
+	return testCase{input: sb.String(), expected: expected}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	perm := rng.Perm(n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = perm[i] + 1
+	}
+	return buildCase(a)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1450/verifierE.go
+++ b/1000-1999/1400-1499/1450-1459/1450/verifierE.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct{ to, val int }
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+const inf = 1e9
+
+func solveCase(n int, edges [][3]int) string {
+	graph := make([][]Edge, n+1)
+	addEdge := func(u, v, w int) { graph[u] = append(graph[u], Edge{v, w}) }
+	for _, e := range edges {
+		x, y, z := e[0], e[1], e[2]
+		addEdge(x, y, 1)
+		if z != 0 {
+			addEdge(y, x, -1)
+		} else {
+			addEdge(y, x, 1)
+		}
+	}
+	col := make([]int, n+1)
+	var dfs func(int, int) bool
+	dfs = func(u, c int) bool {
+		col[u] = c
+		for _, ed := range graph[u] {
+			v := ed.to
+			if col[v] != 0 {
+				if col[v] != -c {
+					return false
+				}
+			} else {
+				if !dfs(v, -c) {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	dis := make([]int, n+1)
+	cnt := make([]int, n+1)
+	inq := make([]bool, n+1)
+	SPFA := func() bool {
+		for i := 1; i <= n; i++ {
+			dis[i] = inf
+			cnt[i] = 0
+			inq[i] = false
+		}
+		dis[1] = 0
+		q := []int{1}
+		inq[1] = true
+		for len(q) > 0 {
+			u := q[0]
+			q = q[1:]
+			inq[u] = false
+			for _, ed := range graph[u] {
+				v := ed.to
+				if dis[v] > dis[u]+ed.val {
+					dis[v] = dis[u] + ed.val
+					cnt[v] = cnt[u] + 1
+					if cnt[v] > n {
+						return true
+					}
+					if !inq[v] {
+						inq[v] = true
+						q = append(q, v)
+					}
+				}
+			}
+		}
+		return false
+	}
+	type Item struct{ dist, node int }
+	type MinHeap []Item
+	var heapLess = func(h MinHeap, i, j int) bool { return h[i].dist < h[j].dist }
+	var hswap = func(h MinHeap, i, j int) { h[i], h[j] = h[j], h[i] }
+	var hpush = func(h *MinHeap, x Item) { *h = append(*h, x) }
+	solveFrom := func(src int) (int, []int, bool) {
+		dist := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			dist[i] = inf
+		}
+		dist[src] = 0
+		h := MinHeap{{0, src}}
+		for len(h) > 0 {
+			// pop min
+			bestIdx := 0
+			for i := 1; i < len(h); i++ {
+				if heapLess(h, i, bestIdx) {
+					bestIdx = i
+				}
+			}
+			it := h[bestIdx]
+			hswap(h, bestIdx, len(h)-1)
+			h = h[:len(h)-1]
+			d, u := it.dist, it.node
+			if d > dist[u] {
+				continue
+			}
+			if d < 0 {
+				return 0, nil, false
+			}
+			for _, ed := range graph[u] {
+				v := ed.to
+				nd := d + ed.val
+				if nd < dist[v] {
+					dist[v] = nd
+					hpush(&h, Item{nd, v})
+				}
+			}
+		}
+		mx := 0
+		for i := 1; i <= n; i++ {
+			if dist[i] > mx {
+				mx = dist[i]
+			}
+		}
+		res := make([]int, n)
+		for i := 1; i <= n; i++ {
+			res[i-1] = dist[i]
+		}
+		return mx, res, true
+	}
+
+	if !dfs(1, 1) || SPFA() {
+		return "NO"
+	}
+	best := -1
+	var bestVec []int
+	for i := 1; i <= n; i++ {
+		mx, vec, ok := solveFrom(i)
+		if ok && mx > best {
+			best = mx
+			bestVec = vec
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	sb.WriteString(fmt.Sprintf("%d\n", best))
+	for i, v := range bestVec {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func buildCase(n int, edges [][3]int) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e[0], e[1], e[2])
+	}
+	exp := solveCase(n, edges)
+	return testCase{input: sb.String(), expected: exp}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(n*2) + 1
+	edges := make([][3]int, m)
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		for v == u {
+			v = rng.Intn(n) + 1
+		}
+		z := rng.Intn(2)
+		edges[i] = [3]int{u, v, z}
+	}
+	return buildCase(n, edges)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected:\n%s\n----\ngot:\n%s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1450/verifierF.go
+++ b/1000-1999/1400-1499/1450-1459/1450/verifierF.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solve(a []int) int {
+	n := len(a)
+	breakCnt := 0
+	for i := 0; i+1 < n; i++ {
+		if a[i] == a[i+1] {
+			breakCnt++
+		}
+	}
+	k := breakCnt + 1
+	palCount := make(map[int]int)
+	l := 0
+	for i := 0; i < n; i++ {
+		if i+1 < n && a[i] != a[i+1] {
+			continue
+		}
+		if a[l] == a[i] {
+			palCount[a[l]]++
+		}
+		l = i + 1
+	}
+	maxPal := (k + 1) / 2
+	for _, c := range palCount {
+		if c > maxPal {
+			return -1
+		}
+	}
+	return k - 1
+}
+
+func buildCase(a []int) testCase {
+	n := len(a)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	expected := fmt.Sprintf("%d", solve(a))
+	return testCase{input: sb.String(), expected: expected}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(5)
+	}
+	return buildCase(a)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1450/verifierG.go
+++ b/1000-1999/1400-1499/1450-1459/1450/verifierG.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solve(n, a, b int, s string) string {
+	alpha := 26
+	fpos := make([]int, alpha)
+	lpos := make([]int, alpha)
+	cnt := make([]int, alpha)
+	for i := range fpos {
+		fpos[i] = n + 1
+	}
+	for i, ch := range s {
+		idx := int(ch - 'a')
+		cnt[idx]++
+		pos := i + 1
+		if pos < fpos[idx] {
+			fpos[idx] = pos
+		}
+		if pos > lpos[idx] {
+			lpos[idx] = pos
+		}
+	}
+	good := make([]bool, alpha)
+	for i := 0; i < alpha; i++ {
+		if cnt[i] == 0 {
+			continue
+		}
+		length := lpos[i] - fpos[i] + 1
+		if a*length <= b*cnt[i] {
+			good[i] = true
+		}
+	}
+	var ans []rune
+	for i := 0; i < alpha; i++ {
+		if cnt[i] == 0 {
+			continue
+		}
+		ok := true
+		for j := 0; j < alpha; j++ {
+			if j == i || cnt[j] == 0 {
+				continue
+			}
+			if !good[j] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			ans = append(ans, rune('a'+i))
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d", len(ans)))
+	if len(ans) > 0 {
+		sb.WriteByte(' ')
+		for i, ch := range ans {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(string(ch))
+		}
+	}
+	return sb.String()
+}
+
+func buildCase(n, a, b int, s string) testCase {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n%s\n", n, a, b, s)
+	exp := solve(n, a, b, s)
+	return testCase{input: sb.String(), expected: exp}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	a := rng.Intn(5) + 1
+	b := rng.Intn(5) + 1
+	bStr := make([]byte, n)
+	for i := 0; i < n; i++ {
+		bStr[i] = byte('a' + rng.Intn(26))
+	}
+	return buildCase(n, a, b, string(bStr))
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %q got %q", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1450/verifierH1.go
+++ b/1000-1999/1400-1499/1450-1459/1450/verifierH1.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func between(x, a, b, n int) bool {
+	if a < b {
+		return a < x && x < b
+	}
+	return a < x || x < b
+}
+
+func cross(a, b, c, d, n int) bool {
+	return between(c, a, b, n) != between(d, a, b, n) && between(a, c, d, n) != between(b, c, d, n)
+}
+
+func pairings(idx []int) [][][2]int {
+	if len(idx) == 0 {
+		return [][][2]int{{}}
+	}
+	first := idx[0]
+	rest := idx[1:]
+	var res [][][2]int
+	for i, v := range rest {
+		rem := append([]int(nil), rest[:i]...)
+		rem = append(rem, rest[i+1:]...)
+		for _, sub := range pairings(rem) {
+			res = append(res, append([][2]int{{first, v}}, sub...))
+		}
+	}
+	return res
+}
+
+func minIntersections(coloring []byte) int {
+	n := len(coloring)
+	var black, white []int
+	for i, c := range coloring {
+		if c == 'b' {
+			black = append(black, i)
+		}
+		if c == 'w' {
+			white = append(white, i)
+		}
+	}
+	pb := pairings(black)
+	pw := pairings(white)
+	best := int(^uint(0) >> 1)
+	for _, bpair := range pb {
+		for _, wpair := range pw {
+			cnt := 0
+			for _, bp := range bpair {
+				for _, wp := range wpair {
+					if cross(bp[0], bp[1], wp[0], wp[1], n) {
+						cnt++
+					}
+				}
+			}
+			if cnt < best {
+				best = cnt
+			}
+		}
+	}
+	if best == int(^uint(0)>>1) {
+		return 0
+	}
+	return best
+}
+
+func expectedValue(s string) int {
+	arr := []byte(s)
+	var pos []int
+	for i, c := range arr {
+		if c == '?' {
+			pos = append(pos, i)
+		}
+	}
+	total := int64(0)
+	count := 0
+	var dfs func(int)
+	dfs = func(i int) {
+		if i == len(pos) {
+			cb, cw := 0, 0
+			for _, c := range arr {
+				if c == 'b' {
+					cb++
+				} else if c == 'w' {
+					cw++
+				}
+			}
+			if cb%2 == 0 && cw%2 == 0 {
+				count++
+				total += int64(minIntersections(arr))
+			}
+			return
+		}
+		arr[pos[i]] = 'b'
+		dfs(i + 1)
+		arr[pos[i]] = 'w'
+		dfs(i + 1)
+	}
+	dfs(0)
+	if count == 0 {
+		return 0
+	}
+	inv := modPow(int64(count), mod-2)
+	return int(total % mod * inv % mod)
+}
+
+func buildCase(s string) testCase {
+	n := len(s)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d 0\n%s\n", n, s)
+	exp := expectedValue(s)
+	return testCase{input: sb.String(), expected: fmt.Sprintf("%d", exp)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := 2 * (rng.Intn(3) + 2) // even, between 4 and 8
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		r := rng.Intn(3)
+		if r == 0 {
+			b[i] = 'b'
+		} else if r == 1 {
+			b[i] = 'w'
+		} else {
+			b[i] = '?'
+		}
+	}
+	return buildCase(string(b))
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1450/verifierH2.go
+++ b/1000-1999/1400-1499/1450-1459/1450/verifierH2.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func between(x, a, b, n int) bool {
+	if a < b {
+		return a < x && x < b
+	}
+	return a < x || x < b
+}
+
+func cross(a, b, c, d, n int) bool {
+	return between(c, a, b, n) != between(d, a, b, n) && between(a, c, d, n) != between(b, c, d, n)
+}
+
+func pairings(idx []int) [][][2]int {
+	if len(idx) == 0 {
+		return [][][2]int{{}}
+	}
+	first := idx[0]
+	rest := idx[1:]
+	var res [][][2]int
+	for i, v := range rest {
+		rem := append([]int(nil), rest[:i]...)
+		rem = append(rem, rest[i+1:]...)
+		for _, sub := range pairings(rem) {
+			res = append(res, append([][2]int{{first, v}}, sub...))
+		}
+	}
+	return res
+}
+
+func minIntersections(coloring []byte) int {
+	n := len(coloring)
+	var black, white []int
+	for i, c := range coloring {
+		if c == 'b' {
+			black = append(black, i)
+		}
+		if c == 'w' {
+			white = append(white, i)
+		}
+	}
+	pb := pairings(black)
+	pw := pairings(white)
+	best := int(^uint(0) >> 1)
+	for _, bpair := range pb {
+		for _, wpair := range pw {
+			cnt := 0
+			for _, bp := range bpair {
+				for _, wp := range wpair {
+					if cross(bp[0], bp[1], wp[0], wp[1], n) {
+						cnt++
+					}
+				}
+			}
+			if cnt < best {
+				best = cnt
+			}
+		}
+	}
+	if best == int(^uint(0)>>1) {
+		return 0
+	}
+	return best
+}
+
+func expectedValue(s string) int {
+	arr := []byte(s)
+	var pos []int
+	for i, c := range arr {
+		if c == '?' {
+			pos = append(pos, i)
+		}
+	}
+	total := int64(0)
+	count := 0
+	var dfs func(int)
+	dfs = func(i int) {
+		if i == len(pos) {
+			cb, cw := 0, 0
+			for _, c := range arr {
+				if c == 'b' {
+					cb++
+				} else if c == 'w' {
+					cw++
+				}
+			}
+			if cb%2 == 0 && cw%2 == 0 {
+				count++
+				total += int64(minIntersections(arr))
+			}
+			return
+		}
+		arr[pos[i]] = 'b'
+		dfs(i + 1)
+		arr[pos[i]] = 'w'
+		dfs(i + 1)
+	}
+	dfs(0)
+	if count == 0 {
+		return 0
+	}
+	inv := modPow(int64(count), mod-2)
+	return int(total % mod * inv % mod)
+}
+
+func buildCase(s string, updates [][2]interface{}) testCase {
+	n := len(s)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n%s\n", n, len(updates), s)
+	cur := s
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("%d\n", expectedValue(cur)))
+	for _, u := range updates {
+		idx := u[0].(int)
+		ch := u[1].(byte)
+		curBytes := []byte(cur)
+		curBytes[idx] = ch
+		cur = string(curBytes)
+		fmt.Fprintf(&sb, "%d %c\n", idx+1, ch)
+		out.WriteString(fmt.Sprintf("%d\n", expectedValue(cur)))
+	}
+	return testCase{input: sb.String(), expected: strings.TrimSpace(out.String())}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := 2 * (rng.Intn(3) + 2)
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		r := rng.Intn(3)
+		if r == 0 {
+			b[i] = 'b'
+		} else if r == 1 {
+			b[i] = 'w'
+		} else {
+			b[i] = '?'
+		}
+	}
+	m := rng.Intn(3) + 1
+	updates := make([][2]interface{}, m)
+	for i := 0; i < m; i++ {
+		idx := rng.Intn(n)
+		chType := rng.Intn(3)
+		var ch byte
+		if chType == 0 {
+			ch = 'b'
+		} else if chType == 1 {
+			ch = 'w'
+		} else {
+			ch = '?'
+		}
+		updates[i] = [2]interface{}{idx, ch}
+	}
+	return buildCase(string(b), updates)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected:\n%s\n----\ngot:\n%s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1450 problems A–H2
- each verifier builds random test cases and checks a user binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC1.go`
- `go build verifierC2.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH1.go`
- `go build verifierH2.go`


------
https://chatgpt.com/codex/tasks/task_e_68861386ed448324ac5d1d7f9d8a208c