### PR TITLE
Add solution for 1578H

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1578/1578H.go
+++ b/1000-1999/1500-1599/1570-1579/1578/1578H.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var (
+	s   string
+	pos int
+)
+
+// parseType parses a type expression starting at position pos
+// according to the grammar described in problemH.txt and
+// returns its order.
+func parseType() int {
+	left := parseFactor()
+	if pos+1 < len(s) && s[pos] == '-' && s[pos+1] == '>' {
+		pos += 2
+		right := parseType()
+		if left+1 > right {
+			return left + 1
+		}
+		return right
+	}
+	return left
+}
+
+// parseFactor parses either the unit type "()" or a parenthesized
+// type expression.
+func parseFactor() int {
+	// assume s[pos] == '(' according to grammar
+	if pos+1 < len(s) && s[pos] == '(' && s[pos+1] == ')' {
+		pos += 2
+		return 0
+	}
+	// '(' T ')'
+	pos++ // consume '('
+	val := parseType()
+	pos++ // consume ')'
+	return val
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	fmt.Fscan(in, &s)
+	pos = 0
+	ans := parseType()
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement Go parser for functional type orders
- follow grammar for unit, parenthesized and function types

## Testing
- `go build ./1000-1999/1500-1599/1570-1579/1578/1578H.go`

------
https://chatgpt.com/codex/tasks/task_e_68863d62b5088324bfa84a39ccd77400