### PR TITLE
Add verifiers for contest 1475

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1475/verifierA.go
+++ b/1000-1999/1400-1499/1470-1479/1475/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func computeA(n int64) string {
+	for n%2 == 0 {
+		n /= 2
+	}
+	if n > 1 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateA(rng *rand.Rand) (string, string) {
+	t := rng.Intn(10) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Int63n(1e14-1) + 2
+		in.WriteString(fmt.Sprintf("%d\n", n))
+		out.WriteString(computeA(n))
+		if i+1 < t {
+			out.WriteByte('\n')
+		}
+	}
+	return in.String(), out.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateA(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1475/verifierB.go
+++ b/1000-1999/1400-1499/1470-1479/1475/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func computeB(n int) string {
+	if n%2020 <= n/2020 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateB(rng *rand.Rand) (string, string) {
+	t := rng.Intn(10) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(1_000_000) + 1
+		in.WriteString(fmt.Sprintf("%d\n", n))
+		out.WriteString(computeB(n))
+		if i+1 < t {
+			out.WriteByte('\n')
+		}
+	}
+	return in.String(), out.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateB(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1475/verifierC.go
+++ b/1000-1999/1400-1499/1470-1479/1475/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(a, b, k int, boys, girls []int) string {
+	cntBoy := make([]int, a+1)
+	cntGirl := make([]int, b+1)
+	for i := 0; i < k; i++ {
+		cntBoy[boys[i]]++
+		cntGirl[girls[i]]++
+	}
+	total := int64(k) * int64(k-1) / 2
+	for i := 1; i <= a; i++ {
+		x := cntBoy[i]
+		total -= int64(x) * int64(x-1) / 2
+	}
+	for i := 1; i <= b; i++ {
+		x := cntGirl[i]
+		total -= int64(x) * int64(x-1) / 2
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func generateC(rng *rand.Rand) (string, string) {
+	a := rng.Intn(10) + 1
+	b := rng.Intn(10) + 1
+	k := rng.Intn(a * b)
+	if k < 2 {
+		k = 2
+	}
+	boys := make([]int, k)
+	girls := make([]int, k)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, k))
+	for i := 0; i < k; i++ {
+		boys[i] = rng.Intn(a) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", boys[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < k; i++ {
+		girls[i] = rng.Intn(b) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", girls[i]))
+	}
+	sb.WriteByte('\n')
+	out := solveC(a, b, k, boys, girls)
+	return sb.String(), out
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateC(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1475/verifierD.go
+++ b/1000-1999/1400-1499/1470-1479/1475/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveD(n int, m int64, a []int64, b []int) string {
+	var total int64
+	ones := []int64{}
+	twos := []int64{}
+	for i := 0; i < n; i++ {
+		total += a[i]
+		if b[i] == 1 {
+			ones = append(ones, a[i])
+		} else {
+			twos = append(twos, a[i])
+		}
+	}
+	if total < m {
+		return "-1"
+	}
+	sort.Slice(ones, func(i, j int) bool { return ones[i] > ones[j] })
+	sort.Slice(twos, func(i, j int) bool { return twos[i] > twos[j] })
+	pref1 := make([]int64, len(ones)+1)
+	for i := 0; i < len(ones); i++ {
+		pref1[i+1] = pref1[i] + ones[i]
+	}
+	pref2 := make([]int64, len(twos)+1)
+	for i := 0; i < len(twos); i++ {
+		pref2[i+1] = pref2[i] + twos[i]
+	}
+	ans := math.MaxInt32
+	i := len(ones)
+	for j := 0; j <= len(twos); j++ {
+		mem := pref2[j]
+		for i > 0 && mem+pref1[i-1] >= m {
+			i--
+		}
+		if mem+pref1[i] >= m {
+			cost := 2*j + i
+			if cost < ans {
+				ans = cost
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	a := make([]int64, n)
+	b := make([]int, n)
+	var total int64
+	for i := 0; i < n; i++ {
+		a[i] = rng.Int63n(20) + 1
+		total += a[i]
+		if rng.Intn(2) == 0 {
+			b[i] = 1
+		} else {
+			b[i] = 2
+		}
+	}
+	m := rng.Int63n(total + 1)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", b[i]))
+	}
+	sb.WriteByte('\n')
+	out := solveD(n, m, a, b)
+	return sb.String(), out
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateD(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1475/verifierE.go
+++ b/1000-1999/1400-1499/1470-1479/1475/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= mod
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func comb(n, r int, fact, invFact []int64) int64 {
+	if r < 0 || r > n {
+		return 0
+	}
+	return fact[n] * invFact[r] % mod * invFact[n-r] % mod
+}
+
+func solveE(n, k int, arr []int, fact, invFact []int64) string {
+	sort.Slice(arr, func(i, j int) bool { return arr[i] > arr[j] })
+	x := arr[k-1]
+	total := 0
+	need := 0
+	for _, v := range arr {
+		if v == x {
+			total++
+		}
+	}
+	for i := 0; i < k; i++ {
+		if arr[i] == x {
+			need++
+		}
+	}
+	ans := comb(total, need, fact, invFact)
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateE(rng *rand.Rand, fact, invFact []int64) (string, string) {
+	n := rng.Intn(15) + 1
+	k := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	out := solveE(n, k, arr, fact, invFact)
+	return sb.String(), out
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	maxN := 1000
+	fact := make([]int64, maxN+1)
+	invFact := make([]int64, maxN+1)
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[maxN] = modPow(fact[maxN], mod-2)
+	for i := maxN; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateE(rng, fact, invFact)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1475/verifierF.go
+++ b/1000-1999/1400-1499/1470-1479/1475/verifierF.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveF(n int, a, b [][]byte) string {
+	row := make([]int, n)
+	col := make([]int, n)
+	for i := 0; i < n; i++ {
+		if a[i][0] != b[i][0] {
+			row[i] = 1
+		}
+	}
+	for j := 0; j < n; j++ {
+		if ((a[0][j] - '0') ^ byte(row[0])) != (b[0][j] - '0') {
+			col[j] = 1
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			v := int(a[i][j]-'0') ^ row[i] ^ col[j]
+			if v != int(b[i][j]-'0') {
+				return "NO"
+			}
+		}
+	}
+	return "YES"
+}
+
+func generateF(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	a := make([][]byte, n)
+	b := make([][]byte, n)
+	row := make([]int, n)
+	col := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = make([]byte, n)
+		b[i] = make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				a[i][j] = '0'
+			} else {
+				a[i][j] = '1'
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		row[i] = rng.Intn(2)
+	}
+	for j := 0; j < n; j++ {
+		col[j] = rng.Intn(2)
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			v := (int(a[i][j]-'0') ^ row[i] ^ col[j])
+			if v == 1 {
+				b[i][j] = '1'
+			} else {
+				b[i][j] = '0'
+			}
+		}
+	}
+	// with probability 1/2 introduce error
+	if rng.Intn(2) == 0 {
+		i := rng.Intn(n)
+		j := rng.Intn(n)
+		if b[i][j] == '0' {
+			b[i][j] = '1'
+		} else {
+			b[i][j] = '0'
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(a[i]))
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(b[i]))
+		sb.WriteByte('\n')
+	}
+	out := solveF(n, a, b)
+	return sb.String(), out
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateF(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1470-1479/1475/verifierG.go
+++ b/1000-1999/1400-1499/1470-1479/1475/verifierG.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveG(n int, arr []int) string {
+	maxA := 0
+	for _, v := range arr {
+		if v > maxA {
+			maxA = v
+		}
+	}
+	freq := make([]int, maxA+1)
+	for _, v := range arr {
+		freq[v]++
+	}
+	dp := make([]int, maxA+1)
+	for i := 1; i <= maxA; i++ {
+		dp[i] = freq[i]
+	}
+	for i := 1; i <= maxA; i++ {
+		if freq[i] == 0 {
+			continue
+		}
+		for j := i * 2; j <= maxA; j += i {
+			if freq[j] > 0 && dp[j] < dp[i]+freq[j] {
+				dp[j] = dp[i] + freq[j]
+			}
+		}
+	}
+	best := 0
+	for i := 1; i <= maxA; i++ {
+		if dp[i] > best {
+			best = dp[i]
+		}
+	}
+	ans := n - best
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateG(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	out := solveG(n, arr)
+	return sb.String(), out
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateG(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A-G in contest 1475

## Testing
- `go build 1000-1999/1400-1499/1470-1479/1475/verifierA.go`
- `go build 1000-1999/1400-1499/1470-1479/1475/verifierB.go`
- `go build 1000-1999/1400-1499/1470-1479/1475/verifierC.go`
- `go build 1000-1999/1400-1499/1470-1479/1475/verifierD.go`
- `go build 1000-1999/1400-1499/1470-1479/1475/verifierE.go`
- `go build 1000-1999/1400-1499/1470-1479/1475/verifierF.go`
- `go build 1000-1999/1400-1499/1470-1479/1475/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68870de66b288324b0e75580ffbfda2b