### PR TITLE
Add Go solution for 1585D

### DIFF
--- a/1000-1999/1500-1599/1580-1589/1585/1585D.go
+++ b/1000-1999/1500-1599/1580-1589/1585/1585D.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		freq := make(map[int]int)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+			freq[a[i]]++
+		}
+
+		// For arrays shorter than 3, no 3-cycle can be applied.
+		if n < 3 {
+			sorted := true
+			for i := 1; i < n; i++ {
+				if a[i] < a[i-1] {
+					sorted = false
+					break
+				}
+			}
+			if sorted {
+				fmt.Fprintln(out, "YES")
+			} else {
+				fmt.Fprintln(out, "NO")
+			}
+			continue
+		}
+
+		// If there is a duplicate value, parity can be adjusted arbitrarily.
+		dup := false
+		for _, v := range freq {
+			if v > 1 {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			fmt.Fprintln(out, "YES")
+			continue
+		}
+
+		// No duplicates: the array is a permutation of 1..n. Check parity.
+		visited := make([]bool, n+1)
+		cycles := 0
+		for i := 1; i <= n; i++ {
+			if !visited[i] {
+				cycles++
+				for j := i; !visited[j]; j = a[j-1] {
+					visited[j] = true
+				}
+			}
+		}
+		if (n-cycles)%2 == 0 {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1585D

## Testing
- `go run 1000-1999/1500-1599/1580-1589/1585/1585D.go << EOF
1
3
3 1 2
EOF`
- `go run 1000-1999/1500-1599/1580-1589/1585/1585D.go << EOF
1
3
2 1 3
EOF`
- `go run 1000-1999/1500-1599/1580-1589/1585/1585D.go << EOF
1
3
2 1 1
EOF`


------
https://chatgpt.com/codex/tasks/task_e_688632fd17b88324ae260be3306d99a6