### PR TITLE
Add Go solution for 1536E

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1536/1536E.go
+++ b/1000-1999/1500-1599/1530-1539/1536/1536E.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 1000000007
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(reader, &n, &m)
+		var hashCount int64
+		zeroExists := false
+		for i := 0; i < n; i++ {
+			var row string
+			fmt.Fscan(reader, &row)
+			for _, ch := range row {
+				if ch == '#' {
+					hashCount++
+				} else if ch == '0' {
+					zeroExists = true
+				}
+			}
+		}
+		ans := modPow(2, hashCount)
+		if !zeroExists {
+			ans--
+			if ans < 0 {
+				ans += mod
+			}
+		}
+		fmt.Fprintln(writer, ans%mod)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1536E in Go

## Testing
- `go build 1000-1999/1500-1599/1530-1539/1536/1536E.go`
- `go vet 1000-1999/1500-1599/1530-1539/1536/1536E.go`


------
https://chatgpt.com/codex/tasks/task_e_688652ba054483249ce16093e1c11140