### PR TITLE
Add Go solution for 1486A

### DIFF
--- a/1000-1999/1400-1499/1480-1489/1486/1486A.go
+++ b/1000-1999/1400-1499/1480-1489/1486/1486A.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		h := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &h[i])
+		}
+		var carry int64
+		possible := true
+		for i := 0; i < n; i++ {
+			carry += h[i]
+			need := int64(i)
+			if carry < need {
+				possible = false
+				break
+			}
+			carry -= need
+		}
+		if possible {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for `1486A` (Shifting Stacks)

## Testing
- `go build ./1000-1999/1400-1499/1480-1489/1486/1486A.go`


------
https://chatgpt.com/codex/tasks/task_e_68868a453b7c8324a74d85f478e01d64