### PR TITLE
Add Go solution for 1573A

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1573/1573A.go
+++ b/1000-1999/1500-1599/1570-1579/1573/1573A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		var s string
+		fmt.Fscan(in, &s)
+		ans := 0
+		for i := 0; i < n; i++ {
+			d := int(s[i] - '0')
+			ans += d
+			if i < n-1 && d > 0 {
+				ans++
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem A in contest 1573

## Testing
- `go build 1000-1999/1500-1599/1570-1579/1573/1573A.go`
- `./1573A < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_688640f133a08324a3f67042c7bdd1ee