### PR TITLE
Add Go verifiers for contest 1473

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1473/verifierA.go
+++ b/1000-1999/1400-1499/1470-1479/1473/verifierA.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsA = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binA*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleA*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1473A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 3
+	d := rng.Intn(100) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, d)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(100)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsA; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1473/verifierB.go
+++ b/1000-1999/1400-1499/1470-1479/1473/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsB = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binB*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleB*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1473B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = 'a'
+		} else {
+			b[i] = 'b'
+		}
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) string {
+	sLen := rng.Intn(20) + 1
+	tLen := rng.Intn(20) + 1
+	s := randString(rng, sLen)
+	t := randString(rng, tLen)
+	return fmt.Sprintf("1\n%s\n%s\n", s, t)
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsB; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1473/verifierC.go
+++ b/1000-1999/1400-1499/1470-1479/1473/verifierC.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsC = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binC*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleC*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1473C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	k := rng.Intn(50) + 1
+	n := rng.Intn(k) + k
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, k)
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsC; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1473/verifierD.go
+++ b/1000-1999/1400-1499/1470-1479/1473/verifierD.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsD = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binD*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleD*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1473D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	var sb strings.Builder
+	prog := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			prog[i] = '+'
+		} else {
+			prog[i] = '-'
+		}
+	}
+	fmt.Fprintf(&sb, "1\n%d %d\n%s\n", n, m, string(prog))
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsD; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1473/verifierE.go
+++ b/1000-1999/1400-1499/1470-1479/1473/verifierE.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsE = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binE*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleE*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1473E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges) + 1
+	edges := make([][3]int, m)
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		for v == u {
+			v = rng.Intn(n) + 1
+		}
+		w := rng.Intn(100) + 1
+		edges[i] = [3]int{u, v, w}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e[0], e[1], e[2])
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsE; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1473/verifierF.go
+++ b/1000-1999/1400-1499/1470-1479/1473/verifierF.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsF = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binF*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleF*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1473F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d", rng.Intn(100)+1)
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		val := rng.Intn(201) - 100
+		fmt.Fprintf(&sb, "%d", val)
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsF; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1473/verifierG.go
+++ b/1000-1999/1400-1499/1470-1479/1473/verifierG.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsG = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binG*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleG*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1473G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		ai := rng.Intn(3) + 1
+		bi := rng.Intn(ai+1) + 1
+		if abs(ai-bi) > 5 {
+			if ai > bi {
+				bi = ai - rng.Intn(5)
+				if bi < 1 {
+					bi = 1
+				}
+			} else {
+				ai = bi - rng.Intn(5)
+				if ai < 1 {
+					ai = 1
+				}
+			}
+		}
+		fmt.Fprintf(&sb, "%d %d\n", ai, bi)
+	}
+	return sb.String()
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsG; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go..verifierG.go to contest 1473
- verifiers compile the submitted binary (and Go reference solution) and run 100 random tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_68870d5a67448324b943b928497d3abc