### PR TITLE
Add Go solution for 1535B

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1535/1535B.go
+++ b/1000-1999/1500-1599/1530-1539/1535/1535B.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		evens := make([]int, 0)
+		odds := make([]int, 0)
+		for _, v := range arr {
+			if v%2 == 0 {
+				evens = append(evens, v)
+			} else {
+				odds = append(odds, v)
+			}
+		}
+		b := append(evens, odds...)
+		count := 0
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				if gcd(b[i], 2*b[j]) > 1 {
+					count++
+				}
+			}
+		}
+		fmt.Fprintln(writer, count)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1535B.go` for contest 1535 problem B

## Testing
- `go run 1000-1999/1500-1599/1530-1539/1535/1535B.go <<EOF
1
4
6 3 5 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6886599110748324bdfeaf10b29a7949