### PR TITLE
Add Go solution for 1553D

### DIFF
--- a/1000-1999/1500-1599/1550-1559/1553/1553D.go
+++ b/1000-1999/1500-1599/1550-1559/1553/1553D.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var q int
+	fmt.Fscan(reader, &q)
+	for ; q > 0; q-- {
+		var s, t string
+		fmt.Fscan(reader, &s)
+		fmt.Fscan(reader, &t)
+
+		i := len(s) - 1
+		j := len(t) - 1
+		for i >= 0 && j >= 0 {
+			if s[i] == t[j] {
+				i--
+				j--
+			} else {
+				i -= 2
+			}
+		}
+
+		if j < 0 {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1553D

## Testing
- `go build ./1000-1999/1500-1599/1550-1559/1553/1553D.go`
- `go run ./1000-1999/1500-1599/1550-1559/1553/1553D.go < /tmp/test.txt`

------
https://chatgpt.com/codex/tasks/task_e_68861ebe51348324a410928599bb8340