### PR TITLE
Add Go solution for 1509C

### DIFF
--- a/1000-1999/1500-1599/1500-1509/1509/1509C.go
+++ b/1000-1999/1500-1599/1500-1509/1509/1509C.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	speeds := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &speeds[i])
+	}
+
+	sort.Slice(speeds, func(i, j int) bool { return speeds[i] < speeds[j] })
+
+	dp := make([][]int64, n)
+	for i := range dp {
+		dp[i] = make([]int64, n)
+	}
+
+	for length := 2; length <= n; length++ {
+		for l := 0; l+length-1 < n; l++ {
+			r := l + length - 1
+			left := dp[l+1][r]
+			right := dp[l][r-1]
+			if left < right {
+				dp[l][r] = left + speeds[r] - speeds[l]
+			} else {
+				dp[l][r] = right + speeds[r] - speeds[l]
+			}
+		}
+	}
+
+	fmt.Fprintln(writer, dp[0][n-1])
+}


### PR DESCRIPTION
## Summary
- implement dynamic programming solution for problem C in contest 1509

## Testing
- `go build 1000-1999/1500-1599/1500-1509/1509/1509C.go`


------
https://chatgpt.com/codex/tasks/task_e_688646f610008324991fb681aa03ec7b