### PR TITLE
Add Go verifiers for CF 1463

### DIFF
--- a/1000-1999/1400-1499/1460-1469/1463/verifierA.go
+++ b/1000-1999/1400-1499/1460-1469/1463/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(a, b, c int64) string {
+	sum := a + b + c
+	if sum%9 != 0 {
+		return "NO"
+	}
+	n := sum / 9
+	if a < n || b < n || c < n {
+		return "NO"
+	}
+	return "YES"
+}
+
+func deterministicCases() [][3]int64 {
+	return [][3]int64{
+		{1, 1, 1},
+		{9, 9, 9},
+		{3, 4, 2},
+		{1, 2, 3},
+		{100000000, 1, 1},
+	}
+}
+
+func randomCase(rng *rand.Rand) (int64, int64, int64) {
+	a := rng.Int63n(100000000) + 1
+	b := rng.Int63n(100000000) + 1
+	c := rng.Int63n(100000000) + 1
+	return a, b, c
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		a, b, c := randomCase(rng)
+		cases = append(cases, [3]int64{a, b, c})
+	}
+	for i, tc := range cases {
+		in := fmt.Sprintf("1\n%d %d %d\n", tc[0], tc[1], tc[2])
+		expect := solveCase(tc[0], tc[1], tc[2])
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d %d\n", i+1, err, tc[0], tc[1], tc[2])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1400-1499/1460-1469/1463/verifierB.go
+++ b/1000-1999/1400-1499/1460-1469/1463/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1463B.go")
+	bin := filepath.Join(os.TempDir(), "oracle1463B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(49) + 2
+	nums := make([]int, n)
+	for i := 0; i < n; i++ {
+		nums[i] = rng.Intn(1000000000) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1400-1499/1460-1469/1463/verifierC.go
+++ b/1000-1999/1400-1499/1460-1469/1463/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1463C.go")
+	bin := filepath.Join(os.TempDir(), "oracle1463C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	times := make([]int, n)
+	pos := make([]int, n)
+	cur := 0
+	for i := 0; i < n; i++ {
+		cur += rng.Intn(5) + 1
+		times[i] = cur
+		pos[i] = rng.Intn(21) - 10
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", times[i], pos[i])
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1400-1499/1460-1469/1463/verifierD.go
+++ b/1000-1999/1400-1499/1460-1469/1463/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1463D.go")
+	bin := filepath.Join(os.TempDir(), "oracle1463D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	nums := rng.Perm(2 * n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		b[i] = nums[i] + 1
+	}
+	sort.Ints(b)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1400-1499/1460-1469/1463/verifierE.go
+++ b/1000-1999/1400-1499/1460-1469/1463/verifierE.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type pair struct{ x, y int }
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1463E.go")
+	bin := filepath.Join(os.TempDir(), "oracle1463E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	k := rng.Intn(n)
+	p := make([]int, n+1)
+	root := 1
+	p[root] = 0
+	for i := 2; i <= n; i++ {
+		p[i] = rng.Intn(i-1) + 1
+	}
+	usedX := make(map[int]bool)
+	usedY := make(map[int]bool)
+	pairs := make([]pair, 0, k)
+	for len(pairs) < k {
+		x := rng.Intn(n) + 1
+		if usedX[x] {
+			continue
+		}
+		y := rng.Intn(n) + 1
+		if y == x || usedY[y] {
+			continue
+		}
+		usedX[x] = true
+		usedY[y] = true
+		pairs = append(pairs, pair{x, y})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", p[i])
+	}
+	sb.WriteByte('\n')
+	for _, pr := range pairs {
+		fmt.Fprintf(&sb, "%d %d\n", pr.x, pr.y)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1400-1499/1460-1469/1463/verifierF.go
+++ b/1000-1999/1400-1499/1460-1469/1463/verifierF.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1463F.go")
+	bin := filepath.Join(os.TempDir(), "oracle1463F.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Uint64()%1000000 + 1
+	x := rng.Intn(22) + 1
+	y := rng.Intn(22) + 1
+	return fmt.Sprintf("%d %d %d\n", n, x, y)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for all six problems of contest 1463
- each verifier generates 100 test cases and compares the candidate output against the reference

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68861aa3c81c8324a7de6ce60127f074