### PR TITLE
Add solution verifiers for Codeforces 1458

### DIFF
--- a/1000-1999/1400-1499/1450-1459/1458/verifierA.go
+++ b/1000-1999/1400-1499/1450-1459/1458/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1458A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(0)
+	tests := make([]Test, 0, 120)
+	for i := 0; i < 110; i++ {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rand.Intn(100) + 1
+			sb.WriteString(strconv.Itoa(val))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rand.Intn(100) + 1
+			sb.WriteString(strconv.Itoa(val))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	// edge cases
+	tests = append(tests, Test{"1 1\n5\n7\n"})
+	tests = append(tests, Test{"3 2\n1 1 1\n0 0\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1458/verifierB.go
+++ b/1000-1999/1400-1499/1450-1459/1458/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1458B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(1)
+	tests := make([]Test, 0, 120)
+	for i := 0; i < 110; i++ {
+		n := rand.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			w := rand.Intn(5) + 1
+			v := rand.Float64()*10 + 1
+			sb.WriteString(fmt.Sprintf("%d %.2f\n", w, v))
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	// simple edge
+	tests = append(tests, Test{"1\n1 1.0\n"})
+	return tests
+}
+
+func normalize(s string) string {
+	return strings.TrimSpace(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if normalize(exp) != normalize(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1458/verifierC.go
+++ b/1000-1999/1400-1499/1450-1459/1458/verifierC.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1458C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randOps(n int) string {
+	letters := []byte{'R', 'L', 'D', 'U', 'I', 'C'}
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteByte(letters[rand.Intn(len(letters))])
+	}
+	return b.String()
+}
+
+func genTests() []Test {
+	rand.Seed(2)
+	tests := make([]Test, 0, 110)
+	for i := 0; i < 100; i++ {
+		t := rand.Intn(3) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", t))
+		for c := 0; c < t; c++ {
+			n := rand.Intn(3) + 1
+			m := rand.Intn(6) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+			for r := 0; r < n; r++ {
+				for c2 := 0; c2 < n; c2++ {
+					if c2 > 0 {
+						sb.WriteByte(' ')
+					}
+					val := rand.Intn(n) + 1
+					sb.WriteString(fmt.Sprintf("%d", val))
+				}
+				sb.WriteByte('\n')
+			}
+			sb.WriteString(randOps(m) + "\n")
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	// edge simple
+	var sb strings.Builder
+	sb.WriteString("1\n1 1\n1\nR\n")
+	tests = append(tests, Test{sb.String()})
+	return tests
+}
+
+func normalize(s string) string {
+	return strings.TrimSpace(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if normalize(exp) != normalize(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1458/verifierD.go
+++ b/1000-1999/1400-1499/1450-1459/1458/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1458D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randString(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		if rand.Intn(2) == 0 {
+			b.WriteByte('0')
+		} else {
+			b.WriteByte('1')
+		}
+	}
+	return b.String()
+}
+
+func genTests() []Test {
+	rand.Seed(3)
+	tests := make([]Test, 0, 110)
+	for i := 0; i < 100; i++ {
+		t := rand.Intn(3) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", t))
+		for j := 0; j < t; j++ {
+			lenS := rand.Intn(10) + 1
+			sb.WriteString(randString(lenS) + "\n")
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	// edge
+	tests = append(tests, Test{"1\n0\n"})
+	return tests
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if normalize(exp) != normalize(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1458/verifierE.go
+++ b/1000-1999/1400-1499/1450-1459/1458/verifierE.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func solve(input string) (string, error) {
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	scanner.Split(bufio.ScanWords)
+	nextInt := func() (int, error) {
+		if !scanner.Scan() {
+			return 0, fmt.Errorf("unexpected EOF")
+		}
+		return strconv.Atoi(scanner.Text())
+	}
+	n, err := nextInt()
+	if err != nil {
+		return "", err
+	}
+	m, err := nextInt()
+	if err != nil {
+		return "", err
+	}
+	short := make(map[[2]int]bool)
+	maxX, maxY := 0, 0
+	for i := 0; i < n; i++ {
+		x, _ := nextInt()
+		y, _ := nextInt()
+		short[[2]int{x, y}] = true
+		if x > maxX {
+			maxX = x
+		}
+		if y > maxY {
+			maxY = y
+		}
+	}
+	query := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		a, _ := nextInt()
+		b, _ := nextInt()
+		query[i] = [2]int{a, b}
+		if a > maxX {
+			maxX = a
+		}
+		if b > maxY {
+			maxY = b
+		}
+	}
+	maxX++
+	maxY++
+	win := make([][]bool, maxX+1)
+	for i := range win {
+		win[i] = make([]bool, maxY+1)
+	}
+	for x := 0; x <= maxX; x++ {
+		for y := 0; y <= maxY; y++ {
+			if x == 0 && y == 0 {
+				win[x][y] = false
+				continue
+			}
+			if short[[2]int{x, y}] {
+				win[x][y] = false
+				continue
+			}
+			res := false
+			for i := 1; i <= x && !res; i++ {
+				if !win[x-i][y] {
+					res = true
+				}
+			}
+			for j := 1; j <= y && !res; j++ {
+				if !win[x][y-j] {
+					res = true
+				}
+			}
+			win[x][y] = res
+		}
+	}
+	var out strings.Builder
+	for i := 0; i < m; i++ {
+		a, b := query[i][0], query[i][1]
+		if a <= maxX && b <= maxY && win[a][b] {
+			out.WriteString("WIN\n")
+		} else {
+			out.WriteString("LOSE\n")
+		}
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Test struct{ input string }
+
+func genTests() []Test {
+	rand.Seed(4)
+	tests := make([]Test, 0, 110)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 1
+		m := rand.Intn(4) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		s := make(map[[2]int]bool)
+		for j := 0; j < n; j++ {
+			x := rand.Intn(5)
+			y := rand.Intn(5)
+			s[[2]int{x, y}] = true
+			sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		}
+		for j := 0; j < m; j++ {
+			a := rand.Intn(5)
+			b := rand.Intn(5)
+			sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	// simple
+	tests = append(tests, Test{"1 1\n0 0\n0 0\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := solve(tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(tc.input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1400-1499/1450-1459/1458/verifierF.go
+++ b/1000-1999/1400-1499/1450-1459/1458/verifierF.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1458F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTree(n int) string {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func genTests() []Test {
+	rand.Seed(5)
+	tests := make([]Test, 0, 110)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(6) + 1
+		inp := genTree(n)
+		tests = append(tests, Test{inp})
+	}
+	// edge minimal
+	tests = append(tests, Test{"1\n"})
+	return tests
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if normalize(exp) != normalize(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1458
- each verifier builds the reference solution and runs over 100 randomized tests
- includes a small DP implementation for problem E

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688617e76cf48324a29d9e96408d44e6