### PR TITLE
Add Go solution for CF 1487A

### DIFF
--- a/1000-1999/1400-1499/1480-1489/1487/1487A.go
+++ b/1000-1999/1400-1499/1480-1489/1487/1487A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		minVal := 101
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+			if a[i] < minVal {
+				minVal = a[i]
+			}
+		}
+		cnt := 0
+		for i := 0; i < n; i++ {
+			if a[i] > minVal {
+				cnt++
+			}
+		}
+		fmt.Fprintln(out, cnt)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for 1487A in Go

## Testing
- `go build 1000-1999/1400-1499/1480-1489/1487/1487A.go`


------
https://chatgpt.com/codex/tasks/task_e_688683fa6af88324bc3113ce2a014ac6