### PR TITLE
Add Go solution for 1545E1

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1545/1545E1.go
+++ b/1000-1999/1500-1599/1540-1549/1545/1545E1.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+type Interval struct{ l, r int }
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	var x int
+	fmt.Fscan(in, &x)
+
+	intervals := make([]Interval, n)
+	for i := 0; i < n; i++ {
+		var tl, tr, l, r int
+		fmt.Fscan(in, &tl, &tr, &l, &r)
+		a := l - tr
+		b := r - tl
+		if a > b {
+			a, b = b, a
+		}
+		intervals[i] = Interval{a, b}
+	}
+	sort.Slice(intervals, func(i, j int) bool {
+		if intervals[i].l == intervals[j].l {
+			return intervals[i].r < intervals[j].r
+		}
+		return intervals[i].l < intervals[j].l
+	})
+	merged := make([]Interval, 0, n)
+	for _, iv := range intervals {
+		if len(merged) == 0 || iv.l > merged[len(merged)-1].r {
+			merged = append(merged, iv)
+		} else {
+			if iv.r > merged[len(merged)-1].r {
+				merged[len(merged)-1].r = iv.r
+			}
+		}
+	}
+
+	ans := 0
+	if len(merged) == 0 {
+		fmt.Fprintln(out, 0)
+		return
+	}
+	if x < merged[0].l {
+		ans = merged[0].l - x
+	} else if x > merged[len(merged)-1].r {
+		ans = x - merged[len(merged)-1].r
+	} else {
+		ans = 0
+		found := false
+		for i, iv := range merged {
+			if x < iv.l {
+				ans = iv.l - x
+				found = true
+				break
+			} else if x <= iv.r {
+				left := x - iv.l
+				right := iv.r - x
+				if left < right {
+					ans = left
+				} else {
+					ans = right
+				}
+				found = true
+				break
+			} else if i+1 < len(merged) && x < merged[i+1].l {
+				ans = 0
+				found = true
+				break
+			}
+		}
+		if !found {
+			ans = 0
+		}
+	}
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- add `1545E1.go` implementing a solver for problem E1 using interval merging

## Testing
- `go vet 1000-1999/1500-1599/1540-1549/1545/1545E1.go`
- `go build 1000-1999/1500-1599/1540-1549/1545/1545E1.go`


------
https://chatgpt.com/codex/tasks/task_e_688666b334908324968fc89842d540d6