### PR TITLE
Add Go solution for 1505D

### DIFF
--- a/1000-1999/1500-1599/1500-1509/1505/1505D.go
+++ b/1000-1999/1500-1599/1500-1509/1505/1505D.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+	seen := make(map[int]bool)
+	for n > 0 {
+		d := n % m
+		if seen[d] {
+			fmt.Println("NO")
+			return
+		}
+		seen[d] = true
+		n /= m
+	}
+	fmt.Println("YES")
+}


### PR DESCRIPTION
## Summary
- implement `1505D.go` for Xenodrome check

## Testing
- `go vet 1000-1999/1500-1599/1500-1509/1505/1505D.go`
- `go build 1000-1999/1500-1599/1500-1509/1505/1505D.go`


------
https://chatgpt.com/codex/tasks/task_e_68864d4106a48324b52e7af444d96228