### PR TITLE
Add Go verifiers for contest 1461

### DIFF
--- a/1000-1999/1400-1499/1460-1469/1461/verifierA.go
+++ b/1000-1999/1400-1499/1460-1469/1461/verifierA.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	k int
+}
+
+func genCase(r *rand.Rand) ([]testCase, string) {
+	t := r.Intn(10) + 1
+	cases := make([]testCase, t)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := r.Intn(1000) + 1
+		k := r.Intn(n) + 1
+		cases[i] = testCase{n: n, k: k}
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	}
+	return cases, sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func maxPalLen(s string) int {
+	n := len(s)
+	best := 0
+	for center := 0; center < n; center++ {
+		l, r := center, center
+		for l >= 0 && r < n && s[l] == s[r] {
+			if r-l+1 > best {
+				best = r - l + 1
+			}
+			l--
+			r++
+		}
+		l, r = center, center+1
+		for l >= 0 && r < n && s[l] == s[r] {
+			if r-l+1 > best {
+				best = r - l + 1
+			}
+			l--
+			r++
+		}
+	}
+	return best
+}
+
+func validate(cases []testCase, out string) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != len(cases) {
+		return fmt.Errorf("expected %d lines got %d", len(cases), len(lines))
+	}
+	for i, tc := range cases {
+		s := strings.TrimSpace(lines[i])
+		if len(s) != tc.n {
+			return fmt.Errorf("case %d: expected length %d got %d", i+1, tc.n, len(s))
+		}
+		for _, ch := range s {
+			if ch != 'a' && ch != 'b' && ch != 'c' {
+				return fmt.Errorf("case %d: invalid char %c", i+1, ch)
+			}
+		}
+		if maxPalLen(s) > tc.k {
+			return fmt.Errorf("case %d: longest palindrome > k", i+1)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		cases, input := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := validate(cases, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1461/verifierB.go
+++ b/1000-1999/1400-1499/1460-1469/1461/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1461B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := r.Intn(50) + 1
+		m := r.Intn(50) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for x := 0; x < n; x++ {
+			for y := 0; y < m; y++ {
+				if r.Intn(2) == 0 {
+					sb.WriteByte('.')
+				} else {
+					sb.WriteByte('*')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1461/verifierC.go
+++ b/1000-1999/1400-1499/1460-1469/1461/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1461C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := r.Intn(100) + 1
+		m := r.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		perm := r.Perm(n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", perm[j]+1))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < m; j++ {
+			rpos := r.Intn(n) + 1
+			p := r.Float64()
+			sb.WriteString(fmt.Sprintf("%d %.6f\n", rpos, p))
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1461/verifierD.go
+++ b/1000-1999/1400-1499/1460-1469/1461/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1461D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := r.Intn(200) + 1
+		q := r.Intn(200) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", r.Intn(1000000)+1))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < q; j++ {
+			sb.WriteString(fmt.Sprintf("%d\n", r.Intn(1000000)+1))
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1461/verifierE.go
+++ b/1000-1999/1400-1499/1460-1469/1461/verifierE.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1461E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	k := r.Int63n(1000) + 1
+	l := r.Int63n(k) + 1
+	rVal := k + r.Int63n(1000)
+	if rVal < k {
+		rVal = k
+	}
+	t := r.Int63n(1000) + 1
+	x := r.Int63n(1000000) + 1
+	y := r.Int63n(1000) + 1
+	return fmt.Sprintf("%d %d %d %d %d %d\n", k, l, rVal, t, x, y)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1461/verifierF.go
+++ b/1000-1999/1400-1499/1460-1469/1461/verifierF.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1461F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) (string, []int, map[rune]bool) {
+	n := r.Intn(15) + 1
+	nums := make([]int, n)
+	for i := 0; i < n; i++ {
+		nums[i] = r.Intn(10)
+	}
+	opsAll := []rune{"+", "-", "*"}
+	opsCount := r.Intn(3) + 1
+	ops := make([]rune, 0, opsCount)
+	used := make(map[rune]bool)
+	for len(ops) < opsCount {
+		c := opsAll[r.Intn(3)]
+		if !used[c] {
+			used[c] = true
+			ops = append(ops, c)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(nums[i]))
+	}
+	sb.WriteByte('\n')
+	for _, c := range ops {
+		sb.WriteRune(c)
+	}
+	sb.WriteByte('\n')
+	allowed := make(map[rune]bool)
+	for _, c := range ops {
+		allowed[c] = true
+	}
+	return sb.String(), nums, allowed
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func evalExpr(nums []int, allowed map[rune]bool, expr string) (*big.Int, error) {
+	expr = strings.ReplaceAll(strings.TrimSpace(expr), " ", "")
+	if len(expr) != len(nums)+(len(nums)-1) {
+		return nil, fmt.Errorf("invalid expression length")
+	}
+	val := big.NewInt(int64(nums[0]))
+	pos := 1
+	for i := 1; i < len(nums); i++ {
+		op := rune(expr[pos-1])
+		if !allowed[op] {
+			return nil, fmt.Errorf("invalid operator")
+		}
+		digit := expr[pos]
+		if digit < '0' || digit > '9' {
+			return nil, fmt.Errorf("invalid digit")
+		}
+		if int(digit-'0') != nums[i] {
+			return nil, fmt.Errorf("unexpected digit")
+		}
+		pos += 2
+		tmp := big.NewInt(int64(nums[i]))
+		switch op {
+		case '+':
+			val.Add(val, tmp)
+		case '-':
+			val.Sub(val, tmp)
+		case '*':
+			val.Mul(val, tmp)
+		default:
+			return nil, fmt.Errorf("bad op")
+		}
+	}
+	return val, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, nums, allowed := genCase(rng)
+		expectExpr, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		expectVal, err := evalExpr(nums, allowed, expectExpr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle produced invalid output on case %d", i+1)
+			os.Exit(1)
+		}
+		gotExpr, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		gotVal, err := evalExpr(nums, allowed, gotExpr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d invalid output: %v\ninput:%s\noutput:%s", i+1, err, input, gotExpr)
+			os.Exit(1)
+		}
+		if gotVal.Cmp(expectVal) != 0 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected value %s got %s\ninput:%s", i+1, expectVal.String(), gotVal.String(), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` with palindrome-based validation logic
- add oracle-based verifiers `verifierB.go`–`verifierE.go`
- add `verifierF.go` validating expression value via `big.Int`

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6886198b8b54832485f58438a2277bf7