### PR TITLE
Add Go solution for 1553E

### DIFF
--- a/1000-1999/1500-1599/1550-1559/1553/1553E.go
+++ b/1000-1999/1500-1599/1550-1559/1553/1553E.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(in, &n, &m)
+		p := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &p[i])
+			p[i]-- // zero-index values
+		}
+
+		cnt := make([]int, n)
+		for i := 0; i < n; i++ {
+			// compute shift k that puts p[i] at position i after shift
+			k := (i - p[i] + n) % n
+			cnt[k]++
+		}
+
+		var candidates []int
+		for k := 0; k < n; k++ {
+			if n-cnt[k] <= 2*m { // mismatches can be fixed with at most m swaps
+				if checkShift(p, n, m, k) {
+					candidates = append(candidates, k)
+				}
+			}
+		}
+
+		fmt.Fprint(out, len(candidates))
+		for _, k := range candidates {
+			fmt.Fprintf(out, " %d", k)
+		}
+		fmt.Fprintln(out)
+	}
+}
+
+func checkShift(p []int, n, m, k int) bool {
+	// permutation mapping from index to where element should go
+	visited := make([]bool, n)
+	swaps := 0
+	for i := 0; i < n; i++ {
+		if !visited[i] {
+			j := i
+			cycleLen := 0
+			for !visited[j] {
+				visited[j] = true
+				j = (p[j] + k) % n
+				cycleLen++
+			}
+			swaps += cycleLen - 1
+			if swaps > m {
+				return false
+			}
+		}
+	}
+	return swaps <= m
+}


### PR DESCRIPTION
## Summary
- implement `1553E.go` solving permutation shift problem

## Testing
- `go run 1000-1999/1500-1599/1550-1559/1553/1553E.go << EOF
1
4 1
2 3 1 4
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68861e784f488324a5872b92e4f7054b