### PR TITLE
Add Go solution for 1475C Ball in Berland

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1475/1475C.go
+++ b/1000-1999/1400-1499/1470-1479/1475/1475C.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b, k int
+		fmt.Fscan(reader, &a, &b, &k)
+		boys := make([]int, k)
+		girls := make([]int, k)
+		for i := 0; i < k; i++ {
+			fmt.Fscan(reader, &boys[i])
+		}
+		for i := 0; i < k; i++ {
+			fmt.Fscan(reader, &girls[i])
+		}
+		cntBoy := make([]int, a+1)
+		cntGirl := make([]int, b+1)
+		for i := 0; i < k; i++ {
+			cntBoy[boys[i]]++
+			cntGirl[girls[i]]++
+		}
+		total := int64(k) * int64(k-1) / 2
+		for i := 1; i <= a; i++ {
+			x := cntBoy[i]
+			total -= int64(x) * int64(x-1) / 2
+		}
+		for i := 1; i <= b; i++ {
+			x := cntGirl[i]
+			total -= int64(x) * int64(x-1) / 2
+		}
+		fmt.Fprintln(writer, total)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1475C

## Testing
- `go build 1000-1999/1400-1499/1470-1479/1475/1475C.go`

------
https://chatgpt.com/codex/tasks/task_e_688693067d5c8324b4be2d6c4d8aeae8