### PR TITLE
Add verifiers for Codeforces contest 1453

### DIFF
--- a/1000-1999/1400-1499/1450-1459/1453/verifierA.go
+++ b/1000-1999/1400-1499/1450-1459/1453/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1453A.go")
+	refBin := filepath.Join(os.TempDir(), "1453A_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(10) + 1
+	arr1 := rand.Perm(100)[:n]
+	arr2 := rand.Perm(100)[:m]
+	sort.Ints(arr1)
+	sort.Ints(arr2)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range arr1 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	for i, v := range arr2 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1453/verifierB.go
+++ b/1000-1999/1400-1499/1450-1459/1453/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1453B.go")
+	refBin := filepath.Join(os.TempDir(), "1453B_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rand.Int63n(1_000_000) - 500_000
+		sb.WriteString(fmt.Sprintf("%d", val))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1453/verifierC.go
+++ b/1000-1999/1400-1499/1450-1459/1453/verifierC.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1453C.go")
+	refBin := filepath.Join(os.TempDir(), "1453C_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			sb.WriteByte(byte('0' + rand.Intn(10)))
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1453/verifierD.go
+++ b/1000-1999/1400-1499/1450-1459/1453/verifierD.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1453D.go")
+	refBin := filepath.Join(os.TempDir(), "1453D_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	k := rand.Int63n(1_000_000_000_000) + 1 // up to 1e12
+	return []byte(fmt.Sprintf("1\n%d\n", k))
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1453/verifierE.go
+++ b/1000-1999/1400-1499/1450-1459/1453/verifierE.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1453E.go")
+	refBin := filepath.Join(os.TempDir(), "1453E_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, i))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1453/verifierF.go
+++ b/1000-1999/1400-1499/1450-1459/1453/verifierF.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1453F.go")
+	refBin := filepath.Join(os.TempDir(), "1453F_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		maxJump := n - i
+		val := rand.Intn(maxJump + 1)
+		sb.WriteString(fmt.Sprintf("%d", val))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems 1453A–F
- each verifier builds the reference solution and checks 100 randomized tests

## Testing
- `go build 1000-1999/1400-1499/1450-1459/1453/verifierA.go`
- `go build 1000-1999/1400-1499/1450-1459/1453/verifierB.go`
- `go build 1000-1999/1400-1499/1450-1459/1453/verifierC.go`
- `go build 1000-1999/1400-1499/1450-1459/1453/verifierD.go`
- `go build 1000-1999/1400-1499/1450-1459/1453/verifierE.go`
- `go build 1000-1999/1400-1499/1450-1459/1453/verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6886152b226c83248d2a5762efe2a6e3