### PR TITLE
Add solution for 1547D in Go

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1547/1547D.go
+++ b/1000-1999/1500-1599/1540-1549/1547/1547D.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	const mask int = (1 << 30) - 1
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		x := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &x[i])
+		}
+		y := make([]int, n)
+		prev := x[0] // x[0] ^ y[0] where y[0] = 0
+		for i := 1; i < n; i++ {
+			y[i] = (^x[i] & mask) & prev
+			prev = x[i] ^ y[i]
+		}
+		for i, v := range y {
+			if i > 0 {
+				out.WriteByte(' ')
+			}
+			fmt.Fprintf(out, "%d", v)
+		}
+		out.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1547D.go` to compute lexicographically minimal co-growing sequence

## Testing
- `go vet 1000-1999/1500-1599/1540-1549/1547/1547D.go`
- `go build 1000-1999/1500-1599/1540-1549/1547/1547D.go`


------
https://chatgpt.com/codex/tasks/task_e_688662526bd4832483d7311ed3ca66c3