### PR TITLE
Add Go solution for 1486D

### DIFF
--- a/1000-1999/1400-1499/1480-1489/1486/1486D.go
+++ b/1000-1999/1400-1499/1480-1489/1486/1486D.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func check(a []int, k int, mid int) bool {
+	n := len(a)
+	prefix := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		if a[i-1] >= mid {
+			prefix[i] = prefix[i-1] + 1
+		} else {
+			prefix[i] = prefix[i-1] - 1
+		}
+	}
+	minPrefix := 0
+	for i := k; i <= n; i++ {
+		if prefix[i]-minPrefix > 0 {
+			return true
+		}
+		if prefix[i-k+1] < minPrefix {
+			minPrefix = prefix[i-k+1]
+		}
+	}
+	return false
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, k int
+	fmt.Fscan(reader, &n, &k)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+
+	low, high := 1, n
+	res := 1
+	for low <= high {
+		mid := (low + high) / 2
+		if check(a, k, mid) {
+			res = mid
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+
+	fmt.Fprintln(writer, res)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 1486D (Max Median)

## Testing
- `go build 1000-1999/1400-1499/1480-1489/1486/1486D.go`
- `go run 1000-1999/1400-1499/1480-1489/1486/1486D.go <<EOF
5 1
1 2 3 4 5
EOF`
- `go run 1000-1999/1400-1499/1480-1489/1486/1486D.go <<EOF
3 3
1 2 3
EOF`
- `go run 1000-1999/1400-1499/1480-1489/1486/1486D.go <<EOF
5 3
1 1 1 1 1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6886892d005c83249b5be493d4c774d4