### PR TITLE
Add Go solution for 1575A

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1575/1575A.go
+++ b/1000-1999/1500-1599/1570-1579/1575/1575A.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+	titles := make([]struct {
+		key string
+		idx int
+	}, n)
+	for i := 0; i < n; i++ {
+		var s string
+		fmt.Fscan(in, &s)
+		b := []byte(s)
+		for j := 1; j < m; j += 2 {
+			b[j] = 'Z' - (b[j] - 'A')
+		}
+		titles[i].key = string(b)
+		titles[i].idx = i + 1
+	}
+	sort.Slice(titles, func(i, j int) bool {
+		return titles[i].key < titles[j].key
+	})
+	out := bufio.NewWriter(os.Stdout)
+	for i, t := range titles {
+		if i > 0 {
+			fmt.Fprint(out, " ")
+		}
+		fmt.Fprint(out, t.idx)
+	}
+	fmt.Fprintln(out)
+	out.Flush()
+}


### PR DESCRIPTION
## Summary
- implement `1575A.go` solution for sorting strings in alternating order

## Testing
- `go build 1000-1999/1500-1599/1570-1579/1575/1575A.go`
- `go vet 1000-1999/1500-1599/1570-1579/1575/1575A.go`


------
https://chatgpt.com/codex/tasks/task_e_688645dde728832484bdc0b37614e0c2