### PR TITLE
Add Go solution for 1491C

### DIFF
--- a/1000-1999/1400-1499/1490-1499/1491/1491C.go
+++ b/1000-1999/1400-1499/1490-1499/1491/1491C.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		s := make([]int64, n+1)
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(reader, &s[i])
+		}
+		add := make([]int64, n+2)
+		var ans int64
+		for i := 1; i <= n; i++ {
+			if add[i] < s[i]-1 {
+				ans += s[i] - 1 - add[i]
+				add[i] = s[i] - 1
+			}
+			leftover := add[i] - (s[i] - 1)
+			add[i+1] += leftover
+			limit := i + int(s[i])
+			if limit > n {
+				limit = n
+			}
+			for j := i + 2; j <= limit; j++ {
+				add[j]++
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `1491C` (Pekora and Trampoline)

## Testing
- `go build 1000-1999/1400-1499/1490-1499/1491/1491C.go`
- `echo '3
6
1 4 2 2 2 2
2
2 3
3
1 1 1
' | go run 1000-1999/1400-1499/1490-1499/1491/1491C.go`

------
https://chatgpt.com/codex/tasks/task_e_68867af2cd2c8324aec76a8692acdd83