### PR TITLE
Add Go solution for 1478C

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1478/1478C.go
+++ b/1000-1999/1400-1499/1470-1479/1478/1478C.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		m := 2 * n
+		d := make([]int64, m)
+		for i := 0; i < m; i++ {
+			fmt.Fscan(reader, &d[i])
+		}
+		sort.Slice(d, func(i, j int) bool { return d[i] > d[j] })
+		ok := true
+		sum := int64(0)
+		seen := make(map[int64]bool)
+		for i := 0; i < m; i += 2 {
+			if d[i] != d[i+1] || d[i]%2 == 1 {
+				ok = false
+				break
+			}
+			rem := d[i] - 2*sum
+			k := int64(n - i/2)
+			if rem <= 0 || rem%(2*k) != 0 {
+				ok = false
+				break
+			}
+			x := rem / (2 * k)
+			if seen[x] || x <= 0 {
+				ok = false
+				break
+			}
+			seen[x] = true
+			sum += x
+		}
+		if ok {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1478C.go` for Nezzar and Symmetric Array

## Testing
- `go run 1000-1999/1400-1499/1470-1479/1478/1478C.go <<EOF
1
2
8 12 8 12
EOF`
- `go run 1000-1999/1400-1499/1470-1479/1478/1478C.go <<EOF
2
2
8 12 8 12
2
9 9 9 9
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688699514f148324afcc5a9358dcf7b7