### PR TITLE
Add Go solution for 1472D

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1472/1472D.go
+++ b/1000-1999/1400-1499/1470-1479/1472/1472D.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+		alice, bob := 0, 0
+		for i, v := range a {
+			if i%2 == 0 { // Alice's move
+				if v%2 == 0 {
+					alice += v
+				}
+			} else { // Bob's move
+				if v%2 == 1 {
+					bob += v
+				}
+			}
+		}
+		if alice > bob {
+			fmt.Fprintln(out, "Alice")
+		} else if bob > alice {
+			fmt.Fprintln(out, "Bob")
+		} else {
+			fmt.Fprintln(out, "Tie")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add solution 1472D.go for the Even-Odd game

## Testing
- `go build 1000-1999/1400-1499/1470-1479/1472/1472D.go`


------
https://chatgpt.com/codex/tasks/task_e_688693d8f3408324b3d679969a94dad4