### PR TITLE
Add Go solution for 1538D

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1538/1538D.go
+++ b/1000-1999/1500-1599/1530-1539/1538/1538D.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func primeCount(x int64) int {
+	cnt := 0
+	for x%2 == 0 {
+		cnt++
+		x /= 2
+	}
+	for i := int64(3); i*i <= x; i += 2 {
+		for x%i == 0 {
+			cnt++
+			x /= i
+		}
+	}
+	if x > 1 {
+		cnt++
+	}
+	return cnt
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b int64
+		var k int
+		fmt.Fscan(reader, &a, &b, &k)
+		cntA := primeCount(a)
+		cntB := primeCount(b)
+		maxOps := cntA + cntB
+		if k == 1 {
+			if a != b && (a%b == 0 || b%a == 0) {
+				fmt.Fprintln(writer, "Yes")
+			} else {
+				fmt.Fprintln(writer, "No")
+			}
+		} else {
+			if k >= 2 && k <= maxOps {
+				fmt.Fprintln(writer, "Yes")
+			} else {
+				fmt.Fprintln(writer, "No")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem D in round 1538

## Testing
- `go run 1000-1999/1500-1599/1530-1539/1538/1538D.go <<EOF
1
4 8 2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68864ee551b88324b4a8832d046e0ddb