### PR TITLE
Add Go verifiers for contest 1454

### DIFF
--- a/1000-1999/1400-1499/1450-1459/1454/verifierA.go
+++ b/1000-1999/1400-1499/1450-1459/1454/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateTests() ([]int, string) {
+	const t = 100
+	r := rand.New(rand.NewSource(1))
+	nums := make([]int, t)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(99) + 2
+		nums[i] = n
+		fmt.Fprintf(&sb, "%d\n", n)
+	}
+	return nums, sb.String()
+}
+
+func verify(nums []int, output string) error {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Split(bufio.ScanWords)
+	for idx, n := range nums {
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			if !scanner.Scan() {
+				return fmt.Errorf("case %d: not enough numbers", idx+1)
+			}
+			var x int
+			fmt.Sscan(scanner.Text(), &x)
+			arr[i] = x
+		}
+		seen := make([]bool, n+1)
+		for i, v := range arr {
+			if v < 1 || v > n {
+				return fmt.Errorf("case %d: value out of range", idx+1)
+			}
+			if seen[v] {
+				return fmt.Errorf("case %d: duplicate value %d", idx+1, v)
+			}
+			if v == i+1 {
+				return fmt.Errorf("case %d: fixed point at %d", idx+1, i+1)
+			}
+			seen[v] = true
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	nums, input := generateTests()
+	out, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if err := verify(nums, out); err != nil {
+		fmt.Fprintln(os.Stderr, "verification failed:", err)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed for problem A")
+}

--- a/1000-1999/1400-1499/1450-1459/1454/verifierB.go
+++ b/1000-1999/1400-1499/1450-1459/1454/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveCaseB(arr []int) int {
+	n := len(arr)
+	freq := make([]int, n+2)
+	idx := make([]int, n+2)
+	for i, a := range arr {
+		if freq[a] == 0 {
+			freq[a] = 1
+			idx[a] = i + 1
+		} else if freq[a] == 1 {
+			freq[a] = 2
+		}
+	}
+	ans := -1
+	for v := 1; v <= n; v++ {
+		if freq[v] == 1 {
+			ans = idx[v]
+			break
+		}
+	}
+	return ans
+}
+
+func generateTests() ([][]int, string) {
+	const t = 100
+	r := rand.New(rand.NewSource(2))
+	arrays := make([][]int, t)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(20) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = r.Intn(n) + 1
+			fmt.Fprintf(&sb, "%d ", arr[j])
+		}
+		fmt.Fprintln(&sb)
+		arrays[i] = arr
+	}
+	return arrays, sb.String()
+}
+
+func verify(arrays [][]int, output string) error {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Split(bufio.ScanWords)
+	for idx, arr := range arrays {
+		if !scanner.Scan() {
+			return fmt.Errorf("case %d: missing output", idx+1)
+		}
+		var ans int
+		fmt.Sscan(scanner.Text(), &ans)
+		expected := solveCaseB(arr)
+		if ans != expected {
+			return fmt.Errorf("case %d: expected %d got %d", idx+1, expected, ans)
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	arrays, input := generateTests()
+	out, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if err := verify(arrays, out); err != nil {
+		fmt.Fprintln(os.Stderr, "verification failed:", err)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed for problem B")
+}

--- a/1000-1999/1400-1499/1450-1459/1454/verifierC.go
+++ b/1000-1999/1400-1499/1450-1459/1454/verifierC.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveCaseC(arr []int) int {
+	n := len(arr)
+	positions := make(map[int][]int)
+	uniq := make([]int, 0)
+	for i, x := range arr {
+		if _, ok := positions[x]; !ok {
+			uniq = append(uniq, x)
+		}
+		positions[x] = append(positions[x], i+1)
+	}
+	ans := n
+	for _, x := range uniq {
+		pos := positions[x]
+		cnt := 0
+		if pos[0] != 1 {
+			cnt++
+		}
+		for i := 1; i < len(pos); i++ {
+			if pos[i] != pos[i-1]+1 {
+				cnt++
+			}
+		}
+		if pos[len(pos)-1] != n {
+			cnt++
+		}
+		if cnt < ans {
+			ans = cnt
+		}
+	}
+	return ans
+}
+
+func generateTests() ([][]int, string) {
+	const t = 100
+	r := rand.New(rand.NewSource(3))
+	arrays := make([][]int, t)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(20) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = r.Intn(n) + 1
+			fmt.Fprintf(&sb, "%d ", arr[j])
+		}
+		fmt.Fprintln(&sb)
+		arrays[i] = arr
+	}
+	return arrays, sb.String()
+}
+
+func verify(arrays [][]int, output string) error {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Split(bufio.ScanWords)
+	for idx, arr := range arrays {
+		if !scanner.Scan() {
+			return fmt.Errorf("case %d: missing output", idx+1)
+		}
+		var ans int
+		fmt.Sscan(scanner.Text(), &ans)
+		expected := solveCaseC(arr)
+		if ans != expected {
+			return fmt.Errorf("case %d: expected %d got %d", idx+1, expected, ans)
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	arrays, input := generateTests()
+	out, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if err := verify(arrays, out); err != nil {
+		fmt.Fprintln(os.Stderr, "verification failed:", err)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed for problem C")
+}

--- a/1000-1999/1400-1499/1450-1459/1454/verifierD.go
+++ b/1000-1999/1400-1499/1450-1459/1454/verifierD.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func isPrime(n uint64) bool {
+	if n <= 1 {
+		return false
+	}
+	if n <= 3 {
+		return true
+	}
+	if n%2 == 0 || n%3 == 0 {
+		return false
+	}
+	for i := uint64(5); i*i <= n; i += 6 {
+		if n%i == 0 || n%(i+2) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func primeFac(n uint64) (uint64, uint64) {
+	m := n
+	var c, p uint64
+	var cnt uint64
+	for m%2 == 0 {
+		cnt++
+		m /= 2
+	}
+	if cnt > c {
+		c = cnt
+		p = 2
+	}
+	for i := uint64(3); i*i <= m; i += 2 {
+		cnt = 0
+		for m%i == 0 {
+			cnt++
+			m /= i
+		}
+		if cnt > c {
+			c = cnt
+			p = i
+		}
+	}
+	if m > 1 && c == 0 {
+		c = 1
+		p = m
+	}
+	return c, p
+}
+
+func solveCaseD(n uint64) (uint64, []uint64) {
+	if isPrime(n) {
+		return 1, []uint64{n}
+	}
+	c, p := primeFac(n)
+	seq := make([]uint64, c)
+	rem := n
+	for i := uint64(0); i < c-1; i++ {
+		seq[i] = p
+		rem /= p
+	}
+	seq[c-1] = rem
+	return c, seq
+}
+
+func generateTests() ([]uint64, string) {
+	const t = 100
+	r := rand.New(rand.NewSource(4))
+	ns := make([]uint64, t)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := uint64(r.Intn(1_000_000_000-2) + 2)
+		ns[i] = n
+		fmt.Fprintf(&sb, "%d\n", n)
+	}
+	return ns, sb.String()
+}
+
+func verify(ns []uint64, output string) error {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Split(bufio.ScanWords)
+	for idx, n := range ns {
+		if !scanner.Scan() {
+			return fmt.Errorf("case %d: missing k", idx+1)
+		}
+		var k uint64
+		fmt.Sscan(scanner.Text(), &k)
+		seq := make([]uint64, k)
+		for i := uint64(0); i < k; i++ {
+			if !scanner.Scan() {
+				return fmt.Errorf("case %d: incomplete sequence", idx+1)
+			}
+			fmt.Sscan(scanner.Text(), &seq[i])
+		}
+		expectedK, expectedSeq := solveCaseD(n)
+		if k != expectedK {
+			return fmt.Errorf("case %d: expected k=%d got %d", idx+1, expectedK, k)
+		}
+		for i := uint64(0); i < k; i++ {
+			if seq[i] != expectedSeq[i] {
+				return fmt.Errorf("case %d: expected %v got %v", idx+1, expectedSeq, seq)
+			}
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	ns, input := generateTests()
+	out, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if err := verify(ns, out); err != nil {
+		fmt.Fprintln(os.Stderr, "verification failed:", err)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed for problem D")
+}

--- a/1000-1999/1400-1499/1450-1459/1454/verifierE.go
+++ b/1000-1999/1400-1499/1450-1459/1454/verifierE.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveCaseE(n int, edges [][2]int) int64 {
+	adj := make([][]int, n+1)
+	deg := make([]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+		deg[u]++
+		deg[v]++
+	}
+	removed := make([]bool, n+1)
+	queue := make([]int, 0)
+	for i := 1; i <= n; i++ {
+		if deg[i] == 1 {
+			queue = append(queue, i)
+		}
+	}
+	qi := 0
+	for qi < len(queue) {
+		u := queue[qi]
+		qi++
+		removed[u] = true
+		for _, v := range adj[u] {
+			if removed[v] {
+				continue
+			}
+			deg[v]--
+			if deg[v] == 1 {
+				queue = append(queue, v)
+			}
+		}
+	}
+	iscycle := make([]bool, n+1)
+	cycleRoots := make([]int, 0)
+	for i := 1; i <= n; i++ {
+		if !removed[i] {
+			iscycle[i] = true
+			cycleRoots = append(cycleRoots, i)
+		}
+	}
+	visited := make([]bool, n+1)
+	var sumS2 int64
+	for _, u := range cycleRoots {
+		var cnt int64 = 1
+		stack := make([]int, 0)
+		for _, v := range adj[u] {
+			if !iscycle[v] && !visited[v] {
+				visited[v] = true
+				stack = append(stack, v)
+				cnt++
+			}
+		}
+		for len(stack) > 0 {
+			v := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			for _, w := range adj[v] {
+				if !iscycle[w] && !visited[w] {
+					visited[w] = true
+					stack = append(stack, w)
+					cnt++
+				}
+			}
+		}
+		sumS2 += cnt * cnt
+	}
+	nn := int64(n)
+	t1 := nn * (nn - 1) / 2
+	t2 := (nn*nn - sumS2) / 2
+	return t1 + t2
+}
+
+func generateGraph(n int, r *rand.Rand) [][2]int {
+	edges := make([][2]int, 0, n)
+	// build random tree first
+	for i := 2; i <= n; i++ {
+		v := r.Intn(i-1) + 1
+		edges = append(edges, [2]int{i, v})
+	}
+	// add one extra edge to create single cycle
+	for {
+		a := r.Intn(n) + 1
+		b := r.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		exists := false
+		for _, e := range edges {
+			if (e[0] == a && e[1] == b) || (e[0] == b && e[1] == a) {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			edges = append(edges, [2]int{a, b})
+			break
+		}
+	}
+	return edges
+}
+
+func generateTests() ([]int, [][][2]int, string) {
+	const t = 100
+	r := rand.New(rand.NewSource(5))
+	ns := make([]int, t)
+	graphs := make([][][2]int, t)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(8) + 3
+		edges := generateGraph(n, r)
+		ns[i] = n
+		graphs[i] = edges
+		fmt.Fprintf(&sb, "%d\n", n)
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+		}
+	}
+	return ns, graphs, sb.String()
+}
+
+func verify(ns []int, graphs [][][2]int, output string) error {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Split(bufio.ScanWords)
+	for idx, n := range ns {
+		if !scanner.Scan() {
+			return fmt.Errorf("case %d: missing output", idx+1)
+		}
+		var ans int64
+		fmt.Sscan(scanner.Text(), &ans)
+		expected := solveCaseE(n, graphs[idx])
+		if ans != expected {
+			return fmt.Errorf("case %d: expected %d got %d", idx+1, expected, ans)
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	ns, graphs, input := generateTests()
+	out, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if err := verify(ns, graphs, out); err != nil {
+		fmt.Fprintln(os.Stderr, "verification failed:", err)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed for problem E")
+}

--- a/1000-1999/1400-1499/1450-1459/1454/verifierF.go
+++ b/1000-1999/1400-1499/1450-1459/1454/verifierF.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveCaseF(a []int) (bool, int, int, int) {
+	n := len(a)
+	L := make([]int, n+2)
+	R := make([]int, n+2)
+	maxL := make([]int, n+2)
+	maxR := make([]int, n+2)
+	stack := make([]int, 0, n+2)
+	a2 := make([]int, n+2)
+	copy(a2[1:], a)
+	a2[0] = 0
+	stack = append(stack, 0)
+	for i := 1; i <= n; i++ {
+		for len(stack) > 0 && a2[stack[len(stack)-1]] >= a2[i] {
+			stack = stack[:len(stack)-1]
+		}
+		L[i] = stack[len(stack)-1] + 1
+		stack = append(stack, i)
+	}
+	stack = stack[:0]
+	a2[n+1] = 0
+	stack = append(stack, n+1)
+	for i := n; i >= 1; i-- {
+		for len(stack) > 0 && a2[stack[len(stack)-1]] >= a2[i] {
+			stack = stack[:len(stack)-1]
+		}
+		R[i] = stack[len(stack)-1] - 1
+		stack = append(stack, i)
+	}
+	maxL[0] = 0
+	for i := 1; i <= n; i++ {
+		maxL[i] = max(maxL[i-1], a2[i])
+	}
+	maxR[n+1] = 0
+	for i := n; i >= 1; i-- {
+		maxR[i] = max(maxR[i+1], a2[i])
+	}
+	for i := 1; i <= n; i++ {
+		u := maxL[L[i]-1]
+		v := maxR[R[i]+1]
+		Li, Ri := L[i], R[i]
+		if u < a2[i] && Li != i && a2[Li] == a2[i] {
+			u = a2[i]
+			Li++
+		}
+		if v < a2[i] && Ri != i && a2[Ri] == a2[i] {
+			v = a2[i]
+			Ri--
+		}
+		if u == a2[i] && v == a2[i] {
+			x := Li - 1
+			y := Ri - Li + 1
+			z := n - x - y
+			return true, x, y, z
+		}
+	}
+	return false, 0, 0, 0
+}
+
+func generateTests() ([][]int, string) {
+	const t = 100
+	r := rand.New(rand.NewSource(6))
+	arrays := make([][]int, t)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(20) + 3
+		fmt.Fprintf(&sb, "%d\n", n)
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = r.Intn(n) + 1
+			fmt.Fprintf(&sb, "%d ", arr[j])
+		}
+		fmt.Fprintln(&sb)
+		arrays[i] = arr
+	}
+	return arrays, sb.String()
+}
+
+func verify(arrays [][]int, output string) error {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Split(bufio.ScanWords)
+	for idx, arr := range arrays {
+		if !scanner.Scan() {
+			return fmt.Errorf("case %d: missing result", idx+1)
+		}
+		token := scanner.Text()
+		success, x, y, z := solveCaseF(arr)
+		if token == "NO" {
+			if success {
+				return fmt.Errorf("case %d: expected YES but got NO", idx+1)
+			}
+		} else if token == "YES" {
+			if !success {
+				return fmt.Errorf("case %d: expected NO but got YES", idx+1)
+			}
+			var X, Y, Z int
+			if !scanner.Scan() {
+				return fmt.Errorf("case %d: missing x", idx+1)
+			}
+			fmt.Sscan(scanner.Text(), &X)
+			if !scanner.Scan() {
+				return fmt.Errorf("case %d: missing y", idx+1)
+			}
+			fmt.Sscan(scanner.Text(), &Y)
+			if !scanner.Scan() {
+				return fmt.Errorf("case %d: missing z", idx+1)
+			}
+			fmt.Sscan(scanner.Text(), &Z)
+			if X != x || Y != y || Z != z {
+				return fmt.Errorf("case %d: expected %d %d %d got %d %d %d", idx+1, x, y, z, X, Y, Z)
+			}
+		} else {
+			return fmt.Errorf("case %d: unexpected token %s", idx+1, token)
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go <binary>")
+		os.Exit(1)
+	}
+	arrays, input := generateTests()
+	out, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if err := verify(arrays, out); err != nil {
+		fmt.Fprintln(os.Stderr, "verification failed:", err)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed for problem F")
+}


### PR DESCRIPTION
## Summary
- implement verifiers in Go for problems A–F of contest 1454
- generate 100 random test cases per problem
- run candidate binaries (or Go sources) and validate their outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688615b710c083248862c6379b78ee88