### PR TITLE
Add Go verifiers for contest 1481

### DIFF
--- a/1000-1999/1400-1499/1480-1489/1481/verifierA.go
+++ b/1000-1999/1400-1499/1480-1489/1481/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	px := rng.Intn(11) - 5
+	py := rng.Intn(11) - 5
+	for px == 0 && py == 0 {
+		px = rng.Intn(11) - 5
+		py = rng.Intn(11) - 5
+	}
+	n := rng.Intn(10) + 1
+	moves := []byte{'U', 'D', 'L', 'R'}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", px, py)
+	for i := 0; i < n; i++ {
+		sb.WriteByte(moves[rng.Intn(4)])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1481A.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1481A.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1481/verifierB.go
+++ b/1000-1999/1400-1499/1480-1489/1481/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(20) + 1
+	h := make([]int, n)
+	for i := 0; i < n; i++ {
+		h[i] = rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(h[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1481B.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1481B.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1481/verifierC.go
+++ b/1000-1999/1400-1499/1480-1489/1481/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(6) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	c := make([]int, m)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(n) + 1
+		b[i] = rng.Intn(n) + 1
+	}
+	for j := 0; j < m; j++ {
+		c[j] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(b[i]))
+	}
+	sb.WriteByte('\n')
+	for j := 0; j < m; j++ {
+		if j > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(c[j]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1481C.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1481C.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1481/verifierD.go
+++ b/1000-1999/1400-1499/1480-1489/1481/verifierD.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 2
+	m := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i == j {
+				sb.WriteByte('*')
+			} else {
+				if rng.Intn(2) == 0 {
+					sb.WriteByte('a')
+				} else {
+					sb.WriteByte('b')
+				}
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1481D.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1481D.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1481/verifierE.go
+++ b/1000-1999/1400-1499/1480-1489/1481/verifierE.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1481E.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1481E.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1481/verifierF.go
+++ b/1000-1999/1400-1499/1480-1489/1481/verifierF.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input string) (string, error) {
+	if _, err := os.Stat(bin); err == nil && !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	x := rng.Intn(n + 1)
+	par := make([]int, n)
+	for i := 1; i < n; i++ {
+		par[i] = rng.Intn(i) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, x)
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(par[i-1]))
+	}
+	if n > 1 {
+		sb.WriteByte('\n')
+	} else {
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref1481F.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1481F.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := randomCase(rng)
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1481 problems A–F
- each verifier compiles the reference solution and runs 100 randomized tests against a given binary

## Testing
- `go run verifierA.go candidate1481A`
- `go run verifierB.go candidate1481B`


------
https://chatgpt.com/codex/tasks/task_e_68870f8a95988324befb4643d3f2ceb9