### PR TITLE
Add naive LIS-based Go solution for 1530H

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1530/1530H.go
+++ b/1000-1999/1500-1599/1530-1539/1530/1530H.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func lis(arr []int) int {
+	b := make([]int, 0)
+	for _, x := range arr {
+		i := lowerBound(b, x)
+		if i == len(b) {
+			b = append(b, x)
+		} else {
+			b[i] = x
+		}
+	}
+	return len(b)
+}
+
+func lowerBound(a []int, x int) int {
+	l, r := 0, len(a)
+	for l < r {
+		m := (l + r) / 2
+		if a[m] < x {
+			l = m + 1
+		} else {
+			r = m
+		}
+	}
+	return l
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var T int
+	if _, err := fmt.Fscan(in, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		for i := range arr {
+			fmt.Fscan(in, &arr[i])
+		}
+		best := lis(arr)
+		rev := make([]int, n)
+		for i := 0; i < n; i++ {
+			rev[i] = arr[n-1-i]
+		}
+		if v := lis(rev); v > best {
+			best = v
+		}
+		fmt.Fprintln(out, best)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go program `1530H.go` that reads the input, computes LIS of the permutation and of its reverse, and prints the larger result.

## Testing
- `go test ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_688655bc804083249ccde919008986e3