### PR TITLE
Add Go solution for 1585A

### DIFF
--- a/1000-1999/1500-1599/1580-1589/1585/1585A.go
+++ b/1000-1999/1500-1599/1580-1589/1585/1585A.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		height := 1
+		alive := true
+		for i := 0; i < n && alive; i++ {
+			if a[i] == 1 {
+				if i > 0 && a[i-1] == 1 {
+					height += 5
+				} else {
+					height += 1
+				}
+			} else {
+				if i > 0 && a[i-1] == 0 {
+					alive = false
+				}
+			}
+		}
+		if alive {
+			fmt.Fprintln(out, height)
+		} else {
+			fmt.Fprintln(out, -1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problem A of contest 1585

## Testing
- `go run 1585A.go << EOF
1
4
1 0 1 1
EOF`
- `go run 1585A.go << EOF
1
3
1 0 0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6886345b558c8324b4792d7cb9a3921d