### PR TITLE
Add Go solution for 1578D

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1578/1578D.go
+++ b/1000-1999/1500-1599/1570-1579/1578/1578D.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func dragonCurve(x, y int64) (int, int64) {
+	bit := int64(1)
+	pos := int64(0)
+	for !(x >= -1 && x <= 0 && y >= -1 && y <= 0) {
+		bit <<= 1
+		if ((x ^ y ^ ((x ^ y) >> 1)) & 1) != 0 {
+			pos = bit - 1 - pos
+		}
+		if ((x ^ y) >> 1 & 1) != 0 {
+			nx := (x >> 1) + ((y + 1) >> 1)
+			ny := ((y + 1) >> 1) - (x >> 1) - 1
+			x, y = nx, ny
+		} else {
+			nx := ((x + 1) >> 1) + (y >> 1)
+			ny := (y >> 1) - ((x + 1) >> 1)
+			x, y = nx, ny
+		}
+	}
+	curve := int((x&1 ^ y&3) + 1)
+	return curve, pos + 1
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	fmt.Fscan(in, &n)
+	for i := 0; i < n; i++ {
+		var x, y int64
+		fmt.Fscan(in, &x, &y)
+		curve, pos := dragonCurve(x, y)
+		fmt.Fprintf(out, "%d %d\n", curve, pos)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Dragon Curve solver in Go using official tutorial's approach

## Testing
- `go build 1000-1999/1500-1599/1570-1579/1578/1578D.go`
- `echo -e "5\n0 0\n-2 0\n-7 -7\n5 -9\n9 9" | go run 1000-1999/1500-1599/1570-1579/1578/1578D.go`

------
https://chatgpt.com/codex/tasks/task_e_68863deeba108324b4870eb3036347a5