### PR TITLE
Add Go solution for 1490C

### DIFF
--- a/1000-1999/1400-1499/1490-1499/1490/1490C.go
+++ b/1000-1999/1400-1499/1490-1499/1490/1490C.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// This program solves problemC from contest 1490. For each input value x, it
+// checks if x can be written as the sum of two positive cubes. Since x is at
+// most 1e12, the cube root is at most 10000. We precompute all cubes up to
+// 10000^3 and then test whether x-a^3 is itself a cube for some a.
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+
+	const limit = 10000
+	cubes := make(map[int64]bool, limit)
+	for i := 1; i <= limit; i++ {
+		v := int64(i)
+		cubes[v*v*v] = true
+	}
+
+	for ; t > 0; t-- {
+		var x int64
+		fmt.Fscan(reader, &x)
+		found := false
+		for i := 1; i <= limit; i++ {
+			a := int64(i)
+			cubeA := a * a * a
+			if cubeA > x {
+				break
+			}
+			if cubes[x-cubeA] {
+				found = true
+				break
+			}
+		}
+		if found {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem 1490C

## Testing
- `go build 1000-1999/1400-1499/1490-1499/1490/1490C.go`
- `go vet 1000-1999/1400-1499/1490-1499/1490/1490C.go`


------
https://chatgpt.com/codex/tasks/task_e_68867ec753a883248b43ce3ead8c9c60