### PR TITLE
Add Go verifiers for CF contest 1465

### DIFF
--- a/1000-1999/1400-1499/1460-1469/1465/1465A.go
+++ b/1000-1999/1400-1499/1460-1469/1465/1465A.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		var s string
+		fmt.Fscan(in, &s)
+		cnt := 0
+		for i := len(s) - 1; i >= 0 && s[i] == ')'; i-- {
+			cnt++
+		}
+		if cnt > n-cnt {
+			fmt.Println("Yes")
+		} else {
+			fmt.Println("No")
+		}
+	}
+}

--- a/1000-1999/1400-1499/1460-1469/1465/problemA.txt
+++ b/1000-1999/1400-1499/1460-1469/1465/problemA.txt
@@ -1,0 +1,13 @@
+You have been assigned to develop a filter for bad messages in the in-game chat. A message is a string S S of length n n, consisting of lowercase English letters and characters ')'. The message is bad if the number of characters ')' at the end of the string strictly greater than the number of remaining characters. For example, the string ")bc)))" has three parentheses at the end, three remaining characters, and is not considered bad.
+
+Input
+
+The first line contains the number of test cases t t (1≤t≤100 1≤t≤100). Description of the t t test cases follows.
+
+The first line of each test case contains an integer n n (1≤n≤100 1≤n≤100). The second line of each test case contains a string S S of length n n, consisting of lowercase English letters and characters ')'.
+
+Output
+
+For each of t t test cases, print "Yes" if the string is bad. Otherwise, print "No".
+
+You can print each letter in any case (upper or lower).

--- a/1000-1999/1400-1499/1460-1469/1465/problemB.txt
+++ b/1000-1999/1400-1499/1460-1469/1465/problemB.txt
@@ -1,0 +1,31 @@
+We call a positive integer number fair if it is divisible by each of its nonzero digits. For example, 102 102 is fair (because it is divisible by 1 1 and 2 2), but 282 282 is not, because it isn't divisible by 8 8. Given a positive integer n n. Find the minimum integer x x, such that n≤x n≤x and x x is fair.
+
+Input
+
+The first line contains number of test cases t t (1≤t≤10 3 1≤t≤10 3). Each of the next t t lines contains an integer n n (1≤n≤10 18 1≤n≤10 18).
+
+Output
+
+For each of t t test cases print a single integer— the least fair number, which is not less than n n.
+
+Example
+
+Input
+
+Copy
+
+4
+1
+282
+1234567890
+1000000000000000000
+
+Output
+
+Copy
+
+1
+288
+1234568040
+1000000000000000000
+

--- a/1000-1999/1400-1499/1460-1469/1465/problemC.txt
+++ b/1000-1999/1400-1499/1460-1469/1465/problemC.txt
@@ -1,0 +1,41 @@
+You are given a n×n n×n chessboard. Rows and columns of the board are numbered from 1 1 to n n. Cell (x,y)(x,y) lies on the intersection of column number x x and row number y y.
+
+Rook is a chess piece, that can in one turn move any number of cells vertically or horizontally. There are m m rooks (m<n m<n) placed on the chessboard in such a way that no pair of rooks attack each other. I.e. there are no pair of rooks that share a row or a column.
+
+In one turn you can move one of the rooks any number of cells vertically or horizontally. Additionally, it shouldn't be attacked by any other rook after movement. What is the minimum number of moves required to place all the rooks on the main diagonal?
+
+The main diagonal of the chessboard is all the cells (i,i)(i,i), where 1≤i≤n 1≤i≤n.
+
+Input
+
+The first line contains the number of test cases t t (1≤t≤10 3 1≤t≤10 3). Description of the t t test cases follows.
+
+The first line of each test case contains two integers n n and m m— size of the chessboard and the number of rooks (2≤n≤10 5 2≤n≤10 5, 1≤m<n 1≤m<n). Each of the next m m lines contains two integers x i x i and y i y i— positions of rooks, i i-th rook is placed in the cell (x i,y i)(x i,y i) (1≤x i,y i≤n 1≤x i,y i≤n). It's guaranteed that no two rooks attack each other in the initial placement.
+
+The sum of n n over all test cases does not exceed 10 5 10 5.
+
+Output
+
+For each of t t test cases print a single integer— the minimum number of moves required to place all the rooks on the main diagonal.
+
+It can be proved that this is always possible.
+
+Example
+
+Input
+
+Copy
+
+4
+3 1
+2 3
+3 2
+2 1
+1 2
+5 3
+2 3
+3 1
+1 2
+5 4
+4 5
+5 1

