### PR TITLE
Add Go solution for 1473A

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1473/1473A.go
+++ b/1000-1999/1400-1499/1470-1479/1473/1473A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, d int
+		fmt.Fscan(reader, &n, &d)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		sort.Ints(arr)
+		if arr[n-1] <= d || arr[0]+arr[1] <= d {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem A of contest 1473 in Go
- uses simple sort to check if largest value <= d or sum of two smallest <= d

## Testing
- `go build 1000-1999/1400-1499/1470-1479/1473/1473A.go`
- `go run 1000-1999/1400-1499/1470-1479/1473/1473A.go << EOF
1
3 3
3 3 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6886909012108324bf430d1cec3dd645