### PR TITLE
Add Go solution for 1505F

### DIFF
--- a/1000-1999/1500-1599/1500-1509/1505/1505F.go
+++ b/1000-1999/1500-1599/1500-1509/1505/1505F.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var a int
+	if _, err := fmt.Fscan(in, &a); err != nil {
+		return
+	}
+
+	if a > 0 {
+		fmt.Fprintln(out, 1)
+	} else if a == 0 {
+		fmt.Fprintln(out, 0)
+	} else {
+		fmt.Fprintln(out, -1)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem F in contest 1505

## Testing
- `go vet 1000-1999/1500-1599/1500-1509/1505/1505F.go`
- `go run 1000-1999/1500-1599/1500-1509/1505/1505F.go <<EOF
10
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68864d8718088324b4ce3b01f2200510