--- a/1000-1999/1400-1499/1460-1469/1465/problemD.txt
+++ b/1000-1999/1400-1499/1460-1469/1465/problemD.txt
@@ -1,0 +1,45 @@
+Currently, XXOC's rap is a string consisting of zeroes, ones, and question marks. Unfortunately, haters gonna hate. They will write x angry comments for every occurrence of subsequence 01 and y angry comments for every occurrence of subsequence 10. You should replace all the question marks with 0 or 1 in such a way that the number of angry comments would be as small as possible.
+
+String b is a subsequence of string a, if it can be obtained by removing some characters from a. Two occurrences of a subsequence are considered distinct if sets of positions of remaining characters are distinct.
+
+Input
+
+The first line contains string s— XXOC's rap (1≤|s|≤10 5). The second line contains two integers x and y— the number of angry comments XXOC will recieve for every occurrence of 01 and 10 accordingly (0≤x,y≤10 6).
+
+Output
+
+Output a single integer— the minimum number of angry comments.
+
+Examples
+
+Input
+
+Copy
+
+0?1
+2 3
+
+Output
+
+Copy
+
+4
+
+Input
+
+Copy
+
+?????
+13 37
+
+Output
+
+Copy
+
+0
+
+Input
+
+Copy
+
+?10?

--- a/1000-1999/1400-1499/1460-1469/1465/problemE.txt
+++ b/1000-1999/1400-1499/1460-1469/1465/problemE.txt
@@ -1,0 +1,57 @@
+You've got a string S S consisting of n n lowercase English letters from your friend. It turned out that this is a number written in poman numerals. The poman numeral system is long forgotten. All that's left is the algorithm to transform number from poman numerals to the numeral system familiar to us. Characters of S S are numbered from 1 1 to n n from left to right. Let's denote the value of S S as f(S)f(S), it is defined as follows:
+
+*    If |S|>1|S|>1, an arbitrary integer m m (1≤m<|S|1≤m<|S|) is chosen, and it is defined that f(S)=−f(S[1,m])+f(S[m+1,|S|])f(S)=−f(S[1,m])+f(S[m+1,|S|]), where S[l,r]S[l,r] denotes the substring of S S from the l l-th to the r r-th position, inclusively. 
+*    Otherwise S=c S=c, where c c is some English letter. Then f(S)=2 p o s(c)f(S)=2 p o s(c), where p o s(c)p o s(c) is the position of letter c c in the alphabet (p o s(p o s(a)=0)=0, p o s(p o s(z)=25)=25). 
+
+Note that m m is chosen independently on each step.
+
+Your friend thinks it is possible to get f(S)=T f(S)=T by choosing the right m m on every step. Is he right?
+
+Input
+
+The first line contains two integers n n and T T (2≤n≤10 5 2≤n≤10 5, −10 15≤T≤10 15−10 15≤T≤10 15).
+
+The second line contains a string S S consisting of n n lowercase English letters.
+
+Output
+
+Print "Yes" if it is possible to get the desired value. Otherwise, print "No".
+
+You can print each letter in any case (upper or lower).
+
+Examples
+
+Input
+
+Copy
+
+2 -1
+ba
+
+Output
+
+Copy
+
+Yes
+
+Input
+
+Copy
+
+3 -7
+abc
+
+Output
+
+Copy
+
+No
+
+Input
+
+Copy
+
+7 -475391
+qohshra
+
+Output

