### PR TITLE
Add Go solution for 1547A

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1547/1547A.go
+++ b/1000-1999/1500-1599/1540-1549/1547/1547A.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var xA, yA int
+		var xB, yB int
+		var xF, yF int
+		fmt.Fscan(reader, &xA, &yA)
+		fmt.Fscan(reader, &xB, &yB)
+		fmt.Fscan(reader, &xF, &yF)
+
+		dist := abs(xA-xB) + abs(yA-yB)
+		if xA == xB && xA == xF {
+			minY := yA
+			maxY := yB
+			if minY > maxY {
+				minY, maxY = maxY, minY
+			}
+			if yF > minY && yF < maxY {
+				dist += 2
+			}
+		} else if yA == yB && yA == yF {
+			minX := xA
+			maxX := xB
+			if minX > maxX {
+				minX, maxX = maxX, minX
+			}
+			if xF > minX && xF < maxX {
+				dist += 2
+			}
+		}
+		fmt.Fprintln(writer, dist)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation of problem 1547A (Shortest Path with Obstacle)

## Testing
- `gofmt -w 1000-1999/1500-1599/1540-1549/1547/1547A.go`


------
https://chatgpt.com/codex/tasks/task_e_688663b0a7248324b684ecd4a809008a