### PR TITLE
Add naive Go solution for 1476G

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1476/1476G.go
+++ b/1000-1999/1400-1499/1470-1479/1476/1476G.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m int
+	fmt.Fscan(reader, &n, &m)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+
+	for q := 0; q < m; q++ {
+		var typ int
+		fmt.Fscan(reader, &typ)
+		if typ == 1 {
+			var l, r, k int
+			fmt.Fscan(reader, &l, &r, &k)
+			l--
+			r--
+			cnt := make(map[int]int)
+			for i := l; i <= r; i++ {
+				cnt[a[i]]++
+			}
+			if len(cnt) < k {
+				fmt.Fprintln(writer, -1)
+				continue
+			}
+			freq := make([]int, 0, len(cnt))
+			for _, v := range cnt {
+				freq = append(freq, v)
+			}
+			sort.Ints(freq)
+			best := int(1e9)
+			for i := 0; i+k-1 < len(freq); i++ {
+				diff := freq[i+k-1] - freq[i]
+				if diff < best {
+					best = diff
+				}
+			}
+			fmt.Fprintln(writer, best)
+		} else {
+			var p, x int
+			fmt.Fscan(reader, &p, &x)
+			p--
+			a[p] = x
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a simple Go implementation for problem 1476G

## Testing
- `go build 1000-1999/1400-1499/1470-1479/1476/1476G.go`


------
https://chatgpt.com/codex/tasks/task_e_68869af62f1883248ce5e36b4809a899