### PR TITLE
Add Go solution for 1473B

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1473/1473B.go
+++ b/1000-1999/1400-1499/1470-1479/1473/1473B.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int) int {
+	return a / gcd(a, b) * b
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var q int
+	fmt.Fscan(reader, &q)
+	for ; q > 0; q-- {
+		var s, t string
+		fmt.Fscan(reader, &s)
+		fmt.Fscan(reader, &t)
+		l := lcm(len(s), len(t))
+		rs := strings.Repeat(s, l/len(s))
+		rt := strings.Repeat(t, l/len(t))
+		if rs == rt {
+			fmt.Fprintln(writer, rs)
+		} else {
+			fmt.Fprintln(writer, -1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for 1473B (String LCM)

## Testing
- `go build 1000-1999/1400-1499/1470-1479/1473/1473B.go`


------
https://chatgpt.com/codex/tasks/task_e_6886904a0c688324afb1052afd7434a1