### PR TITLE
Add Go solution for 1485C

### DIFF
--- a/1000-1999/1400-1499/1480-1489/1485/1485C.go
+++ b/1000-1999/1400-1499/1480-1489/1485/1485C.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var x, y int64
+		fmt.Fscan(reader, &x, &y)
+		limit := int64(math.Min(float64(y), math.Sqrt(float64(x))))
+		var ans int64
+		for k := int64(1); k <= limit; k++ {
+			bmax := x/k - 1
+			if bmax > y {
+				bmax = y
+			}
+			if bmax > k {
+				ans += bmax - k
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1485C

## Testing
- `go build 1000-1999/1400-1499/1480-1489/1485/1485C.go`
- `go vet 1000-1999/1400-1499/1480-1489/1485/1485C.go`


------
https://chatgpt.com/codex/tasks/task_e_68868b1769f083248a09e109e39d8cb0