### PR TITLE
Add Go verifiers for contest 1455

### DIFF
--- a/1000-1999/1400-1499/1450-1459/1455/verifierA.go
+++ b/1000-1999/1400-1499/1450-1459/1455/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refA.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1455A.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	digits := rng.Intn(30) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteByte(byte('1' + rng.Intn(9)))
+	for i := 1; i < digits; i++ {
+		sb.WriteByte(byte('0' + rng.Intn(10)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1455/verifierB.go
+++ b/1000-1999/1400-1499/1450-1459/1455/verifierB.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refB.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1455B.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	x := rng.Intn(1_000_000) + 1
+	return fmt.Sprintf("1\n%d\n", x)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1455/verifierC.go
+++ b/1000-1999/1400-1499/1450-1459/1455/verifierC.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refC.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1455C.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	x := rng.Intn(1_000_000) + 1
+	y := rng.Intn(1_000_000) + 1
+	return fmt.Sprintf("1\n%d %d\n", x, y)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1455/verifierD.go
+++ b/1000-1999/1400-1499/1450-1459/1455/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refD.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1455D.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	x := rng.Intn(501)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(501)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1455/verifierE.go
+++ b/1000-1999/1400-1499/1450-1459/1455/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refE.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1455E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	pts := make([][2]int, 4)
+	used := make(map[[2]int]bool)
+	for i := 0; i < 4; i++ {
+		for {
+			p := [2]int{rng.Intn(11), rng.Intn(11)}
+			if !used[p] {
+				used[p] = true
+				pts[i] = p
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	for i := 0; i < 4; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", pts[i][0], pts[i][1]))
+	}
+	return sb.String()
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1455/verifierF.go
+++ b/1000-1999/1400-1499/1450-1459/1455/verifierF.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type item struct {
+	idx int
+	ch  byte
+}
+
+func brute(n, k int, s string) string {
+	arr := make([]item, n)
+	for i := 0; i < n; i++ {
+		arr[i] = item{i, s[i]}
+	}
+	best := ""
+	var rec func(int, []item)
+	rec = func(pos int, cur []item) {
+		if pos == n {
+			var sb strings.Builder
+			for i := 0; i < n; i++ {
+				sb.WriteByte(cur[i].ch)
+			}
+			cand := sb.String()
+			if best == "" || cand < best {
+				best = cand
+			}
+			return
+		}
+		j := 0
+		for cur[j].idx != pos {
+			j++
+		}
+		tmp := make([]item, n)
+		copy(tmp, cur)
+		rec(pos+1, tmp)
+		if j > 0 {
+			copy(tmp, cur)
+			tmp[j], tmp[j-1] = tmp[j-1], tmp[j]
+			rec(pos+1, tmp)
+		}
+		if j < n-1 {
+			copy(tmp, cur)
+			tmp[j], tmp[j+1] = tmp[j+1], tmp[j]
+			rec(pos+1, tmp)
+		}
+		copy(tmp, cur)
+		tmp[j].ch = byte(int(tmp[j].ch-'a'-1+k)%k + 'a')
+		rec(pos+1, tmp)
+		copy(tmp, cur)
+		tmp[j].ch = byte(int(tmp[j].ch-'a'+1)%k + 'a')
+		rec(pos+1, tmp)
+	}
+	rec(0, arr)
+	return best
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(4) + 2
+	bytesArr := make([]byte, n)
+	for i := 0; i < n; i++ {
+		bytesArr[i] = byte('a' + rng.Intn(k))
+	}
+	s := string(bytesArr)
+	return fmt.Sprintf("1\n%d %d\n%s\n", n, k, s)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		var n, k int
+		var s string
+		fmt.Sscanf(strings.Split(in, "\n")[1], "%d %d", &n, &k)
+		s = strings.TrimSpace(strings.Split(in, "\n")[2])
+		expected := brute(n, k, s)
+		got, err := runBinary(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1455/verifierG.go
+++ b/1000-1999/1400-1499/1450-1459/1455/verifierG.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refG.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1455G.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genProgram(rng *rand.Rand) (int, int, []string) {
+	n := rng.Intn(8) + 1
+	s := rng.Intn(10) + 1
+	lines := make([]string, 0, n)
+	open := 0
+	for len(lines) < n {
+		if open > 0 && rng.Intn(4) == 0 && len(lines) < n { // close block
+			lines = append(lines, "end")
+			open--
+			continue
+		}
+		typ := rng.Intn(2)
+		if typ == 0 && open < 2 {
+			y := rng.Intn(10)
+			lines = append(lines, fmt.Sprintf("if %d", y))
+			open++
+		} else {
+			y := rng.Intn(10)
+			v := rng.Intn(10) + 1
+			lines = append(lines, fmt.Sprintf("set %d %d", y, v))
+		}
+	}
+	for open > 0 {
+		lines = append(lines, "end")
+		open--
+	}
+	return len(lines), s, lines
+}
+
+func buildInput(n, s int, lines []string) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, s))
+	for _, ln := range lines {
+		sb.WriteString(ln)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, s, lines := genProgram(rng)
+		input := buildInput(n, s, lines)
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for all problems of contest 1455
- verifiers build reference binaries, generate 100 random tests and compare output
- brute force reference implemented for problem F

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*


------
https://chatgpt.com/codex/tasks/task_e_688616433de8832496756ae9e5352a9b