### PR TITLE
Add Go solution for 1475E

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1475/1475E.go
+++ b/1000-1999/1400-1499/1470-1479/1475/1475E.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+const MOD int64 = 1000000007
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	const maxN = 1000
+	fact := make([]int64, maxN+1)
+	invFact := make([]int64, maxN+1)
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	invFact[maxN] = modPow(fact[maxN], MOD-2)
+	for i := maxN; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % MOD
+	}
+
+	comb := func(n, r int) int64 {
+		if r < 0 || r > n {
+			return 0
+		}
+		return fact[n] * invFact[r] % MOD * invFact[n-r] % MOD
+	}
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		sort.Slice(arr, func(i, j int) bool { return arr[i] > arr[j] })
+		x := arr[k-1]
+		total := 0
+		need := 0
+		for _, v := range arr {
+			if v == x {
+				total++
+			}
+		}
+		for i := 0; i < k; i++ {
+			if arr[i] == x {
+				need++
+			}
+		}
+		ans := comb(total, need)
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 1475E (Advertising Agency)

## Testing
- `go build ./1000-1999/1400-1499/1470-1479/1475/1475E.go`


------
https://chatgpt.com/codex/tasks/task_e_688691ee4ee88324872cdd9626ed6ebe