### PR TITLE
Add Go solution for 1551A

### DIFF
--- a/1000-1999/1500-1599/1550-1559/1551/1551A.go
+++ b/1000-1999/1500-1599/1550-1559/1551/1551A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		base := n / 3
+		r := n % 3
+		c1, c2 := base, base
+		if r == 1 {
+			c1++
+		} else if r == 2 {
+			c2++
+		}
+		fmt.Fprintln(writer, c1, c2)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1551A

## Testing
- `go build 1000-1999/1500-1599/1550-1559/1551/1551A.go`
- `cat <<EOF | go run 1000-1999/1500-1599/1550-1559/1551/1551A.go
3
1000
30
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68862923af608324a90e20dcf0f81dfb