### PR TITLE
Add solution for 1458E

### DIFF
--- a/1000-1999/1400-1499/1450-1459/1458/1458E.go
+++ b/1000-1999/1400-1499/1450-1459/1458/1458E.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+
+	// read shortcut positions
+	rowMap := make(map[int][]int) // y -> list of x
+	colMap := make(map[int][]int) // x -> list of y
+	shortSet := make(map[[2]int]struct{})
+	for i := 0; i < n; i++ {
+		var x, y int
+		fmt.Fscan(in, &x, &y)
+		rowMap[y] = append(rowMap[y], x)
+		colMap[x] = append(colMap[x], y)
+		shortSet[[2]int{x, y}] = struct{}{}
+	}
+	for y := range rowMap {
+		xs := rowMap[y]
+		sort.Ints(xs)
+		rowMap[y] = xs
+	}
+	for x := range colMap {
+		ys := colMap[x]
+		sort.Ints(ys)
+		colMap[x] = ys
+	}
+
+	for i := 0; i < m; i++ {
+		var a, b int
+		fmt.Fscan(in, &a, &b)
+		if _, ok := shortSet[[2]int{a, b}]; ok {
+			fmt.Fprintln(out, "LOSE")
+			continue
+		}
+		win := false
+		if xs, ok := rowMap[b]; ok {
+			// check if there exists shortcut (x,b) with x < a
+			idx := sort.SearchInts(xs, a)
+			if idx > 0 {
+				win = true
+			}
+		}
+		if !win {
+			if ys, ok := colMap[a]; ok {
+				idx := sort.SearchInts(ys, b)
+				if idx > 0 {
+					win = true
+				}
+			}
+		}
+		if !win {
+			if a^b != 0 {
+				win = true
+			}
+		}
+		if win {
+			fmt.Fprintln(out, "WIN")
+		} else {
+			fmt.Fprintln(out, "LOSE")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for Nim Shortcuts (1458E)

## Testing
- `go build 1000-1999/1400-1499/1450-1459/1458/1458E.go`
- `go vet 1000-1999/1400-1499/1450-1459/1458/1458E.go`


------
https://chatgpt.com/codex/tasks/task_e_68866b141b9083249f4b630c2ed3f43b