### PR TITLE
Add verifiers for CF 1452

### DIFF
--- a/1000-1999/1400-1499/1450-1459/1452/verifierA.go
+++ b/1000-1999/1400-1499/1450-1459/1452/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(x, y int) int {
+	if x < y {
+		x, y = y, x
+	}
+	if x == y {
+		return 2 * x
+	}
+	return 2*x - 1
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("run error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	const t = 100
+	xs := make([]int, t)
+	ys := make([]int, t)
+	exp := make([]int, t)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", t)
+	for i := 0; i < t; i++ {
+		xs[i] = rand.Intn(10001)
+		ys[i] = rand.Intn(10001)
+		exp[i] = solve(xs[i], ys[i])
+		fmt.Fprintf(&b, "%d %d\n", xs[i], ys[i])
+	}
+	out, err := runBinary(binary, b.String())
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) != t {
+		fmt.Printf("expected %d lines, got %d\noutput:\n%s\n", t, len(fields), out)
+		os.Exit(1)
+	}
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil || v != exp[i] {
+			fmt.Printf("test %d failed: input=(%d,%d) expected=%d got=%s\n", i+1, xs[i], ys[i], exp[i], f)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1452/verifierB.go
+++ b/1000-1999/1400-1499/1450-1459/1452/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testB struct {
+	arr []int64
+}
+
+func solveB(arr []int64) int64 {
+	n := int64(len(arr))
+	var sum, mx int64
+	for _, v := range arr {
+		sum += v
+		if v > mx {
+			mx = v
+		}
+	}
+	need1 := mx*(n-1) - sum
+	if need1 < 0 {
+		need1 = 0
+	}
+	sum += need1
+	rem := sum % (n - 1)
+	var need2 int64
+	if rem != 0 {
+		need2 = (n - 1) - rem
+	}
+	return need1 + need2
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("run error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	const t = 100
+	tests := make([]testB, t)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(5) + 1
+		arr := make([]int64, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rand.Int63n(20)
+		}
+		tests[i].arr = arr
+		fmt.Fprintf(&b, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", arr[j])
+		}
+		b.WriteByte('\n')
+	}
+	out, err := runBinary(binary, b.String())
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) != t {
+		fmt.Printf("expected %d lines, got %d\noutput:\n%s\n", t, len(fields), out)
+		os.Exit(1)
+	}
+	for i, f := range fields {
+		v, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			fmt.Printf("invalid output on test %d: %s\n", i+1, f)
+			os.Exit(1)
+		}
+		exp := solveB(tests[i].arr)
+		if v != exp {
+			fmt.Printf("test %d failed: expected %d got %d\n", i+1, exp, v)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1452/verifierC.go
+++ b/1000-1999/1400-1499/1450-1459/1452/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveC(s string) int {
+	openRound := 0
+	openSquare := 0
+	ans := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			openRound++
+		case '[':
+			openSquare++
+		case ')':
+			if openRound > 0 {
+				ans++
+				openRound--
+			}
+		case ']':
+			if openSquare > 0 {
+				ans++
+				openSquare--
+			}
+		}
+	}
+	return ans
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("run error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func randomString(n int) string {
+	chars := []byte{'(', ')', '[', ']'}
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	const t = 100
+	strs := make([]string, t)
+	exp := make([]int, t)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", t)
+	for i := 0; i < t; i++ {
+		s := randomString(rand.Intn(20) + 1)
+		strs[i] = s
+		exp[i] = solveC(s)
+		b.WriteString(s)
+		b.WriteByte('\n')
+	}
+	out, err := runBinary(binary, b.String())
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) != t {
+		fmt.Printf("expected %d lines, got %d\noutput:\n%s\n", t, len(fields), out)
+		os.Exit(1)
+	}
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil || v != exp[i] {
+			fmt.Printf("test %d failed: input=%s expected=%d got=%s\n", i+1, strs[i], exp[i], f)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1452/verifierD.go
+++ b/1000-1999/1400-1499/1450-1459/1452/verifierD.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= mod
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func solveD(n int) int64 {
+	dp := make([]int64, n+1)
+	sum0 := make([]int64, n+1)
+	sum1 := make([]int64, n+1)
+	dp[0] = 1
+	sum0[0] = 1
+	for i := 1; i <= n; i++ {
+		if (i-1)&1 == 0 {
+			dp[i] = sum0[i-1]
+		} else {
+			dp[i] = sum1[i-1]
+		}
+		if dp[i] >= mod {
+			dp[i] %= mod
+		}
+		if i&1 == 0 {
+			sum0[i] = (sum0[i-1] + dp[i]) % mod
+			sum1[i] = sum1[i-1]
+		} else {
+			sum1[i] = (sum1[i-1] + dp[i]) % mod
+			sum0[i] = sum0[i-1]
+		}
+	}
+	total := modPow(2, int64(n))
+	invTotal := modPow(total, mod-2)
+	return dp[n] * invTotal % mod
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("run error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	const t = 100
+	for i := 0; i < t; i++ {
+		n := rand.Intn(50) + 1
+		exp := solveD(n)
+		input := fmt.Sprintf("%d\n", n)
+		out, err := runBinary(binary, input)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		vStr := strings.TrimSpace(out)
+		v, err := strconv.ParseInt(vStr, 10, 64)
+		if err != nil || v != exp {
+			fmt.Printf("test %d failed: n=%d expected=%d got=%s\n", i+1, n, exp, vStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1452/verifierE.go
+++ b/1000-1999/1400-1499/1450-1459/1452/verifierE.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testE struct {
+	n, m, k int
+	l, r    []int
+}
+
+func solveE(t testE) int {
+	n, m, k := t.n, t.m, t.k
+	l, r := t.l, t.r
+	w := n - k + 1
+	f := make([][]int, m)
+	for p := 0; p < m; p++ {
+		f[p] = make([]int, w+1)
+		for i := 1; i <= w; i++ {
+			li, ri := l[p], r[p]
+			wi, wj := i, i+k-1
+			a := li
+			if wi > a {
+				a = wi
+			}
+			b := ri
+			if wj < b {
+				b = wj
+			}
+			if a <= b {
+				f[p][i] = b - a + 1
+			} else {
+				f[p][i] = 0
+			}
+		}
+	}
+	base := make([]int, w+2)
+	for i := 1; i <= w; i++ {
+		s := 0
+		for p := 0; p < m; p++ {
+			s += f[p][i]
+		}
+		base[i] = s
+	}
+	bestLeft := make([]int, w+2)
+	for i := 1; i <= w; i++ {
+		if i-k >= 1 {
+			if base[i-k] > bestLeft[i-1] {
+				bestLeft[i] = base[i-k]
+			} else {
+				bestLeft[i] = bestLeft[i-1]
+			}
+		} else {
+			bestLeft[i] = bestLeft[i-1]
+		}
+	}
+	bestRight := make([]int, w+2)
+	for i := w; i >= 1; i-- {
+		if i+k <= w {
+			if base[i+k] > bestRight[i+1] {
+				bestRight[i] = base[i+k]
+			} else {
+				bestRight[i] = bestRight[i+1]
+			}
+		} else {
+			bestRight[i] = bestRight[i+1]
+		}
+	}
+	best := 0
+	for i := 1; i <= w; i++ {
+		if bestLeft[i] > 0 {
+			tmp := base[i] + bestLeft[i]
+			if tmp > best {
+				best = tmp
+			}
+		}
+		if bestRight[i] > 0 {
+			tmp := base[i] + bestRight[i]
+			if tmp > best {
+				best = tmp
+			}
+		}
+		if base[i] > best {
+			best = base[i]
+		}
+		lo := i - k + 1
+		if lo < 1 {
+			lo = 1
+		}
+		hi := i + k - 1
+		if hi > w {
+			hi = w
+		}
+		for j := lo; j <= hi; j++ {
+			mn := 0
+			for p := 0; p < m; p++ {
+				x := f[p][i]
+				y := f[p][j]
+				if x < y {
+					mn += x
+				} else {
+					mn += y
+				}
+			}
+			tmp := base[i] + base[j] - mn
+			if tmp > best {
+				best = tmp
+			}
+		}
+	}
+	return best
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("run error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	const tnum = 100
+	for ti := 0; ti < tnum; ti++ {
+		n := rand.Intn(8) + 2
+		m := rand.Intn(3) + 1
+		k := rand.Intn(n) + 1
+		l := make([]int, m)
+		r := make([]int, m)
+		for i := 0; i < m; i++ {
+			a := rand.Intn(n) + 1
+			b := rand.Intn(n) + 1
+			if a > b {
+				a, b = b, a
+			}
+			l[i] = a
+			r[i] = b
+		}
+		test := testE{n: n, m: m, k: k, l: l, r: r}
+		exp := solveE(test)
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d %d %d\n", n, m, k)
+		for i := 0; i < m; i++ {
+			fmt.Fprintf(&in, "%d %d\n", l[i], r[i])
+		}
+		out, err := runBinary(binary, in.String())
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		vStr := strings.TrimSpace(out)
+		v, err := strconv.Atoi(vStr)
+		if err != nil || v != exp {
+			fmt.Printf("test %d failed: expected=%d got=%s\n", ti+1, exp, vStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1452/verifierF.go
+++ b/1000-1999/1400-1499/1450-1459/1452/verifierF.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type queryF struct {
+	typ int
+	pos int
+	val int64
+	x   int
+	k   int64
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveQueries(n int, cnt []int64, qs []queryF) []int64 {
+	c := make([]int64, n)
+	copy(c, cnt)
+	res := []int64{}
+	for _, q := range qs {
+		if q.typ == 1 {
+			c[q.pos] = q.val
+		} else {
+			x := q.x
+			k := q.k
+			m := n - x - 1
+			arr := make([]int64, maxInt(1, m+1))
+			var small int64
+			for i := 0; i <= x && i < n; i++ {
+				small += c[i]
+			}
+			arr[0] = small
+			for j := 1; j <= m; j++ {
+				arr[j] = c[x+j]
+			}
+			need := k
+			if arr[0] >= need {
+				res = append(res, 0)
+				continue
+			}
+			var totUnits int64
+			for j, v := range arr {
+				if v == 0 {
+					continue
+				}
+				totUnits += v << uint(j)
+			}
+			if totUnits < need {
+				res = append(res, -1)
+				continue
+			}
+			var ans int64
+			need2 := need - arr[0]
+			for need2 > 0 {
+				r1 := (need2 + 1) / 2
+				var avail1 int64
+				if len(arr) > 1 {
+					avail1 = arr[1]
+				}
+				need1 := r1 - avail1
+				if need1 <= 0 {
+					ans += r1
+					break
+				}
+				jj := 2
+				for jj <= m && (jj >= len(arr) || arr[jj] == 0) {
+					jj++
+				}
+				if jj > m {
+					ans = -1
+					break
+				}
+				sj := int64(1) << (jj - 1)
+				needCj := (need1 + sj - 1) / sj
+				if needCj > arr[jj] {
+					needCj = arr[jj]
+				}
+				ans += needCj
+				arr[jj] -= needCj
+				arr[jj-1] += needCj * 2
+			}
+			res = append(res, ans)
+		}
+	}
+	return res
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("run error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	const tnum = 100
+	for ti := 0; ti < tnum; ti++ {
+		n := rand.Intn(5) + 1
+		q := rand.Intn(8) + 2
+		cnt := make([]int64, n)
+		for i := range cnt {
+			cnt[i] = rand.Int63n(5)
+		}
+		queries := make([]queryF, q)
+		hasType2 := false
+		for i := 0; i < q; i++ {
+			if rand.Intn(2) == 0 {
+				queries[i].typ = 1
+				queries[i].pos = rand.Intn(n)
+				queries[i].val = rand.Int63n(10)
+			} else {
+				queries[i].typ = 2
+				queries[i].x = rand.Intn(n)
+				queries[i].k = rand.Int63n(10) + 1
+				hasType2 = true
+			}
+		}
+		if !hasType2 {
+			queries[0].typ = 2
+			queries[0].x = 0
+			queries[0].k = 1
+		}
+		expOut := solveQueries(n, cnt, queries)
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d %d\n", n, q)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				in.WriteByte(' ')
+			}
+			fmt.Fprintf(&in, "%d", cnt[i])
+		}
+		in.WriteByte('\n')
+		for _, qu := range queries {
+			if qu.typ == 1 {
+				fmt.Fprintf(&in, "1 %d %d\n", qu.pos, qu.val)
+			} else {
+				fmt.Fprintf(&in, "2 %d %d\n", qu.x, qu.k)
+			}
+		}
+		out, err := runBinary(binary, in.String())
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		outs := strings.Fields(strings.TrimSpace(out))
+		if len(outs) != len(expOut) {
+			fmt.Printf("test %d failed: expected %d lines got %d\noutput:\n%s\n", ti+1, len(expOut), len(outs), out)
+			os.Exit(1)
+		}
+		for i, field := range outs {
+			v, err := strconv.ParseInt(field, 10, 64)
+			if err != nil || v != expOut[i] {
+				fmt.Printf("test %d failed at result %d: expected %d got %s\n", ti+1, i+1, expOut[i], field)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1452/verifierG.go
+++ b/1000-1999/1400-1499/1450-1459/1452/verifierG.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type state struct {
+	th  int
+	rem int
+	u   int
+}
+
+type pqState []state
+
+func (pq pqState) Len() int            { return len(pq) }
+func (pq pqState) Less(i, j int) bool  { return pq[i].th > pq[j].th }
+func (pq pqState) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *pqState) Push(x interface{}) { *pq = append(*pq, x.(state)) }
+func (pq *pqState) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	x := old[n-1]
+	*pq = old[:n-1]
+	return x
+}
+
+func solveG(n int, edges [][]int, bob []int) []int {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	const INF = int(1e9)
+	dBob := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		dBob[i] = INF
+	}
+	q := make([]int, 0, n)
+	for _, v := range bob {
+		dBob[v] = 0
+		q = append(q, v)
+	}
+	for qi := 0; qi < len(q); qi++ {
+		u := q[qi]
+		for _, v := range adj[u] {
+			if dBob[v] > dBob[u]+1 {
+				dBob[v] = dBob[u] + 1
+				q = append(q, v)
+			}
+		}
+	}
+	bestTh := make([]int, n+1)
+	for i := range bestTh {
+		bestTh[i] = -1
+	}
+	pqh := &pqState{}
+	heap.Init(pqh)
+	for u := 1; u <= n; u++ {
+		th := dBob[u]
+		heap.Push(pqh, state{th: th, rem: th, u: u})
+	}
+	for pqh.Len() > 0 {
+		st := heap.Pop(pqh).(state)
+		u, th, rem := st.u, st.th, st.rem
+		if th <= bestTh[u] {
+			continue
+		}
+		bestTh[u] = th
+		if rem == 0 {
+			continue
+		}
+		for _, v := range adj[u] {
+			if th > bestTh[v] {
+				heap.Push(pqh, state{th: th, rem: rem - 1, u: v})
+			}
+		}
+	}
+	ans := make([]int, n)
+	for i := 1; i <= n; i++ {
+		ans[i-1] = bestTh[i]
+	}
+	return ans
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("run error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	const tnum = 100
+	for ti := 0; ti < tnum; ti++ {
+		n := rand.Intn(8) + 2
+		edges := make([][]int, n-1)
+		for i := 2; i <= n; i++ {
+			p := rand.Intn(i-1) + 1
+			edges[i-2] = []int{p, i}
+		}
+		k := rand.Intn(n) + 1
+		perm := rand.Perm(n)
+		bob := make([]int, k)
+		for i := 0; i < k; i++ {
+			bob[i] = perm[i] + 1
+		}
+		exp := solveG(n, edges, bob)
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d\n", n)
+		for _, e := range edges {
+			fmt.Fprintf(&in, "%d %d\n", e[0], e[1])
+		}
+		fmt.Fprintf(&in, "%d\n", k)
+		for i, v := range bob {
+			if i > 0 {
+				in.WriteByte(' ')
+			}
+			fmt.Fprintf(&in, "%d", v)
+		}
+		in.WriteByte('\n')
+		out, err := runBinary(binary, in.String())
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		if len(fields) != n {
+			fmt.Printf("test %d failed: expected %d values got %d\noutput:\n%s\n", ti+1, n, len(fields), out)
+			os.Exit(1)
+		}
+		for i, f := range fields {
+			v, err := strconv.Atoi(f)
+			if err != nil || v != exp[i] {
+				fmt.Printf("test %d failed at vertex %d: expected %d got %s\n", ti+1, i+1, exp[i], f)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces contest 1452 problems A–G
- each verifier generates 100 random tests and checks a submitted binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6886149f44748324928fc2dee9719723