### PR TITLE
Add Go solution for 1557B

### DIFF
--- a/1000-1999/1500-1599/1550-1559/1557/1557B.go
+++ b/1000-1999/1500-1599/1550-1559/1557/1557B.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		arr := make([]int, n)
+		pos := make(map[int]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+			pos[arr[i]] = i
+		}
+		sortedArr := make([]int, n)
+		copy(sortedArr, arr)
+		sort.Ints(sortedArr)
+		segments := 1
+		for i := 0; i < n-1; i++ {
+			if pos[sortedArr[i]]+1 != pos[sortedArr[i+1]] {
+				segments++
+			}
+		}
+		if segments <= k {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1557B using segment counting approach

## Testing
- `go build 1000-1999/1500-1599/1550-1559/1557/1557B.go`
- `go vet 1000-1999/1500-1599/1550-1559/1557/1557B.go`


------
https://chatgpt.com/codex/tasks/task_e_688626214ac08324b7d8500362cdf532