### PR TITLE
Add verifiers for contest 1469

### DIFF
--- a/1000-1999/1400-1499/1460-1469/1469/verifierA.go
+++ b/1000-1999/1400-1499/1460-1469/1469/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(99) + 2 // length between 2 and 100
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = '?'
+	}
+	i := rng.Intn(n)
+	j := rng.Intn(n - 1)
+	if j >= i {
+		j++
+	}
+	s[i] = '('
+	s[j] = ')'
+	return string(s)
+}
+
+func expected(s string) string {
+	n := len(s)
+	if n%2 == 1 || s[0] == ')' || s[n-1] == '(' {
+		return "NO"
+	}
+	return "YES"
+}
+
+func runCase(bin string, s string) error {
+	input := fmt.Sprintf("1\n%s\n", s)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	got := strings.ToUpper(strings.TrimSpace(out))
+	exp := expected(s)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := generateCase(rng)
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1469/verifierB.go
+++ b/1000-1999/1400-1499/1460-1469/1469/verifierB.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) ([]int, []int) {
+	n := rng.Intn(100) + 1
+	r := make([]int, n)
+	for i := 0; i < n; i++ {
+		r[i] = rng.Intn(201) - 100
+	}
+	m := rng.Intn(100) + 1
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		b[i] = rng.Intn(201) - 100
+	}
+	return r, b
+}
+
+func expected(r, b []int) int {
+	bestR := 0
+	sum := 0
+	for _, v := range r {
+		sum += v
+		if sum > bestR {
+			bestR = sum
+		}
+	}
+	bestB := 0
+	sum = 0
+	for _, v := range b {
+		sum += v
+		if sum > bestB {
+			bestB = sum
+		}
+	}
+	return bestR + bestB
+}
+
+func runCase(bin string, r, b []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(r)))
+	for i, v := range r {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", len(b)))
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := expected(r, b)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		r, b := generateCase(rng)
+		if err := runCase(bin, r, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1469/verifierC.go
+++ b/1000-1999/1400-1499/1460-1469/1469/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func generateCase(rng *rand.Rand) (int, int, []int) {
+	n := rng.Intn(50) + 2
+	k := rng.Intn(20) + 2
+	h := make([]int, n)
+	for i := 0; i < n; i++ {
+		h[i] = rng.Intn(50)
+	}
+	return n, k, h
+}
+
+func expected(n, k int, h []int) string {
+	low, high := h[0], h[0]
+	for i := 1; i < n; i++ {
+		l := max(h[i], low-(k-1))
+		r := min(h[i]+k-1, high+(k-1))
+		if l > r {
+			return "NO"
+		}
+		low, high = l, r
+	}
+	if h[n-1] >= low && h[n-1] <= high {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runCase(bin string, n, k int, h []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range h {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got := strings.ToUpper(strings.TrimSpace(out))
+	expect := expected(n, k, h)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, h := generateCase(rng)
+		if err := runCase(bin, n, k, h); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1469/verifierD.go
+++ b/1000-1999/1400-1499/1460-1469/1469/verifierD.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) int {
+	return rng.Intn(50) + 3
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	m, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if m > n+5 {
+		return fmt.Errorf("too many operations")
+	}
+	if len(fields) != 1+2*m {
+		return fmt.Errorf("expected %d numbers got %d", 1+2*m, len(fields))
+	}
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = i
+	}
+	idx := 1
+	for i := 0; i < m; i++ {
+		x, err1 := strconv.Atoi(fields[idx])
+		y, err2 := strconv.Atoi(fields[idx+1])
+		idx += 2
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("bad indices")
+		}
+		if x < 1 || x > n || y < 1 || y > n || x == y {
+			return fmt.Errorf("invalid indices")
+		}
+		ax := a[x]
+		ay := a[y]
+		a[x] = int(math.Ceil(float64(ax) / float64(ay)))
+	}
+	ones := 0
+	twos := 0
+	for i := 1; i <= n; i++ {
+		if a[i] == 1 {
+			ones++
+		} else if a[i] == 2 {
+			twos++
+		}
+	}
+	if ones != n-1 || twos != 1 {
+		return fmt.Errorf("final array incorrect")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := generateCase(rng)
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1469/verifierE.go
+++ b/1000-1999/1400-1499/1460-1469/1469/verifierE.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, k int, s string) string {
+	m := k
+	if m > 20 {
+		m = 20
+	}
+	size := 1 << m
+	seen := make([]bool, size)
+	zeros := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		zeros[i+1] = zeros[i]
+		if s[i] == '0' {
+			zeros[i+1]++
+		}
+	}
+	mask := 0
+	for i := 0; i < n; i++ {
+		mask = ((mask << 1) & (size - 1))
+		if s[i] == '1' {
+			mask |= 1
+		}
+		if i >= k-1 {
+			start := i - k + 1
+			if k > m {
+				if zeros[start+k-m]-zeros[start] == 0 {
+					seen[mask] = true
+				}
+			} else {
+				seen[mask] = true
+			}
+		}
+	}
+	ans := -1
+	for y := 0; y < size; y++ {
+		var idx int
+		if k > m {
+			idx = (^y) & (size - 1)
+		} else {
+			idx = (size - 1) ^ y
+		}
+		if !seen[idx] {
+			ans = y
+			break
+		}
+	}
+	if ans == -1 {
+		return "NO"
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	if k > m {
+		for i := 0; i < k-m; i++ {
+			sb.WriteByte('0')
+		}
+	}
+	sb.WriteString(fmt.Sprintf("%0*b", m, ans))
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (int, int, string) {
+	n := rng.Intn(50) + 1
+	k := rng.Intn(n) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	return n, k, sb.String()
+}
+
+func runCase(bin string, n, k int, s string) error {
+	input := fmt.Sprintf("1\n%d %d\n%s\n", n, k, s)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	expect := expected(n, k, s)
+	if strings.TrimSpace(out) != expect {
+		return fmt.Errorf("expected %q got %q", expect, strings.TrimSpace(out))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, s := generateCase(rng)
+		if err := runCase(bin, n, k, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1469/verifierF.go
+++ b/1000-1999/1400-1499/1460-1469/1469/verifierF.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func can(R int64, lengths []int64, k int64) bool {
+	if R == 0 {
+		return k <= 1
+	}
+	n := len(lengths)
+	arr := make([]int64, n)
+	copy(arr, lengths)
+	sort.Slice(arr, func(i, j int) bool { return arr[i] > arr[j] })
+	cnt := make([]int64, R+1)
+	cnt[0] = 1
+	total := int64(1)
+	idx := int64(0)
+	for _, L := range arr {
+		for idx < R {
+			if cnt[idx] == 0 {
+				idx++
+				continue
+			}
+			m := R - idx - 1
+			if m <= 0 {
+				idx++
+				continue
+			}
+			break
+		}
+		if idx >= R || total >= k {
+			break
+		}
+		d := idx
+		cnt[d]--
+		total--
+		m := R - d - 1
+		if L <= 2*m+1 {
+			x := (L - 1) / 2
+			for i := int64(1); i <= x && d+1+i <= R; i++ {
+				cnt[d+1+i] += 2
+			}
+			if L%2 == 0 && d+1+L/2 <= R {
+				cnt[d+1+L/2]++
+			}
+			total += L - 1
+		} else {
+			for i := int64(1); i <= m && d+1+i <= R; i++ {
+				cnt[d+1+i] += 2
+			}
+			total += 2 * m
+		}
+		if total >= k {
+			return true
+		}
+	}
+	return total >= k
+}
+
+func expected(lengths []int64, k int64) int64 {
+	sum := int64(1)
+	for _, L := range lengths {
+		sum += L - 2
+	}
+	if sum < k {
+		return -1
+	}
+	l, r := int64(1), int64(200000)
+	for l < r {
+		mid := (l + r) / 2
+		if can(mid, lengths, k) {
+			r = mid
+		} else {
+			l = mid + 1
+		}
+	}
+	return l
+}
+
+func generateCase(rng *rand.Rand) ([]int64, int64) {
+	n := rng.Intn(8) + 1
+	lengths := make([]int64, n)
+	for i := 0; i < n; i++ {
+		lengths[i] = int64(rng.Intn(8) + 3)
+	}
+	var sum int64 = 1
+	for _, L := range lengths {
+		sum += L - 2
+	}
+	k := int64(rng.Intn(int(sum+5)) + 2)
+	return lengths, k
+}
+
+func runCase(bin string, lengths []int64, k int64) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", len(lengths), k))
+	for i, v := range lengths {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := expected(lengths, k)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		lengths, k := generateCase(rng)
+		if err := runCase(bin, lengths, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for Codeforces contest 1469 problems A–F
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68870bfc30a083248ca53de15a98cace