### PR TITLE
Add Go solution for 1538F

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1538/1538F.go
+++ b/1000-1999/1500-1599/1530-1539/1538/1538F.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+   "bufio"
+   "fmt"
+   "os"
+)
+
+func main() {
+   reader := bufio.NewReader(os.Stdin)
+   writer := bufio.NewWriter(os.Stdout)
+   defer writer.Flush()
+
+   var t int
+   fmt.Fscan(reader, &t)
+   for ; t > 0; t-- {
+      var l, r int64
+      fmt.Fscan(reader, &l, &r)
+      var ans int64
+      for p := int64(1); p <= r; p *= 10 {
+         ans += r/p - l/p
+      }
+      fmt.Fprintln(writer, ans)
+   }
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1538F

## Testing
- `go build 1000-1999/1500-1599/1530-1539/1538/1538F.go`
- `go vet 1000-1999/1500-1599/1530-1539/1538/1538F.go`
- `go run 1000-1999/1500-1599/1530-1539/1538/1538F.go << EOF
1
9 10
EOF`
- `go run 1000-1999/1500-1599/1530-1539/1538/1538F.go << EOF
1
489999 490000
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68864f2b5b64832493f58f16fa1884ef