### PR TITLE
Add Go verifiers for contest 1467

### DIFF
--- a/1000-1999/1400-1499/1460-1469/1467/verifierA.go
+++ b/1000-1999/1400-1499/1460-1469/1467/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct{ n int }
+
+func solveA(n int) string {
+	if n == 1 {
+		return "9"
+	}
+	if n == 2 {
+		return "98"
+	}
+	if n == 3 {
+		return "989"
+	}
+	res := make([]byte, n)
+	res[0] = '9'
+	res[1] = '8'
+	res[2] = '9'
+	for i := 3; i < n; i++ {
+		res[i] = byte('0' + (i-3)%10)
+	}
+	return string(res)
+}
+
+func buildInputA(n int) string {
+	return fmt.Sprintf("1\n%d\n", n)
+}
+
+func runCaseA(bin string, tc testCaseA) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(buildInputA(tc.n))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := solveA(tc.n)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func generateCasesA() []testCaseA {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCaseA, 0, 100)
+	for _, n := range []int{1, 2, 3, 4, 5, 10, 11, 20, 50, 100} {
+		cases = append(cases, testCaseA{n})
+	}
+	for len(cases) < 100 {
+		cases = append(cases, testCaseA{rng.Intn(100) + 1})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCasesA()
+	for i, tc := range cases {
+		if err := runCaseA(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (n=%d)\n", i+1, err, tc.n)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1467/verifierB.go
+++ b/1000-1999/1400-1499/1460-1469/1467/verifierB.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n   int
+	arr []int
+}
+
+func isHillOrValley(arr []int, i int) bool {
+	if i <= 0 || i >= len(arr)-1 {
+		return false
+	}
+	return (arr[i] > arr[i-1] && arr[i] > arr[i+1]) || (arr[i] < arr[i-1] && arr[i] < arr[i+1])
+}
+
+func solveB(n int, a []int) int {
+	if n <= 2 {
+		return 0
+	}
+	hv := make([]bool, n)
+	total := 0
+	for i := 1; i < n-1; i++ {
+		hv[i] = isHillOrValley(a, i)
+		if hv[i] {
+			total++
+		}
+	}
+	ans := total
+	for i := 0; i < n; i++ {
+		orig := a[i]
+		before := 0
+		for j := i - 1; j <= i+1; j++ {
+			if j > 0 && j < n-1 && hv[j] {
+				before++
+			}
+		}
+		if i > 0 {
+			a[i] = a[i-1]
+			after := 0
+			for j := i - 1; j <= i+1; j++ {
+				if j > 0 && j < n-1 && isHillOrValley(a, j) {
+					after++
+				}
+			}
+			if total-before+after < ans {
+				ans = total - before + after
+			}
+		}
+		if i < n-1 {
+			a[i] = a[i+1]
+			after := 0
+			for j := i - 1; j <= i+1; j++ {
+				if j > 0 && j < n-1 && isHillOrValley(a, j) {
+					after++
+				}
+			}
+			if total-before+after < ans {
+				ans = total - before + after
+			}
+		}
+		a[i] = orig
+	}
+	return ans
+}
+
+func buildInputB(tc testCaseB) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprint(tc.n))
+	sb.WriteByte('\n')
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCaseB(bin string, tc testCaseB) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(buildInputB(tc))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := solveB(tc.n, append([]int(nil), tc.arr...))
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func generateCasesB() []testCaseB {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCaseB, 0, 100)
+	cases = append(cases, testCaseB{n: 1, arr: []int{5}}, testCaseB{n: 2, arr: []int{1, 2}})
+	for len(cases) < 100 {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(30)
+		}
+		cases = append(cases, testCaseB{n: n, arr: arr})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCasesB()
+	for i, tc := range cases {
+		if err := runCaseB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (n=%d)\n", i+1, err, tc.n)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1467/verifierC.go
+++ b/1000-1999/1400-1499/1460-1469/1467/verifierC.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	n1, n2, n3 int
+	a1, a2, a3 []int64
+}
+
+func solveC(tc testCaseC) int64 {
+	sums := []int64{0, 0, 0}
+	mins := []int64{1<<63 - 1, 1<<63 - 1, 1<<63 - 1}
+	arrs := [][]int64{tc.a1, tc.a2, tc.a3}
+	for i := 0; i < 3; i++ {
+		for _, v := range arrs[i] {
+			sums[i] += v
+			if v < mins[i] {
+				mins[i] = v
+			}
+		}
+	}
+	total := sums[0] + sums[1] + sums[2]
+	cand := sums[0]
+	if sums[1] < cand {
+		cand = sums[1]
+	}
+	if sums[2] < cand {
+		cand = sums[2]
+	}
+	pair := mins[0] + mins[1]
+	if pair < cand {
+		cand = pair
+	}
+	pair = mins[0] + mins[2]
+	if pair < cand {
+		cand = pair
+	}
+	pair = mins[1] + mins[2]
+	if pair < cand {
+		cand = pair
+	}
+	return total - 2*cand
+}
+
+func buildInputC(tc testCaseC) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n1, tc.n2, tc.n3))
+	for i, arr := range [][]int64{tc.a1, tc.a2, tc.a3} {
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		if i < 2 {
+			sb.WriteByte('\n')
+		} else {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func runCaseC(bin string, tc testCaseC) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(buildInputC(tc))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := solveC(tc)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func generateCasesC() []testCaseC {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCaseC, 0, 100)
+	for len(cases) < 100 {
+		n1 := rng.Intn(5) + 1
+		n2 := rng.Intn(5) + 1
+		n3 := rng.Intn(5) + 1
+		a1 := make([]int64, n1)
+		a2 := make([]int64, n2)
+		a3 := make([]int64, n3)
+		for i := 0; i < n1; i++ {
+			a1[i] = int64(rng.Intn(20) + 1)
+		}
+		for i := 0; i < n2; i++ {
+			a2[i] = int64(rng.Intn(20) + 1)
+		}
+		for i := 0; i < n3; i++ {
+			a3[i] = int64(rng.Intn(20) + 1)
+		}
+		cases = append(cases, testCaseC{n1, n2, n3, a1, a2, a3})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCasesC()
+	for i, tc := range cases {
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1467/verifierD.go
+++ b/1000-1999/1400-1499/1460-1469/1467/verifierD.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type queryD struct {
+	idx int
+	x   int64
+}
+
+type testCaseD struct {
+	n   int
+	k   int
+	q   int
+	arr []int64
+	qs  []queryD
+}
+
+const MOD int64 = 1000000007
+
+func solveD(tc testCaseD) []int64 {
+	n, k := tc.n, tc.k
+	dp := make([][]int64, k+1)
+	for i := 0; i <= k; i++ {
+		dp[i] = make([]int64, n+2)
+	}
+	for i := 1; i <= n; i++ {
+		dp[0][i] = 1
+	}
+	for t := 1; t <= k; t++ {
+		for i := 1; i <= n; i++ {
+			var v int64
+			if i > 1 {
+				v += dp[t-1][i-1]
+			}
+			if i < n {
+				v += dp[t-1][i+1]
+			}
+			if v >= MOD {
+				v %= MOD
+			}
+			dp[t][i] = v
+		}
+	}
+	coef := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		var c int64
+		for t := 0; t <= k; t++ {
+			c = (c + dp[t][i]*dp[k-t][i]) % MOD
+		}
+		coef[i] = c
+	}
+	a := append([]int64{0}, tc.arr...)
+	total := int64(0)
+	for i := 1; i <= n; i++ {
+		total = (total + a[i]*coef[i]) % MOD
+	}
+	res := make([]int64, tc.q)
+	for qi, qu := range tc.qs {
+		total = (total - a[qu.idx]*coef[qu.idx]) % MOD
+		if total < 0 {
+			total += MOD
+		}
+		a[qu.idx] = qu.x
+		total = (total + a[qu.idx]*coef[qu.idx]) % MOD
+		res[qi] = total
+	}
+	return res
+}
+
+func buildInputD(tc testCaseD) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.k, tc.q))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for _, qu := range tc.qs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", qu.idx, qu.x))
+	}
+	return sb.String()
+}
+
+func runCaseD(bin string, tc testCaseD) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(buildInputD(tc))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	results := []int64{}
+	for scanner.Scan() {
+		var v int64
+		if _, err := fmt.Sscan(scanner.Text(), &v); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		results = append(results, v)
+	}
+	expect := solveD(tc)
+	if len(results) != len(expect) {
+		return fmt.Errorf("expected %d lines got %d", len(expect), len(results))
+	}
+	for i := range expect {
+		if results[i]%MOD != expect[i]%MOD {
+			return fmt.Errorf("on query %d expected %d got %d", i+1, expect[i], results[i])
+		}
+	}
+	return nil
+}
+
+func generateCasesD() []testCaseD {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCaseD, 0, 100)
+	for len(cases) < 100 {
+		n := rng.Intn(5) + 2
+		k := rng.Intn(5) + 1
+		q := rng.Intn(5) + 1
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			arr[i] = int64(rng.Intn(10) + 1)
+		}
+		qs := make([]queryD, q)
+		for i := 0; i < q; i++ {
+			qs[i] = queryD{idx: rng.Intn(n) + 1, x: int64(rng.Intn(10) + 1)}
+		}
+		cases = append(cases, testCaseD{n, k, q, arr, qs})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCasesD()
+	for i, tc := range cases {
+		if err := runCaseD(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1460-1469/1467/verifierE.go
+++ b/1000-1999/1400-1499/1460-1469/1467/verifierE.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+type testCaseE struct {
+	n     int
+	vals  []int
+	edges []edge
+}
+
+func checkRoot(adj [][]int, val []int, root int) bool {
+	freq := make(map[int]int)
+	stack := []struct {
+		node, parent int
+		enter        bool
+	}{{root, -1, true}}
+	for len(stack) > 0 {
+		s := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if s.enter {
+			if freq[val[s.node]] >= 1 {
+				return false
+			}
+			freq[val[s.node]]++
+			stack = append(stack, struct {
+				node, parent int
+				enter        bool
+			}{s.node, s.parent, false})
+			for _, to := range adj[s.node] {
+				if to == s.parent {
+					continue
+				}
+				stack = append(stack, struct {
+					node, parent int
+					enter        bool
+				}{to, s.node, true})
+			}
+		} else {
+			freq[val[s.node]]--
+		}
+	}
+	return true
+}
+
+func solveE(tc testCaseE) int {
+	adj := make([][]int, tc.n+1)
+	for _, e := range tc.edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	count := 0
+	val := append([]int{0}, tc.vals...)
+	for r := 1; r <= tc.n; r++ {
+		if checkRoot(adj, val, r) {
+			count++
+		}
+	}
+	return count
+}
+
+func buildInputE(tc testCaseE) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprint(tc.n))
+	sb.WriteByte('\n')
+	for i, v := range tc.vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for _, e := range tc.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String()
+}
+
+func runCaseE(bin string, tc testCaseE) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(buildInputE(tc))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := solveE(tc)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func generateCasesE() []testCaseE {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCaseE, 0, 100)
+	for len(cases) < 100 {
+		n := rng.Intn(7) + 1
+		vals := make([]int, n)
+		for i := 0; i < n; i++ {
+			vals[i] = rng.Intn(10) + 1
+		}
+		edges := make([]edge, n-1)
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			edges[i-2] = edge{p, i}
+		}
+		cases = append(cases, testCaseE{n, vals, edges})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCasesE()
+	for i, tc := range cases {
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifierA.go for problem A with random case generator
- add Go verifierB.go for problem B implementing hill/valley logic
- add Go verifierC.go for problem C using sums formula
- add Go verifierD.go for problem D including DP coefficient calc
- add Go verifierE.go for problem E with tree root check

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68870ae402e883248d7195b217ce1906