### PR TITLE
Add Go solution for 1584A

### DIFF
--- a/1000-1999/1500-1599/1580-1589/1584/1584A.go
+++ b/1000-1999/1500-1599/1580-1589/1584/1584A.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var u, v int64
+		fmt.Fscan(reader, &u, &v)
+		x := -u * u
+		y := v * v
+		fmt.Fprintln(writer, x, y)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 1584A based on simple algebraic identity

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68862ee281c08324a8f43eeaaf192746