### PR TITLE
Add Go solution for 1475B

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1475/1475B.go
+++ b/1000-1999/1400-1499/1470-1479/1475/1475B.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		if n%2020 <= n/2020 {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution `1475B.go` for New Year's Number

## Testing
- `go build 1000-1999/1400-1499/1470-1479/1475/1475B.go`
- `echo -e "5\n4041\n4042\n8081\n8079\n1" | go run 1000-1999/1400-1499/1470-1479/1475/1475B.go`

------
https://chatgpt.com/codex/tasks/task_e_6886934c944c8324b286fd529b9eb2bc