### PR TITLE
Add Go solution for 1468F

### DIFF
--- a/1000-1999/1400-1499/1460-1469/1468/1468F.go
+++ b/1000-1999/1400-1499/1460-1469/1468/1468F.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int64) int64 {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		type dir struct{ x, y int64 }
+		cnt := make(map[dir]int64)
+		for i := 0; i < n; i++ {
+			var x, y, u, v int64
+			fmt.Fscan(reader, &x, &y, &u, &v)
+			dx := u - x
+			dy := v - y
+			g := gcd(dx, dy)
+			dx /= g
+			dy /= g
+			cnt[dir{dx, dy}]++
+		}
+		var ans int64
+		for d, c := range cnt {
+			opp := dir{-d.x, -d.y}
+			if v, ok := cnt[opp]; ok {
+				ans += c * v
+			}
+		}
+		ans /= 2
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add `1468F.go` with solution for problem F of contest 1468

## Testing
- `go build 1000-1999/1400-1499/1460-1469/1468/1468F.go`
- `go vet 1000-1999/1400-1499/1460-1469/1468/1468F.go`

------
https://chatgpt.com/codex/tasks/task_e_68866e16a3788324b45c8d27f374c332