--- a/1000-1999/1400-1499/1460-1469/1465/problemF.txt
+++ b/1000-1999/1400-1499/1460-1469/1465/problemF.txt
@@ -1,0 +1,55 @@
+According to a legend the Hanoi Temple holds a permutation of integers from 1 to n. There are n stones of distinct colors lying in one line in front of the temple. Monks can perform the following operation on stones: choose a position i (1≤i≤n) and cyclically shift stones at positions i, p[i], p[p[i]], .... That is, a stone from position i will move to position p[i], a stone from position p[i] will move to position p[p[i]], and so on, a stone from position j, such that p[j]=i, will move to position i.
+
+Each day the monks must obtain a new arrangement of stones using an arbitrary number of these operations. When all possible arrangements will have been obtained, the world will end. You are wondering, what if some elements of the permutation could be swapped just before the beginning? How many days would the world last?
+
+You want to get a permutation that will allow the world to last as long as possible, using the minimum number of exchanges of two elements of the permutation.
+
+Two arrangements of stones are considered different if there exists a position i such that the colors of the stones on that position are different in these arrangements.
+
+Input
+
+Each test consists of multiple test cases. The first line contains the number of test cases t (1≤t≤10 3). Description of the test cases follows.
+
+The first line of each test case contains n (3≤n≤10 6). The next line contains n integers p 1,…,p n (1≤p i≤n). It is guaranteed that p is a permutation.
+
+It is guaranteed that the sum of n over all test cases does not exceed 10 6.
+
+Output
+
+For each of the t test cases, print two integers on a new line: the largest possible number of days the world can last, modulo 10 9+7, and the minimum number of exchanges required for that.
+
+Examples
+
+Input
+
+Copy
+
+3
+3
+2 3 1
+3
+2 1 3
+3
+1 2 3
+
+Output
+
+Copy
+
+3 0
+3 1
+3 2
+
+Input
+
+Copy
+
+5
+4
+2 3 4 1
+4
+2 3 1 4
+4
+2 1 4 3
+4
+2 1 3 4

