### PR TITLE
Add Go solution for CF 1530A

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1530/1530A.go
+++ b/1000-1999/1500-1599/1530-1539/1530/1530A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(in, &s)
+		maxDigit := byte('0')
+		for i := 0; i < len(s); i++ {
+			if s[i] > maxDigit {
+				maxDigit = s[i]
+			}
+		}
+		fmt.Fprintln(out, int(maxDigit-'0'))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem `1530A` in contest directory 1000-1999/1500-1599/1530-1539/1530

## Testing
- `gofmt -w 1000-1999/1500-1599/1530-1539/1530/1530A.go`
- `go build 1000-1999/1500-1599/1530-1539/1530/1530A.go`

------
https://chatgpt.com/codex/tasks/task_e_688656d4a7b08324b5a88ab5b38fe7e7