### PR TITLE
Add Go solution for CF1478A

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1478/1478A.go
+++ b/1000-1999/1400-1499/1470-1479/1478/1478A.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		maxFreq := 0
+		prev := -1
+		freq := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			if x == prev {
+				freq++
+			} else {
+				if freq > maxFreq {
+					maxFreq = freq
+				}
+				prev = x
+				freq = 1
+			}
+		}
+		if freq > maxFreq {
+			maxFreq = freq
+		}
+		fmt.Fprintln(writer, maxFreq)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1478A in Go

## Testing
- `go run 1000-1999/1400-1499/1470-1479/1478/1478A.go <<EOF`
  `1`
  `6`
  `1 1 2 2 3 4`
  `EOF`

------
https://chatgpt.com/codex/tasks/task_e_688699dd5c488324b6df51efb7ca68eb