### PR TITLE
Add solution for 1528B in Go

### DIFF
--- a/1000-1999/1500-1599/1520-1529/1528/1528B.go
+++ b/1000-1999/1500-1599/1520-1529/1528/1528B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 998244353
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+
+	d := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		for j := i; j <= n; j += i {
+			d[j]++
+		}
+	}
+
+	var ans int64 = 1
+	for i := 2; i <= n; i++ {
+		ans = (2*ans + int64(d[i]-d[i-1])) % mod
+	}
+
+	if ans < 0 {
+		ans += mod
+	}
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1528B

## Testing
- `go build 1000-1999/1500-1599/1520-1529/1528/1528B.go`


------
https://chatgpt.com/codex/tasks/task_e_68861ae9c65c8324a5de49aed6691832