### PR TITLE
Add Go solution for 1537E2

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1537/1537E2.go
+++ b/1000-1999/1500-1599/1530-1539/1537/1537E2.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, k int
+	fmt.Fscan(reader, &n, &k)
+	var s string
+	fmt.Fscan(reader, &s)
+
+	best := 1
+	for i := 1; i < n; i++ {
+		if s[i] > s[i%best] {
+			break
+		}
+		if s[i] < s[i%best] {
+			best = i + 1
+		}
+	}
+
+	prefix := s[:best]
+	res := make([]byte, k)
+	for i := 0; i < k; i++ {
+		res[i] = prefix[i%best]
+	}
+	fmt.Fprintln(writer, string(res))
+}


### PR DESCRIPTION
## Summary
- implement solution for 1537E2 (Erase and Extend hard version)

## Testing
- `go build 1000-1999/1500-1599/1530-1539/1537/1537E2.go`

------
https://chatgpt.com/codex/tasks/task_e_6886557665208324adb1c79faa7a1ee7