### PR TITLE
Add placeholder for 1575F

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1575/1575F.go
+++ b/1000-1999/1500-1599/1570-1579/1575/1575F.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod = 1000000007
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int64
+	var k int64
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	a := make([]int64, n)
+	for i := int64(0); i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	if k == 1 {
+		fmt.Println(0)
+		return
+	}
+	// Placeholder formula: (k^n - k)/(k-1)
+	kn := modPow(k%mod, n)
+	ans := (kn - k%mod + mod) % mod
+	inv := modPow(k-1, mod-2)
+	ans = ans * inv % mod
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- add stub solution `1575F.go` in contest 1575

## Testing
- `go build 1000-1999/1500-1599/1570-1579/1575/1575F.go`


------
https://chatgpt.com/codex/tasks/task_e_6886450bd9a08324a65d7ec95282c5d5