### PR TITLE
Add Go solution for problem 1520B

### DIFF
--- a/1000-1999/1500-1599/1520-1529/1520/1520B.go
+++ b/1000-1999/1500-1599/1520-1529/1520/1520B.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		count := 0
+		for length := 1; length <= 9; length++ {
+			for digit := 1; digit <= 9; digit++ {
+				val := 0
+				for i := 0; i < length; i++ {
+					val = val*10 + digit
+				}
+				if val <= n {
+					count++
+				}
+			}
+		}
+		fmt.Fprintln(writer, count)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for ordinary numbers problem (1520B)

## Testing
- `go vet 1000-1999/1500-1599/1520-1529/1520/1520B.go`
- `go build 1000-1999/1500-1599/1520-1529/1520/1520B.go`

------
https://chatgpt.com/codex/tasks/task_e_6886168a36a883249a07fe6f818bdd2b