### PR TITLE
Add Go solution for 1537A

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1537/1537A.go
+++ b/1000-1999/1500-1599/1530-1539/1537/1537A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		sum := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			sum += x
+		}
+		if sum == n {
+			fmt.Fprintln(writer, 0)
+		} else if sum < n {
+			fmt.Fprintln(writer, 1)
+		} else {
+			fmt.Fprintln(writer, sum-n)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1537A.go` with the standard logic for Codeforces 1537A

## Testing
- `go build 1000-1999/1500-1599/1530-1539/1537/1537A.go`

------
https://chatgpt.com/codex/tasks/task_e_688654ea52088324b760929be1810c61