### PR TITLE
Add Go solution for 1472C

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1472/1472C.go
+++ b/1000-1999/1400-1499/1470-1479/1472/1472C.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		dp := make([]int64, n)
+		var ans int64
+		for i := n - 1; i >= 0; i-- {
+			dp[i] = a[i]
+			next := i + int(a[i])
+			if next < n {
+				dp[i] += dp[next]
+			}
+			if dp[i] > ans {
+				ans = dp[i]
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem 1472C (Long Jumps)

## Testing
- `go build 1000-1999/1400-1499/1470-1479/1472/1472C.go`

------
https://chatgpt.com/codex/tasks/task_e_688694aa8efc8324b51a1f9c4cf3e3ca