### PR TITLE
Add Go solution for 1531E1

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1531/1531E1.go
+++ b/1000-1999/1500-1599/1530-1539/1531/1531E1.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func build(ids []int, l, r int, s []byte, pos *int) []int {
+	if r-l == 1 {
+		return []int{ids[l]}
+	}
+	mid := (l + r) / 2
+	left := build(ids, l, mid, s, pos)
+	right := build(ids, mid, r, s, pos)
+	i, j := 0, 0
+	res := make([]int, 0, len(left)+len(right))
+	for i < len(left) && j < len(right) {
+		if *pos >= len(s) || s[*pos] == '0' {
+			res = append(res, left[i])
+			i++
+		} else {
+			res = append(res, right[j])
+			j++
+		}
+		(*pos)++
+	}
+	res = append(res, left[i:]...)
+	res = append(res, right[j:]...)
+	return res
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var s string
+	fmt.Fscan(in, &s)
+	const n = 16
+	ids := make([]int, n)
+	for i := 0; i < n; i++ {
+		ids[i] = i
+	}
+	pos := 0
+	order := build(ids, 0, n, []byte(s), &pos)
+	ans := make([]int, n)
+	for rank, idx := range order {
+		ans[idx] = rank + 1
+	}
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	fmt.Fprintln(out, n)
+	for i, v := range ans {
+		if i > 0 {
+			fmt.Fprint(out, " ")
+		}
+		fmt.Fprint(out, v)
+	}
+	fmt.Fprintln(out)
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem E1 in contest 1531

## Testing
- `go build 1000-1999/1500-1599/1530-1539/1531/1531E1.go`
- `echo 101011010001100100011011001111011000011110010 | ./1531E1`

------
https://chatgpt.com/codex/tasks/task_e_688651e848ac8324a01b063eb186d442