### PR TITLE
Add Go verifiers for contest 1472

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1472/verifierA.go
+++ b/1000-1999/1400-1499/1470-1479/1472/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type TestCase struct {
+    input    string
+    expected string
+}
+
+func solveA(w, h, n int64) string {
+    count := int64(1)
+    for w%2 == 0 {
+        count <<= 1
+        w >>= 1
+    }
+    for h%2 == 0 {
+        count <<= 1
+        h >>= 1
+    }
+    if count >= n {
+        return "YES"
+    }
+    return "NO"
+}
+
+func generateTests() []TestCase {
+    r := rand.New(rand.NewSource(42))
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        w := r.Int63n(1000) + 1
+        h := r.Int63n(1000) + 1
+        n := r.Int63n(1000) + 1
+        expected := solveA(w, h, n)
+        input := fmt.Sprintf("1\n%d %d %d\n", w, h, n)
+        tests[i] = TestCase{input: input, expected: expected}
+    }
+    return tests
+}
+
+func run(binary string, tc TestCase) (string, error) {
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(tc.input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    cmd.Env = append(os.Environ(), "LC_ALL=C")
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    binary := os.Args[1]
+    tests := generateTests()
+    for i, tc := range tests {
+        got, err := run(binary, tc)
+        if err != nil {
+            os.Exit(1)
+        }
+        if got != tc.expected {
+            fmt.Printf("Test %d failed: expected %q got %q\nInput:\n%s", i+1, tc.expected, got, tc.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1400-1499/1470-1479/1472/verifierB.go
+++ b/1000-1999/1400-1499/1470-1479/1472/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type TestCase struct {
+    input    string
+    expected string
+}
+
+func solveB(arr []int) string {
+    cnt1, cnt2 := 0, 0
+    for _, v := range arr {
+        if v == 1 {
+            cnt1++
+        } else if v == 2 {
+            cnt2++
+        }
+    }
+    if cnt1%2 != 0 {
+        return "NO"
+    }
+    if cnt1 == 0 && cnt2%2 == 1 {
+        return "NO"
+    }
+    return "YES"
+}
+
+func generateTests() []TestCase {
+    r := rand.New(rand.NewSource(42))
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        n := r.Intn(10) + 1
+        arr := make([]int, n)
+        var sb strings.Builder
+        for j := 0; j < n; j++ {
+            if j > 0 {
+                sb.WriteByte(' ')
+            }
+            val := 1 + r.Intn(2)
+            arr[j] = val
+            fmt.Fprintf(&sb, "%d", val)
+        }
+        expected := solveB(arr)
+        input := fmt.Sprintf("1\n%d\n%s\n", n, sb.String())
+        tests[i] = TestCase{input: input, expected: expected}
+    }
+    return tests
+}
+
+func run(binary string, tc TestCase) (string, error) {
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(tc.input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    binary := os.Args[1]
+    tests := generateTests()
+    for i, tc := range tests {
+        got, err := run(binary, tc)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != tc.expected {
+            fmt.Printf("Test %d failed: expected %q got %q\nInput:\n%s", i+1, tc.expected, got, tc.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1400-1499/1470-1479/1472/verifierC.go
+++ b/1000-1999/1400-1499/1470-1479/1472/verifierC.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type TestCase struct {
+    input    string
+    expected string
+}
+
+func solveC(a []int64) string {
+    n := len(a)
+    dp := make([]int64, n)
+    var ans int64
+    for i := n - 1; i >= 0; i-- {
+        dp[i] = a[i]
+        next := i + int(a[i])
+        if next < n {
+            dp[i] += dp[next]
+        }
+        if dp[i] > ans {
+            ans = dp[i]
+        }
+    }
+    return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []TestCase {
+    r := rand.New(rand.NewSource(42))
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        n := r.Intn(10) + 1
+        arr := make([]int64, n)
+        var sb strings.Builder
+        for j := 0; j < n; j++ {
+            arr[j] = int64(r.Intn(10) + 1)
+            if j > 0 {
+                sb.WriteByte(' ')
+            }
+            fmt.Fprintf(&sb, "%d", arr[j])
+        }
+        expected := solveC(arr)
+        input := fmt.Sprintf("1\n%d\n%s\n", n, sb.String())
+        tests[i] = TestCase{input: input, expected: expected}
+    }
+    return tests
+}
+
+func run(binary string, tc TestCase) (string, error) {
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(tc.input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    binary := os.Args[1]
+    tests := generateTests()
+    for i, tc := range tests {
+        got, err := run(binary, tc)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != tc.expected {
+            fmt.Printf("Test %d failed: expected %q got %q\nInput:\n%s", i+1, tc.expected, got, tc.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1400-1499/1470-1479/1472/verifierD.go
+++ b/1000-1999/1400-1499/1470-1479/1472/verifierD.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+type TestCase struct {
+    input    string
+    expected string
+}
+
+func solveD(a []int) string {
+    sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+    alice, bob := 0, 0
+    for i, v := range a {
+        if i%2 == 0 {
+            if v%2 == 0 {
+                alice += v
+            }
+        } else {
+            if v%2 == 1 {
+                bob += v
+            }
+        }
+    }
+    if alice > bob {
+        return "Alice"
+    } else if bob > alice {
+        return "Bob"
+    }
+    return "Tie"
+}
+
+func generateTests() []TestCase {
+    r := rand.New(rand.NewSource(42))
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        n := r.Intn(10) + 1
+        arr := make([]int, n)
+        var sb strings.Builder
+        for j := 0; j < n; j++ {
+            arr[j] = r.Intn(100) + 1
+            if j > 0 {
+                sb.WriteByte(' ')
+            }
+            fmt.Fprintf(&sb, "%d", arr[j])
+        }
+        expected := solveD(arr)
+        input := fmt.Sprintf("1\n%d\n%s\n", n, sb.String())
+        tests[i] = TestCase{input: input, expected: expected}
+    }
+    return tests
+}
+
+func run(binary string, tc TestCase) (string, error) {
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(tc.input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    binary := os.Args[1]
+    tests := generateTests()
+    for i, tc := range tests {
+        got, err := run(binary, tc)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != tc.expected {
+            fmt.Printf("Test %d failed: expected %q got %q\nInput:\n%s", i+1, tc.expected, got, tc.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1400-1499/1470-1479/1472/verifierE.go
+++ b/1000-1999/1400-1499/1470-1479/1472/verifierE.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+type TestCase struct {
+    input    string
+    expected string
+}
+
+func solveE(h, w []int) []int {
+    n := len(h)
+    for i := 0; i < n; i++ {
+        if h[i] > w[i] {
+            h[i], w[i] = w[i], h[i]
+        }
+    }
+    idx := make([]int, n)
+    for i := range idx { idx[i] = i }
+    sort.Slice(idx, func(i, j int) bool { return h[idx[i]] < h[idx[j]] })
+    tmp := -1
+    ans := make([]int, n)
+    for i := range ans { ans[i] = -1 }
+    for i := 0; i < n; {
+        j := i
+        hh := h[idx[i]]
+        for j < n && h[idx[j]] == hh { j++ }
+        for k := i; k < j; k++ {
+            id := idx[k]
+            if tmp != -1 && w[tmp] < w[id] {
+                ans[id] = tmp
+            }
+        }
+        for k := i; k < j; k++ {
+            id := idx[k]
+            if tmp == -1 || w[tmp] > w[id] {
+                tmp = id
+            }
+        }
+        i = j
+    }
+    res := make([]int, n)
+    for i := range ans {
+        if ans[i] >= 0 {
+            res[i] = ans[i] + 1
+        } else {
+            res[i] = -1
+        }
+    }
+    return res
+}
+
+func generateTests() []TestCase {
+    r := rand.New(rand.NewSource(42))
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        n := r.Intn(10) + 1
+        h := make([]int, n)
+        w := make([]int, n)
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+        for j := 0; j < n; j++ {
+            h[j] = r.Intn(20) + 1
+            w[j] = r.Intn(20) + 1
+            sb.WriteString(fmt.Sprintf("%d %d\n", h[j], w[j]))
+        }
+        ans := solveE(append([]int(nil), h...), append([]int(nil), w...))
+        var out strings.Builder
+        for j, v := range ans {
+            if j > 0 {
+                out.WriteByte(' ')
+            }
+            out.WriteString(fmt.Sprintf("%d", v))
+        }
+        tests[i] = TestCase{input: sb.String(), expected: strings.TrimSpace(out.String())}
+    }
+    return tests
+}
+
+func run(binary string, tc TestCase) (string, error) {
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(tc.input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    binary := os.Args[1]
+    tests := generateTests()
+    for i, tc := range tests {
+        got, err := run(binary, tc)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != tc.expected {
+            fmt.Printf("Test %d failed: expected %q got %q\nInput:\n%s", i+1, tc.expected, got, tc.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1400-1499/1470-1479/1472/verifierF.go
+++ b/1000-1999/1400-1499/1470-1479/1472/verifierF.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+type TestCase struct {
+    input    string
+    expected string
+}
+
+func solveF(n, m int, pairs [][2]int) string {
+    colMask := make(map[int]int)
+    for _, p := range pairs {
+        r, c := p[0], p[1]
+        if r == 1 {
+            colMask[c] |= 1
+        } else {
+            colMask[c] |= 2
+        }
+    }
+    cols := make([]int, 0, len(colMask))
+    for c := range colMask {
+        cols = append(cols, c)
+    }
+    sort.Ints(cols)
+    pendingRow := 0
+    pendingCol := 0
+    ok := true
+    for _, c := range cols {
+        mask := colMask[c]
+        if mask == 3 {
+            if pendingRow != 0 {
+                ok = false
+                break
+            }
+            continue
+        }
+        row := 1
+        if mask == 2 {
+            row = 2
+        }
+        if pendingRow == 0 {
+            pendingRow = row
+            pendingCol = c
+        } else {
+            diff := c - pendingCol
+            same := 0
+            if row == pendingRow {
+                same = 1
+            }
+            if diff%2 != same {
+                ok = false
+                break
+            }
+            pendingRow = 0
+        }
+    }
+    if pendingRow != 0 {
+        ok = false
+    }
+    if ok {
+        return "YES"
+    }
+    return "NO"
+}
+
+func generateTests() []TestCase {
+    r := rand.New(rand.NewSource(42))
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        n := r.Intn(5) + 1
+        m := r.Intn(10)
+        pairs := make([][2]int, m)
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("1\n%d %d\n", n, m))
+        for j := 0; j < m; j++ {
+            r1 := r.Intn(2) + 1
+            c := r.Intn(10) + 1
+            pairs[j] = [2]int{r1, c}
+            sb.WriteString(fmt.Sprintf("%d %d\n", r1, c))
+        }
+        expected := solveF(n, m, pairs)
+        tests[i] = TestCase{input: sb.String(), expected: expected}
+    }
+    return tests
+}
+
+func run(binary string, tc TestCase) (string, error) {
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(tc.input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    binary := os.Args[1]
+    tests := generateTests()
+    for i, tc := range tests {
+        got, err := run(binary, tc)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != tc.expected {
+            fmt.Printf("Test %d failed: expected %q got %q\nInput:\n%s", i+1, tc.expected, got, tc.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1400-1499/1470-1479/1472/verifierG.go
+++ b/1000-1999/1400-1499/1470-1479/1472/verifierG.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+type TestCase struct {
+    input    string
+    expected string
+}
+
+func solveG(n, m int, edges [][2]int) []int {
+    g := make([][]int, n)
+    for _, e := range edges {
+        u, v := e[0], e[1]
+        u--
+        v--
+        g[u] = append(g[u], v)
+    }
+    dist := make([]int, n)
+    for i := range dist {
+        dist[i] = -1
+    }
+    q := make([]int, 0, n)
+    q = append(q, 0)
+    dist[0] = 0
+    for head := 0; head < len(q); head++ {
+        u := q[head]
+        for _, v := range g[u] {
+            if dist[v] == -1 {
+                dist[v] = dist[u] + 1
+                q = append(q, v)
+            }
+        }
+    }
+    ord := make([]int, n)
+    for i := range ord {
+        ord[i] = i
+    }
+    sort.Slice(ord, func(i, j int) bool { return dist[ord[i]] > dist[ord[j]] })
+    dp := make([]int, n)
+    copy(dp, dist)
+    for _, u := range ord {
+        for _, v := range g[u] {
+            if dist[u] < dist[v] {
+                if dp[u] > dp[v] {
+                    dp[u] = dp[v]
+                }
+            } else {
+                if dp[u] > dist[v] {
+                    dp[u] = dist[v]
+                }
+            }
+        }
+    }
+    return dp
+}
+
+func generateTests() []TestCase {
+    r := rand.New(rand.NewSource(42))
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        n := r.Intn(6) + 1
+        m := r.Intn(n*(n-1)/2 + 1)
+        edges := make([][2]int, m)
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("1\n%d %d\n", n, m))
+        for j := 0; j < m; j++ {
+            u := r.Intn(n) + 1
+            v := r.Intn(n) + 1
+            edges[j] = [2]int{u, v}
+            sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+        }
+        ans := solveG(n, m, edges)
+        var out strings.Builder
+        for j, v := range ans {
+            if j > 0 {
+                out.WriteByte(' ')
+            }
+            out.WriteString(fmt.Sprintf("%d", v))
+        }
+        tests[i] = TestCase{input: sb.String(), expected: strings.TrimSpace(out.String())}
+    }
+    return tests
+}
+
+func run(binary string, tc TestCase) (string, error) {
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(tc.input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierG.go /path/to/binary")
+        os.Exit(1)
+    }
+    binary := os.Args[1]
+    tests := generateTests()
+    for i, tc := range tests {
+        got, err := run(binary, tc)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != tc.expected {
+            fmt.Printf("Test %d failed: expected %q got %q\nInput:\n%s", i+1, tc.expected, got, tc.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+


### PR DESCRIPTION
## Summary
- add solution verifiers `verifierA.go` through `verifierG.go`
- each verifier runs a supplied binary against 100 deterministic tests

## Testing
- `go run verifierA.go ./1472A`
- `go run verifierB.go ./1472B`
- `go run verifierC.go ./1472C`
- `go run verifierG.go ./1472G`


------
https://chatgpt.com/codex/tasks/task_e_68870d148d688324a46df633205d0889