### PR TITLE
Add Go verifiers for CF contest 1451

### DIFF
--- a/1000-1999/1400-1499/1450-1459/1451/verifierA.go
+++ b/1000-1999/1400-1499/1450-1459/1451/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int64) int {
+	switch {
+	case n == 1:
+		return 0
+	case n == 2:
+		return 1
+	case n == 3:
+		return 2
+	case n%2 == 0:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func runCase(bin string, n int64) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(&out, &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	want := expected(n)
+	if got != want {
+		return fmt.Errorf("n=%d expected %d got %d", n, want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1000000000}
+	for len(cases) < 100 {
+		cases = append(cases, rng.Int63n(1000000000)+1)
+	}
+	for i, n := range cases {
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1451/verifierB.go
+++ b/1000-1999/1400-1499/1450-1459/1451/verifierB.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct{ l, r int }
+
+type testcase struct {
+	n  int
+	q  int
+	s  string
+	qs []query
+}
+
+func expected(tc testcase) []string {
+	res := make([]string, tc.q)
+	for idx, qr := range tc.qs {
+		l := qr.l
+		r := qr.r
+		first := tc.s[l-1]
+		last := tc.s[r-1]
+		ok := false
+		for i := 0; i < l-1; i++ {
+			if tc.s[i] == first {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			for i := r; i < tc.n; i++ {
+				if tc.s[i] == last {
+					ok = true
+					break
+				}
+			}
+		}
+		if ok {
+			res[idx] = "YES"
+		} else {
+			res[idx] = "NO"
+		}
+	}
+	return res
+}
+
+func runCase(bin string, tc testcase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n%s\n", tc.n, tc.q, tc.s))
+	for _, qr := range tc.qs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", qr.l, qr.r))
+	}
+	input := fmt.Sprintf("1\n%s", sb.String())
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := strings.Fields(out.String())
+	expect := expected(tc)
+	if len(gotLines) != len(expect) {
+		return fmt.Errorf("expected %d lines got %d", len(expect), len(gotLines))
+	}
+	for i := range expect {
+		if strings.ToUpper(gotLines[i]) != expect[i] {
+			return fmt.Errorf("query %d expected %s got %s", i+1, expect[i], gotLines[i])
+		}
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testcase {
+	n := rng.Intn(20) + 2
+	q := rng.Intn(20) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	s := sb.String()
+	qs := make([]query, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n-1) + 1
+		r := rng.Intn(n-l) + l + 1
+		qs[i] = query{l, r}
+	}
+	return testcase{n, q, s, qs}
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testcase, 0, 100)
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1451/verifierC.go
+++ b/1000-1999/1400-1499/1450-1459/1451/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, k int, a, b string) bool {
+	var ca, cb [26]int
+	for i := 0; i < n; i++ {
+		ca[a[i]-'a']++
+		cb[b[i]-'a']++
+	}
+	carry := 0
+	for i := 0; i < 26; i++ {
+		available := ca[i] + carry
+		if available < cb[i] {
+			return false
+		}
+		diff := available - cb[i]
+		if diff%k != 0 {
+			return false
+		}
+		carry = diff
+	}
+	return carry == 0
+}
+
+func runCase(bin string, n, k int, a, b string) error {
+	input := fmt.Sprintf("1\n%d %d\n%s\n%s\n", n, k, a, b)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := "No"
+	if solve(n, k, a, b) {
+		expect = "Yes"
+	}
+	if strings.ToLower(got) != strings.ToLower(expect) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	bs := make([]byte, n)
+	for i := range bs {
+		bs[i] = byte('a' + rng.Intn(26))
+	}
+	return string(bs)
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(5) + 1
+		if k > n {
+			k = n
+		}
+		a := randString(rng, n)
+		b := randString(rng, n)
+		if err := runCase(bin, n, k, a, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1451/verifierD.go
+++ b/1000-1999/1400-1499/1450-1459/1451/verifierD.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(d, k int64) string {
+	D2 := d * d
+	k2 := k * k
+	x := int64(math.Sqrt(float64(D2) / float64(2*k2)))
+	for (x+1)*(x+1)*2*k2 <= D2 {
+		x++
+	}
+	for x >= 0 && x*x*2*k2 > D2 {
+		x--
+	}
+	rem := D2 - x*x*k2
+	y := int64(math.Sqrt(float64(rem) / float64(k2)))
+	for (y+1)*(y+1)*k2 <= rem {
+		y++
+	}
+	for y >= 0 && y*y*k2 > rem {
+		y--
+	}
+	if y > x {
+		return "Ashish"
+	}
+	return "Utkarsh"
+}
+
+func runCase(bin string, d, k int64) error {
+	input := fmt.Sprintf("1\n%d %d\n", d, k)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := expected(d, k)
+	if strings.ToLower(got) != strings.ToLower(want) {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		d := rng.Int63n(1000) + 1
+		k := rng.Int63n(d) + 1
+		if err := runCase(bin, d, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1451/verifierE1.go
+++ b/1000-1999/1400-1499/1450-1459/1451/verifierE1.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCase(bin string, arr []int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	r := bufio.NewReader(stdout)
+	w := bufio.NewWriter(stdin)
+	fmt.Fprintf(w, "%d\n", len(arr))
+	w.Flush()
+	for {
+		var op string
+		if _, err := fmt.Fscan(r, &op); err != nil {
+			cmd.Wait()
+			return fmt.Errorf("failed reading command: %v\n%s", err, stderr.String())
+		}
+		if op == "!" {
+			out := make([]int, len(arr))
+			for i := range out {
+				if _, err := fmt.Fscan(r, &out[i]); err != nil {
+					cmd.Wait()
+					return fmt.Errorf("failed to read answer: %v", err)
+				}
+			}
+			if err := cmd.Wait(); err != nil {
+				return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+			}
+			for i := range arr {
+				if arr[i] != out[i] {
+					return fmt.Errorf("expected %v got %v", arr, out)
+				}
+			}
+			break
+		}
+		var i, j int
+		if _, err := fmt.Fscan(r, &i, &j); err != nil {
+			cmd.Wait()
+			return fmt.Errorf("failed reading indices: %v", err)
+		}
+		i--
+		j--
+		var ans int
+		switch op {
+		case "AND":
+			ans = arr[i] & arr[j]
+		case "OR":
+			ans = arr[i] | arr[j]
+		case "XOR":
+			ans = arr[i] ^ arr[j]
+		default:
+			cmd.Wait()
+			return fmt.Errorf("unknown operation %s", op)
+		}
+		fmt.Fprintf(w, "%d\n", ans)
+		w.Flush()
+	}
+	return nil
+}
+
+func randomArray(rng *rand.Rand) []int {
+	pow := rng.Intn(3) + 2 // 4..32
+	n := 1 << pow
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(n)
+	}
+	return arr
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := randomArray(rng)
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1451/verifierE2.go
+++ b/1000-1999/1400-1499/1450-1459/1451/verifierE2.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCase(bin string, arr []int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	r := bufio.NewReader(stdout)
+	w := bufio.NewWriter(stdin)
+	fmt.Fprintf(w, "%d\n", len(arr))
+	w.Flush()
+	for {
+		var op string
+		if _, err := fmt.Fscan(r, &op); err != nil {
+			cmd.Wait()
+			return fmt.Errorf("failed reading command: %v\n%s", err, stderr.String())
+		}
+		if op == "!" {
+			out := make([]int, len(arr))
+			for i := range out {
+				if _, err := fmt.Fscan(r, &out[i]); err != nil {
+					cmd.Wait()
+					return fmt.Errorf("failed to read answer: %v", err)
+				}
+			}
+			if err := cmd.Wait(); err != nil {
+				return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+			}
+			for i := range arr {
+				if arr[i] != out[i] {
+					return fmt.Errorf("expected %v got %v", arr, out)
+				}
+			}
+			break
+		}
+		var i, j int
+		if _, err := fmt.Fscan(r, &i, &j); err != nil {
+			cmd.Wait()
+			return fmt.Errorf("failed reading indices: %v", err)
+		}
+		i--
+		j--
+		var ans int
+		switch op {
+		case "AND":
+			ans = arr[i] & arr[j]
+		case "OR":
+			ans = arr[i] | arr[j]
+		case "XOR":
+			ans = arr[i] ^ arr[j]
+		default:
+			cmd.Wait()
+			return fmt.Errorf("unknown operation %s", op)
+		}
+		fmt.Fprintf(w, "%d\n", ans)
+		w.Flush()
+	}
+	return nil
+}
+
+func randomArray(rng *rand.Rand) []int {
+	pow := rng.Intn(3) + 2 // 4..32
+	n := 1 << pow
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(n)
+	}
+	return arr
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := randomArray(rng)
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1451/verifierF.go
+++ b/1000-1999/1400-1499/1450-1459/1451/verifierF.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const maxN = 100
+const maxM = 100
+
+var grundy [maxN + 2][maxM + 2]int
+
+func init() {
+	seen := make([]int, maxN*maxM+5)
+	timestamp := 1
+	for i := maxN; i >= 1; i-- {
+		for j := maxM; j >= 1; j-- {
+			timestamp++
+			seen[0] = timestamp
+			for x := i; x <= maxN; x++ {
+				for y := j; y <= maxM; y++ {
+					if x == i && y == j {
+						continue
+					}
+					v := grundy[x][y]
+					if v < len(seen) {
+						seen[v] = timestamp
+					}
+				}
+			}
+			mex := 0
+			for seen[mex] == timestamp {
+				mex++
+			}
+			grundy[i][j] = mex
+		}
+	}
+}
+
+func expected(board [][]int) string {
+	xor := 0
+	for i := 0; i < len(board); i++ {
+		for j := 0; j < len(board[i]); j++ {
+			if board[i][j]&1 == 1 {
+				xor ^= grundy[i+1][j+1]
+			}
+		}
+	}
+	if xor != 0 {
+		return "Ashish"
+	}
+	return "Jeel"
+}
+
+func runCase(bin string, board [][]int) error {
+	n := len(board)
+	m := len(board[0])
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			sb.WriteString(fmt.Sprintf("%d", board[i][j]))
+			if j+1 < m {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := expected(board)
+	if strings.ToLower(got) != strings.ToLower(want) {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func randomBoard(rng *rand.Rand) [][]int {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	b := make([][]int, n)
+	for i := range b {
+		b[i] = make([]int, m)
+		for j := range b[i] {
+			b[i][j] = rng.Intn(3)
+		}
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		board := randomBoard(rng)
+		if err := runCase(bin, board); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems in contest 1451
- support running with compiled binaries or with `go run` using `--`
- each verifier generates 100 random test cases and checks output

## Testing
- `go run verifierA.go -- 1451A.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE1.go`
- `go build verifierE2.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68861412fe148324bb610e58ce0fb6a9