### PR TITLE
Add Go solution for 1545D

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1545/1545D.go
+++ b/1000-1999/1500-1599/1540-1549/1545/1545D.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var m, k int
+	if _, err := fmt.Fscan(reader, &m, &k); err != nil {
+		return
+	}
+	vals := make([][]int64, k)
+	S := make([]int64, k)
+	Q := make([]int64, k)
+	for i := 0; i < k; i++ {
+		vals[i] = make([]int64, m)
+		for j := 0; j < m; j++ {
+			fmt.Fscan(reader, &vals[i][j])
+			S[i] += vals[i][j]
+			Q[i] += vals[i][j] * vals[i][j]
+		}
+	}
+
+	vsum := (S[k-1] - S[0]) / int64(k-1)
+	y := -1
+	var delta int64
+	for i := 1; i < k-1; i++ {
+		expected := S[0] + int64(i)*vsum
+		if S[i] != expected {
+			y = i
+			delta = S[i] - expected
+			break
+		}
+	}
+	if y == -1 {
+		// should not happen
+		return
+	}
+
+	idx := make([]int, 0, 3)
+	for i := 0; i < k && len(idx) < 3; i++ {
+		if i != y {
+			idx = append(idx, i)
+		}
+	}
+
+	t1, t2, t3 := float64(idx[0]), float64(idx[1]), float64(idx[2])
+	q1, q2, q3 := float64(Q[idx[0]]), float64(Q[idx[1]]), float64(Q[idx[2]])
+	yf := float64(y)
+	L1 := (yf - t2) * (yf - t3) / ((t1 - t2) * (t1 - t3))
+	L2 := (yf - t1) * (yf - t3) / ((t2 - t1) * (t2 - t3))
+	L3 := (yf - t1) * (yf - t2) / ((t3 - t1) * (t3 - t2))
+	expectedQ := q1*L1 + q2*L2 + q3*L3
+	expQ := int64(math.Round(expectedQ))
+
+	diffQ := Q[y] - expQ
+	p := (diffQ/int64(delta) - delta) / 2
+	fmt.Fprintf(writer, "%d %d\n", y, p)
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1545D

## Testing
- `go build 1000-1999/1500-1599/1540-1549/1545/1545D.go`
- `echo '5 7
6 9 9 6 9
10 7 10 8 10
11 11 11 10 8
12 12 12 12 9
14 13 12 10 13
11 14 16 14 14
12 15 18 15 15' | ./1545D`

------
https://chatgpt.com/codex/tasks/task_e_6886659b071883248d2cef3398404e10