### PR TITLE
Add Go solution for 1486B

### DIFF
--- a/1000-1999/1400-1499/1480-1489/1486/1486B.go
+++ b/1000-1999/1400-1499/1480-1489/1486/1486B.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		xs := make([]int64, n)
+		ys := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &xs[i], &ys[i])
+		}
+		sort.Slice(xs, func(i, j int) bool { return xs[i] < xs[j] })
+		sort.Slice(ys, func(i, j int) bool { return ys[i] < ys[j] })
+		if n%2 == 1 {
+			fmt.Fprintln(writer, 1)
+		} else {
+			xRange := xs[n/2] - xs[n/2-1] + 1
+			yRange := ys[n/2] - ys[n/2-1] + 1
+			fmt.Fprintln(writer, xRange*yRange)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problem 1486B in `1000-1999/1400-1499/1480-1489/1486`

## Testing
- `go vet 1000-1999/1400-1499/1480-1489/1486/1486B.go`
- `go build 1000-1999/1400-1499/1480-1489/1486/1486B.go`

------
https://chatgpt.com/codex/tasks/task_e_688689ff4d0c8324bdf6c25323ac5959