--- a/1000-1999/1400-1499/1460-1469/1465/verifierA.go
+++ b/1000-1999/1400-1499/1460-1469/1465/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseA struct {
+	s string
+}
+
+func genTestsA() []testCaseA {
+	rand.Seed(42)
+	tests := make([]testCaseA, 100)
+	for i := range tests {
+		n := rand.Intn(100) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			if rand.Intn(3) == 0 {
+				sb.WriteByte(')')
+			} else {
+				sb.WriteByte(byte('a' + rand.Intn(26)))
+			}
+		}
+		tests[i] = testCaseA{sb.String()}
+	}
+	// add edge cases
+	tests = append(tests, testCaseA{")"})
+	tests = append(tests, testCaseA{"abc"})
+	return tests
+}
+
+func solveA(tc testCaseA) string {
+	n := len(tc.s)
+	cnt := 0
+	for i := n - 1; i >= 0 && tc.s[i] == ')'; i-- {
+		cnt++
+	}
+	if cnt > n-cnt {
+		return "Yes"
+	}
+	return "No"
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=1")
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%s\n", len(tc.s), tc.s)
+		exp := solveA(tc)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1465/verifierB.go
+++ b/1000-1999/1400-1499/1460-1469/1465/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseB struct {
+	n int64
+}
+
+func genTestsB() []testCaseB {
+	rand.Seed(43)
+	tests := make([]testCaseB, 100)
+	for i := range tests {
+		var n int64
+		if rand.Intn(2) == 0 {
+			n = int64(rand.Intn(1000) + 1)
+		} else {
+			n = rand.Int63n(1e12) + 1
+		}
+		tests[i] = testCaseB{n}
+	}
+	tests = append(tests, testCaseB{1})
+	tests = append(tests, testCaseB{282})
+	return tests
+}
+
+func isFair(x int64) bool {
+	t := x
+	for t > 0 {
+		d := t % 10
+		if d != 0 && x%int64(d) != 0 {
+			return false
+		}
+		t /= 10
+	}
+	return true
+}
+
+func solveB(tc testCaseB) int64 {
+	x := tc.n
+	for {
+		if isFair(x) {
+			return x
+		}
+		x++
+	}
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=1")
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n", tc.n)
+		exp := solveB(tc)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != fmt.Sprintf("%d", exp) {
+			fmt.Printf("test %d failed: expected %d got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1465/verifierC.go
+++ b/1000-1999/1400-1499/1460-1469/1465/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type rook struct {
+	x, y int
+}
+
+type testCaseC struct {
+	n     int
+	rooks []rook
+}
+
+func genTestsC() []testCaseC {
+	rand.Seed(44)
+	tests := make([]testCaseC, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 2
+		m := rand.Intn(n-1) + 1
+		rows := rand.Perm(n)[:m]
+		cols := rand.Perm(n)[:m]
+		rs := make([]rook, m)
+		for j := 0; j < m; j++ {
+			rs[j] = rook{rows[j] + 1, cols[j] + 1}
+		}
+		tests[i] = testCaseC{n: n, rooks: rs}
+	}
+	// add sample-like cases
+	tests = append(tests, testCaseC{n: 3, rooks: []rook{{2, 3}}})
+	tests = append(tests, testCaseC{n: 3, rooks: []rook{{2, 1}, {1, 2}}})
+	tests = append(tests, testCaseC{n: 5, rooks: []rook{{2, 3}, {3, 1}, {1, 2}}})
+	tests = append(tests, testCaseC{n: 5, rooks: []rook{{4, 5}, {5, 1}, {2, 2}, {3, 3}}})
+	return tests
+}
+
+func solveC(tc testCaseC) int {
+	mp := make(map[int]int)
+	notDiag := 0
+	for _, r := range tc.rooks {
+		if r.x != r.y {
+			mp[r.x] = r.y
+			notDiag++
+		}
+	}
+	vis := make(map[int]int)
+	cycles := 0
+	for x := range mp {
+		if vis[x] != 0 {
+			continue
+		}
+		cur := x
+		for vis[cur] == 0 {
+			vis[cur] = x
+			next, ok := mp[cur]
+			if !ok {
+				break
+			}
+			cur = next
+		}
+		if vis[cur] == x {
+			cycles++
+		}
+	}
+	return notDiag + cycles
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=1")
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "1\n%d %d\n", tc.n, len(tc.rooks))
+		for _, r := range tc.rooks {
+			fmt.Fprintf(&sb, "%d %d\n", r.x, r.y)
+		}
+		input := sb.String()
+		exp := solveC(tc)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != fmt.Sprintf("%d", exp) {
+			fmt.Printf("test %d failed: expected %d got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1465/verifierD.go
+++ b/1000-1999/1400-1499/1460-1469/1465/verifierD.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseD struct {
+	s    string
+	x, y int
+}
+
+func genTestsD() []testCaseD {
+	rand.Seed(45)
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rand.Intn(6) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			r := rand.Intn(3)
+			if r == 0 {
+				sb.WriteByte('0')
+			} else if r == 1 {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('?')
+			}
+		}
+		x := rand.Intn(5)
+		y := rand.Intn(5)
+		tests[i] = testCaseD{sb.String(), x, y}
+	}
+	tests = append(tests, testCaseD{"0?1", 2, 3})
+	tests = append(tests, testCaseD{"?????", 13, 37})
+	tests = append(tests, testCaseD{"?10?", 239, 7})
+	tests = append(tests, testCaseD{"01101001", 5, 7})
+	return tests
+}
+
+func cost(str string, x, y int) int64 {
+	zeros, ones := 0, 0
+	var c int64
+	for i := 0; i < len(str); i++ {
+		if str[i] == '0' {
+			c += int64(y * ones)
+			zeros++
+		} else {
+			c += int64(x * zeros)
+			ones++
+		}
+	}
+	return c
+}
+
+func solveD(tc testCaseD) int64 {
+	pos := []int{}
+	for i, ch := range tc.s {
+		if ch == '?' {
+			pos = append(pos, i)
+		}
+	}
+	best := int64(1<<63 - 1)
+	total := 1 << len(pos)
+	buf := []byte(tc.s)
+	for mask := 0; mask < total; mask++ {
+		for j, p := range pos {
+			if mask>>j&1 == 1 {
+				buf[p] = '1'
+			} else {
+				buf[p] = '0'
+			}
+		}
+		c := cost(string(buf), tc.x, tc.y)
+		if c < best {
+			best = c
+		}
+	}
+	return best
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=1")
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%s\n%d %d\n", tc.s, tc.x, tc.y)
+		exp := solveD(tc)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != fmt.Sprintf("%d", exp) {
+			fmt.Printf("test %d failed: expected %d got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1465/verifierE.go
+++ b/1000-1999/1400-1499/1460-1469/1465/verifierE.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseE struct {
+	n int
+	t int64
+	s string
+}
+
+func genTestsE() []testCaseE {
+	rand.Seed(46)
+	tests := make([]testCaseE, 100)
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	for i := range tests {
+		n := rand.Intn(8) + 2
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteByte(letters[rand.Intn(26)])
+		}
+		t := rand.Int63n(2000) - 1000
+		tests[i] = testCaseE{n, t, sb.String()}
+	}
+	tests = append(tests, testCaseE{2, -1, "ba"})
+	tests = append(tests, testCaseE{3, -7, "abc"})
+	tests = append(tests, testCaseE{7, -475391, "qohshra"})
+	return tests
+}
+
+func value(ch byte) int64 {
+	return 1 << (ch - 'a')
+}
+
+func solveE(tc testCaseE) bool {
+	vals := make([]int64, tc.n)
+	for i := 0; i < tc.n; i++ {
+		vals[i] = value(tc.s[i])
+	}
+	t := tc.t - vals[tc.n-1] + vals[tc.n-2]
+	sum := int64(0)
+	counts := make([]int64, 26)
+	for i := 0; i < tc.n-2; i++ {
+		sum += vals[i]
+		counts[tc.s[i]-'a']++
+	}
+	target := t + sum
+	if target%2 != 0 {
+		return false
+	}
+	target /= 2
+	for b := 25; b >= 0; b-- {
+		need := target >> uint(b) & 1
+		if need == 1 {
+			if counts[b] == 0 {
+				return false
+			}
+			counts[b]--
+		}
+		if b > 0 {
+			counts[b-1] += counts[b] * 2
+		}
+	}
+	return true
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=1")
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d\n%s\n", tc.n, tc.t, tc.s)
+		exp := solveE(tc)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(strings.ToLower(got))
+		expected := "no"
+		if exp {
+			expected = "yes"
+		}
+		if got != expected {
+			fmt.Printf("test %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1465/verifierF.go
+++ b/1000-1999/1400-1499/1460-1469/1465/verifierF.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseF struct {
+	n int
+	p []int
+}
+
+func genTestsF() []testCaseF {
+	rand.Seed(47)
+	tests := make([]testCaseF, 100)
+	for i := range tests {
+		n := rand.Intn(4) + 3 // 3..6
+		perm := rand.Perm(n)
+		for j := range perm {
+			perm[j]++
+		}
+		tests[i] = testCaseF{n, perm}
+	}
+	tests = append(tests, testCaseF{3, []int{2, 3, 1}})
+	tests = append(tests, testCaseF{3, []int{2, 1, 3}})
+	tests = append(tests, testCaseF{3, []int{1, 2, 3}})
+	return tests
+}
+
+func prodCycles(p []int) int {
+	n := len(p)
+	vis := make([]bool, n)
+	prod := 1
+	for i := 0; i < n; i++ {
+		if !vis[i] {
+			l := 0
+			j := i
+			for !vis[j] {
+				vis[j] = true
+				j = p[j] - 1
+				l++
+			}
+			prod *= l
+		}
+	}
+	return prod
+}
+
+func solveF(tc testCaseF) (int, int) {
+	start := make([]int, tc.n)
+	copy(start, tc.p)
+	type node struct {
+		perm []int
+		d    int
+	}
+	m := make(map[string]int)
+	q := list.New()
+	key := fmt.Sprint(start)
+	m[key] = 0
+	q.PushBack(node{start, 0})
+	bestProd := prodCycles(start)
+	bestDist := 0
+	for q.Len() > 0 {
+		e := q.Front()
+		q.Remove(e)
+		cur := e.Value.(node)
+		p := cur.perm
+		prod := prodCycles(p)
+		if prod > bestProd {
+			bestProd = prod
+			bestDist = cur.d
+		} else if prod == bestProd && cur.d < bestDist {
+			bestDist = cur.d
+		}
+		for i := 0; i < tc.n; i++ {
+			for j := i + 1; j < tc.n; j++ {
+				np := make([]int, tc.n)
+				copy(np, p)
+				np[i], np[j] = np[j], np[i]
+				k := fmt.Sprint(np)
+				if _, ok := m[k]; !ok {
+					m[k] = cur.d + 1
+					q.PushBack(node{np, cur.d + 1})
+				}
+			}
+		}
+	}
+	return bestProd % 1000000007, bestDist
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=1")
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsF()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", 1)
+		fmt.Fprintf(&sb, "%d\n", tc.n)
+		for j, v := range tc.p {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		prod, dist := solveF(tc)
+		exp := fmt.Sprintf("%d %d", prod, dist)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add contest directory for 1465
- include problem statements A–F
- implement reference solution for 1465A
- provide verifiers for problems A–F generating 100+ tests each

## Testing
- `gofmt -w 1000-1999/1400-1499/1460-1469/1465/*.go`

------
https://chatgpt.com/codex/tasks/task_e_68861bbbe5588324ac446fcacf5094b5