### PR TITLE
Add Go solution for 1547C

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1547/1547C.go
+++ b/1000-1999/1500-1599/1540-1549/1547/1547C.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var k, n, m int
+		fmt.Fscan(reader, &k, &n, &m)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		b := make([]int, m)
+		for i := 0; i < m; i++ {
+			fmt.Fscan(reader, &b[i])
+		}
+		res := make([]int, 0, n+m)
+		i, j := 0, 0
+		lines := k
+		possible := true
+		for i < n || j < m {
+			if i < n && a[i] == 0 {
+				res = append(res, 0)
+				lines++
+				i++
+				continue
+			}
+			if j < m && b[j] == 0 {
+				res = append(res, 0)
+				lines++
+				j++
+				continue
+			}
+			if i < n && a[i] <= lines {
+				res = append(res, a[i])
+				i++
+				continue
+			}
+			if j < m && b[j] <= lines {
+				res = append(res, b[j])
+				j++
+				continue
+			}
+			possible = false
+			break
+		}
+		if !possible {
+			fmt.Fprintln(writer, -1)
+		} else {
+			for idx, v := range res {
+				if idx > 0 {
+					writer.WriteByte(' ')
+				}
+				fmt.Fprint(writer, v)
+			}
+			writer.WriteByte('\n')
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for Pair Programming 1547C

## Testing
- `go run 1000-1999/1500-1599/1540-1549/1547/1547C.go <<EOF`
  `1`
  `3 2 2`
  `2 0`
  `0 5`
  `EOF`


------
https://chatgpt.com/codex/tasks/task_e_6886632495bc8324a8e96c4e93fcec5e