### PR TITLE
Add Go solution for 1475A

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1475/1475A.go
+++ b/1000-1999/1400-1499/1470-1479/1475/1475A.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		for n%2 == 0 {
+			n /= 2
+		}
+		if n > 1 {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for `1475A - Odd Divisor`

## Testing
- `go build ./1000-1999/1400-1499/1470-1479/1475/1475A.go`

------
https://chatgpt.com/codex/tasks/task_e_68869396a5008324bf0e21f7fb93b143