### PR TITLE
Add Go solution for problem 1490F

### DIFF
--- a/1000-1999/1400-1499/1490-1499/1490/1490F.go
+++ b/1000-1999/1400-1499/1490-1499/1490/1490F.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		freq := make(map[int]int, n)
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			freq[x]++
+		}
+		freqCount := make(map[int]int)
+		freqs := make([]int, 0, len(freq))
+		for _, f := range freq {
+			freqs = append(freqs, f)
+			freqCount[f]++
+		}
+		sort.Ints(freqs)
+		uniqueFreq := make([]int, 0, len(freqCount))
+		for i, f := range freqs {
+			if i == 0 || f != freqs[i-1] {
+				uniqueFreq = append(uniqueFreq, f)
+			}
+		}
+		sort.Ints(uniqueFreq)
+		ans := n
+		suffix := 0
+		for i := len(uniqueFreq) - 1; i >= 0; i-- {
+			f := uniqueFreq[i]
+			suffix += freqCount[f]
+			keep := suffix * f
+			if n-keep < ans {
+				ans = n - keep
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for `problemF` under 1490 directory

## Testing
- `go build 1000-1999/1400-1499/1490-1499/1490/1490F.go`
- `echo -e "1\n6\n1 3 2 1 4 2" | go run 1000-1999/1400-1499/1490-1499/1490/1490F.go`

------
https://chatgpt.com/codex/tasks/task_e_68867e3b7da08324988a5a727df9ac05