### PR TITLE
Add Go solution for 1539C

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1539/1539C.go
+++ b/1000-1999/1500-1599/1530-1539/1539/1539C.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	var k, x int64
+	if _, err := fmt.Fscan(in, &n, &k, &x); err != nil {
+		return
+	}
+	levels := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &levels[i])
+	}
+
+	sort.Slice(levels, func(i, j int) bool { return levels[i] < levels[j] })
+
+	gaps := make([]int64, 0)
+	for i := 1; i < n; i++ {
+		diff := levels[i] - levels[i-1]
+		if diff > x {
+			gaps = append(gaps, (diff-1)/x)
+		}
+	}
+
+	sort.Slice(gaps, func(i, j int) bool { return gaps[i] < gaps[j] })
+
+	groups := len(gaps) + 1
+	for _, cost := range gaps {
+		if k >= cost {
+			k -= cost
+			groups--
+		} else {
+			break
+		}
+	}
+
+	fmt.Fprintln(out, groups)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1539C (Stable Groups)

## Testing
- `go build 1000-1999/1500-1599/1530-1539/1539/1539C.go`


------
https://chatgpt.com/codex/tasks/task_e_688657a701148324a190211fe6bc50ad