### PR TITLE
Add verifiers for contest 1476

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1476/verifierA.go
+++ b/1000-1999/1400-1499/1470-1479/1476/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func solveCase(n, k int64) int64 {
+	mult := (n + k - 1) / k
+	sum := mult * k
+	ans := (sum + n - 1) / n
+	return ans
+}
+
+func buildCase(n, k int64) testCase {
+	input := fmt.Sprintf("1\n%d %d\n", n, k)
+	output := fmt.Sprintf("%d\n", solveCase(n, k))
+	return testCase{input: input, output: output}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Int63n(1000) + 1
+	k := rng.Int63n(1000) + 1
+	return buildCase(n, k)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.output)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	// some deterministic cases
+	cases = append(cases, buildCase(1, 5))
+	cases = append(cases, buildCase(4, 3))
+	cases = append(cases, buildCase(8, 8))
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1476/verifierB.go
+++ b/1000-1999/1400-1499/1470-1479/1476/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func solveCase(p []int64, k int64) int64 {
+	sum := p[0]
+	var add int64
+	for i := 1; i < len(p); i++ {
+		required := (p[i]*100 + k - 1) / k
+		if sum < required {
+			diff := required - sum
+			add += diff
+			sum += diff
+		}
+		sum += p[i]
+	}
+	return add
+}
+
+func buildCase(p []int64, k int64) testCase {
+	n := len(p)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", p[i]))
+	}
+	sb.WriteByte('\n')
+	output := fmt.Sprintf("%d\n", solveCase(p, k))
+	return testCase{input: sb.String(), output: output}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 2
+	k := rng.Int63n(10) + 1
+	p := make([]int64, n)
+	for i := range p {
+		p[i] = rng.Int63n(100) + 1
+	}
+	return buildCase(p, k)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.output)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase([]int64{5, 50, 202, 202}, 1))
+	cases = append(cases, buildCase([]int64{1, 1, 1}, 100))
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1476/verifierC.go
+++ b/1000-1999/1400-1499/1470-1479/1476/verifierC.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveCase(c, a, b []int) int {
+	n := len(c)
+	cur, ans := 0, 0
+	for i := 1; i < n; i++ {
+		diff := abs(a[i] - b[i])
+		if diff == 0 {
+			cur = 0
+		} else {
+			cur = max(diff, cur+c[i-1]-diff)
+		}
+		ans = max(ans, cur+c[i])
+	}
+	return ans + 1
+}
+
+func buildCase(c, a, b []int) testCase {
+	n := len(c)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range c {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	out := fmt.Sprintf("%d\n", solveCase(c, a, b))
+	return testCase{input: sb.String(), output: out}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 2
+	c := make([]int, n)
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		c[i] = rng.Intn(10) + 2
+		a[i] = rng.Intn(c[i]-1) + 1
+		b[i] = rng.Intn(c[i]-1) + 1
+	}
+	return buildCase(c, a, b)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.output)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase([]int{2, 2}, []int{1, 1}, []int{1, 2}))
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1476/verifierD.go
+++ b/1000-1999/1400-1499/1470-1479/1476/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func solveCase(n int, s string) string {
+	s = " " + s
+	left := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		if s[i] == 'L' {
+			left[i] = 1
+			if i >= 2 && s[i-1] == 'R' {
+				left[i] = 2 + left[i-2]
+			}
+		}
+	}
+	right := make([]int, n+2)
+	for i := n; i >= 1; i-- {
+		if s[i] == 'R' {
+			right[i] = 1
+			if i+1 <= n && s[i+1] == 'L' {
+				right[i] = 2 + right[i+2]
+			}
+		}
+	}
+	ans := make([]int, n+1)
+	ans[0] = 1 + right[1]
+	for i := 1; i < n; i++ {
+		ans[i] = 1 + left[i] + right[i+1]
+	}
+	ans[n] = 1 + left[n]
+	var sb strings.Builder
+	for i := 0; i <= n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", ans[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildCase(n int, s string) testCase {
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	output := solveCase(n, s)
+	return testCase{input: input, output: output}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	bytes := make([]byte, n)
+	for i := range bytes {
+		if rng.Intn(2) == 0 {
+			bytes[i] = 'L'
+		} else {
+			bytes[i] = 'R'
+		}
+	}
+	return buildCase(n, string(bytes))
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.output)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase(1, "L"))
+	cases = append(cases, buildCase(2, "LR"))
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1476/verifierE.go
+++ b/1000-1999/1400-1499/1470-1479/1476/verifierE.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+type IntHeap []int
+
+func (h IntHeap) Len() int            { return len(h) }
+func (h IntHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h IntHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *IntHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *IntHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func matchPattern(s, t string) bool {
+	for i := 0; i < len(s); i++ {
+		if t[i] != '_' && t[i] != s[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func solveCase(N, M, K int, A []string, B []string, P []int) (bool, []int) {
+	bMx := 1 << K
+	nodes := 1
+	for i := 0; i < K; i++ {
+		nodes *= 27
+	}
+	isValid := make([]bool, nodes)
+	id := make([]int, nodes)
+	par := make([]int, nodes)
+	adj := make([][]int, nodes)
+	getCharId := func(ch byte) int {
+		if ch == '_' {
+			return 26
+		}
+		return int(ch - 'a')
+	}
+	hsh := func(s string) int {
+		res := 0
+		mult := 1
+		for i := 0; i < K; i++ {
+			res += mult * getCharId(s[i])
+			mult *= 27
+		}
+		return res
+	}
+	for i := 0; i < N; i++ {
+		u := hsh(A[i])
+		isValid[u] = true
+		id[u] = i + 1
+	}
+	for i := 0; i < M; i++ {
+		p := P[i] - 1
+		if !matchPattern(B[i], A[p]) {
+			return false, nil
+		}
+		sBytes := []byte(B[i])
+		t := A[p]
+		u := hsh(t)
+		for mask := 0; mask < bMx; mask++ {
+			tmp := make([]byte, K)
+			copy(tmp, sBytes)
+			for j := 0; j < K; j++ {
+				if mask&(1<<j) != 0 {
+					tmp[j] = '_'
+				}
+			}
+			v := hsh(string(tmp))
+			if u == v || !isValid[u] || !isValid[v] {
+				continue
+			}
+			adj[u] = append(adj[u], v)
+			par[v]++
+		}
+	}
+	h := &IntHeap{}
+	heap.Init(h)
+	for i := 0; i < N; i++ {
+		u := hsh(A[i])
+		if par[u] == 0 {
+			heap.Push(h, u)
+		}
+	}
+	result := make([]int, 0, N)
+	for len(result) < N {
+		if h.Len() == 0 {
+			return false, nil
+		}
+		u := heap.Pop(h).(int)
+		result = append(result, id[u])
+		for _, v := range adj[u] {
+			par[v]--
+			if par[v] == 0 {
+				heap.Push(h, v)
+			}
+		}
+	}
+	return true, result
+}
+
+func buildCase(N, M, K int, A []string, B []string, P []int) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", N, M, K))
+	for i := 0; i < N; i++ {
+		sb.WriteString(fmt.Sprintf("%s\n", A[i]))
+	}
+	for i := 0; i < M; i++ {
+		sb.WriteString(fmt.Sprintf("%s %d\n", B[i], P[i]))
+	}
+	ok, order := solveCase(N, M, K, A, B, P)
+	var out string
+	if !ok {
+		out = "NO\n"
+	} else {
+		var b strings.Builder
+		b.WriteString("YES\n")
+		for i, v := range order {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(fmt.Sprintf("%d", v))
+		}
+		b.WriteByte('\n')
+		out = b.String()
+	}
+	return testCase{input: sb.String(), output: out}
+}
+
+func randPattern(rng *rand.Rand, K int, allowUnderscore bool) string {
+	b := make([]byte, K)
+	for i := 0; i < K; i++ {
+		if allowUnderscore && rng.Intn(3) == 0 {
+			b[i] = '_'
+		} else {
+			b[i] = byte('a' + rng.Intn(3))
+		}
+	}
+	return string(b)
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	K := rng.Intn(2) + 1
+	N := rng.Intn(3) + 1
+	M := rng.Intn(3) + 1
+	set := make(map[string]bool)
+	A := make([]string, 0, N)
+	for len(A) < N {
+		p := randPattern(rng, K, true)
+		if !set[p] {
+			set[p] = true
+			A = append(A, p)
+		}
+	}
+	B := make([]string, M)
+	P := make([]int, M)
+	for i := 0; i < M; i++ {
+		B[i] = randPattern(rng, K, false)
+		P[i] = rng.Intn(N) + 1
+	}
+	return buildCase(N, M, K, A, B, P)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.output)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase(1, 1, 1, []string{"a"}, []string{"a"}, []int{1}))
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1476/verifierF.go
+++ b/1000-1999/1400-1499/1470-1479/1476/verifierF.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func illuminated(n int, p []int, dir []byte) bool {
+	for j := 0; j < n; j++ {
+		ok := false
+		for i := 0; i < n && !ok; i++ {
+			if i == j {
+				continue
+			}
+			if dir[i] == 'L' && i > j && i-p[i] <= j {
+				ok = true
+			}
+			if dir[i] == 'R' && i < j && i+p[i] >= j {
+				ok = true
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func bruteForce(p []int) (bool, string) {
+	n := len(p)
+	dir := make([]byte, n)
+	for mask := 0; mask < 1<<n; mask++ {
+		for i := 0; i < n; i++ {
+			if (mask>>i)&1 == 1 {
+				dir[i] = 'R'
+			} else {
+				dir[i] = 'L'
+			}
+		}
+		if illuminated(n, p, dir) {
+			return true, string(dir)
+		}
+	}
+	return false, ""
+}
+
+func buildCase(p []int) testCase {
+	n := len(p)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	ok, dir := bruteForce(p)
+	var out string
+	if !ok {
+		out = "NO\n"
+	} else {
+		out = fmt.Sprintf("YES\n%s\n", dir)
+	}
+	return testCase{input: sb.String(), output: out}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 2
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = rng.Intn(n)
+	}
+	return buildCase(p)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.output)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase([]int{1, 1}))
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1476/verifierG.go
+++ b/1000-1999/1400-1499/1470-1479/1476/verifierG.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+type query struct {
+	typ int
+	l   int
+	r   int
+	k   int
+	p   int
+	x   int
+}
+
+func solveCase(a []int, qs []query) string {
+	var sb strings.Builder
+	for _, q := range qs {
+		if q.typ == 1 {
+			l := q.l - 1
+			r := q.r - 1
+			cnt := make(map[int]int)
+			for i := l; i <= r; i++ {
+				cnt[a[i]]++
+			}
+			if len(cnt) < q.k {
+				sb.WriteString("-1\n")
+				continue
+			}
+			freq := make([]int, 0, len(cnt))
+			for _, v := range cnt {
+				freq = append(freq, v)
+			}
+			sort.Ints(freq)
+			best := int(1e9)
+			for i := 0; i+q.k-1 < len(freq); i++ {
+				diff := freq[i+q.k-1] - freq[i]
+				if diff < best {
+					best = diff
+				}
+			}
+			sb.WriteString(fmt.Sprintf("%d\n", best))
+		} else {
+			a[q.p-1] = q.x
+		}
+	}
+	return sb.String()
+}
+
+func buildCase(a []int, qs []query) testCase {
+	n := len(a)
+	m := len(qs)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for _, q := range qs {
+		if q.typ == 1 {
+			sb.WriteString(fmt.Sprintf("1 %d %d %d\n", q.l, q.r, q.k))
+		} else {
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", q.p, q.x))
+		}
+	}
+	out := solveCase(append([]int(nil), a...), qs)
+	return testCase{input: sb.String(), output: out}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(5) + 1
+	}
+	qs := make([]query, m)
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			k := rng.Intn(3) + 1
+			qs[i] = query{typ: 1, l: l, r: r, k: k}
+		} else {
+			p := rng.Intn(n) + 1
+			x := rng.Intn(5) + 1
+			qs[i] = query{typ: 2, p: p, x: x}
+		}
+	}
+	return buildCase(a, qs)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.output)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	a0 := []int{1, 2, 3}
+	qs0 := []query{{typ: 1, l: 1, r: 3, k: 2}}
+	cases = append(cases, buildCase(a0, qs0))
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for every problem in Codeforces contest 1476
- each verifier generates 100+ test cases and runs a provided solution binary

## Testing
- `go run verifierA.go ./tmpA`
- `go run verifierB.go ./tmpB`
- `go run verifierC.go ./tmpC`
- `go run verifierD.go ./tmpD`

------
https://chatgpt.com/codex/tasks/task_e_68870e2c72e08324b5e4956cb8c9dcfb