### PR TITLE
Add Go solution verifiers for CF contest 1479

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1479/verifierA.go
+++ b/1000-1999/1400-1499/1470-1479/1479/verifierA.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseA []int
+
+func genTestsA() []testCaseA {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCaseA, 100)
+	for i := range tests {
+		n := rng.Intn(8) + 2 // 2..9
+		p := rng.Perm(n)
+		for j := range p {
+			p[j]++
+		}
+		tests[i] = append(testCaseA(nil), p...)
+	}
+	return tests
+}
+
+func isLocalMin(p []int, idx int) bool {
+	n := len(p)
+	val := p[idx]
+	left := int(1e9)
+	right := int(1e9)
+	if idx > 0 {
+		left = p[idx-1]
+	}
+	if idx+1 < n {
+		right = p[idx+1]
+	}
+	return val < left && val < right
+}
+
+func runCase(bin string, perm []int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	inW := bufio.NewWriter(stdin)
+	outR := bufio.NewReader(stdout)
+	fmt.Fprintln(inW, len(perm))
+	inW.Flush()
+
+	queries := 0
+	for {
+		line, err := outR.ReadString('\n')
+		if err != nil {
+			cmd.Process.Kill()
+			return fmt.Errorf("read error: %v", err)
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "?") {
+			queries++
+			if queries > 100 {
+				cmd.Process.Kill()
+				return fmt.Errorf("too many queries")
+			}
+			parts := strings.Fields(line)
+			if len(parts) != 2 {
+				cmd.Process.Kill()
+				return fmt.Errorf("invalid query: %s", line)
+			}
+			idx, err := strconv.Atoi(parts[1])
+			if err != nil || idx < 1 || idx > len(perm) {
+				cmd.Process.Kill()
+				return fmt.Errorf("query out of range")
+			}
+			fmt.Fprintln(inW, perm[idx-1])
+			inW.Flush()
+		} else if strings.HasPrefix(line, "!") {
+			parts := strings.Fields(line)
+			if len(parts) != 2 {
+				cmd.Process.Kill()
+				return fmt.Errorf("invalid answer: %s", line)
+			}
+			idx, err := strconv.Atoi(parts[1])
+			if err != nil || idx < 1 || idx > len(perm) {
+				cmd.Process.Kill()
+				return fmt.Errorf("answer out of range")
+			}
+			if !isLocalMin(perm, idx-1) {
+				cmd.Process.Kill()
+				return fmt.Errorf("wrong answer: %d not local minimum", idx)
+			}
+			stdin.Close()
+			cmd.Wait()
+			return nil
+		} else {
+			cmd.Process.Kill()
+			return fmt.Errorf("invalid output: %s", line)
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	for i, p := range tests {
+		if err := runCase(bin, p); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1470-1479/1479/verifierB1.go
+++ b/1000-1999/1400-1499/1470-1479/1479/verifierB1.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n   int
+	arr []int
+}
+
+func genTestsB() []testCaseB {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCaseB, 100)
+	for i := range cases {
+		n := rng.Intn(6) + 1 // 1..6
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(n) + 1
+		}
+		cases[i] = testCaseB{n: n, arr: arr}
+	}
+	return cases
+}
+
+func segments(a []int) int {
+	if len(a) == 0 {
+		return 0
+	}
+	cnt := 1
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[i-1] {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func bruteMax(tc testCaseB) int {
+	n := tc.n
+	best := 0
+	for mask := 0; mask < 1<<n; mask++ {
+		var w, b []int
+		for i := 0; i < n; i++ {
+			if mask>>i&1 == 1 {
+				b = append(b, tc.arr[i])
+			} else {
+				w = append(w, tc.arr[i])
+			}
+		}
+		val := segments(w) + segments(b)
+		if val > best {
+			best = val
+		}
+	}
+	return best
+}
+
+func runCase(bin string, tc testCaseB, expected int) error {
+	var input bytes.Buffer
+	fmt.Fprintln(&input, 1)
+	fmt.Fprintln(&input, tc.n)
+	for i, v := range tc.arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprint(&input, v)
+	}
+	input.WriteByte('\n')
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	val, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("non-integer output")
+	}
+	if val != expected {
+		return fmt.Errorf("expected %d got %d", expected, val)
+	}
+	if len(fields) > 1 {
+		return fmt.Errorf("extra output")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTestsB()
+	for i, tc := range cases {
+		exp := bruteMax(tc)
+		if err := runCase(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1400-1499/1470-1479/1479/verifierB2.go
+++ b/1000-1999/1400-1499/1470-1479/1479/verifierB2.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n   int
+	arr []int
+}
+
+func genTestsB() []testCaseB {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCaseB, 100)
+	for i := range cases {
+		n := rng.Intn(6) + 1 // 1..6
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(n) + 1
+		}
+		cases[i] = testCaseB{n: n, arr: arr}
+	}
+	return cases
+}
+
+func segments(a []int) int {
+	if len(a) == 0 {
+		return 0
+	}
+	cnt := 1
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[i-1] {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func bruteMin(tc testCaseB) int {
+	n := tc.n
+	best := 1<<31 - 1
+	for mask := 0; mask < 1<<n; mask++ {
+		var w, b []int
+		for i := 0; i < n; i++ {
+			if mask>>i&1 == 1 {
+				b = append(b, tc.arr[i])
+			} else {
+				w = append(w, tc.arr[i])
+			}
+		}
+		val := segments(w) + segments(b)
+		if val < best {
+			best = val
+		}
+	}
+	return best
+}
+
+func runCase(bin string, tc testCaseB, expected int) error {
+	var input bytes.Buffer
+	fmt.Fprintln(&input, 1)
+	fmt.Fprintln(&input, tc.n)
+	for i, v := range tc.arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprint(&input, v)
+	}
+	input.WriteByte('\n')
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	val, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("non-integer output")
+	}
+	if val != expected {
+		return fmt.Errorf("expected %d got %d", expected, val)
+	}
+	if len(fields) > 1 {
+		return fmt.Errorf("extra output")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTestsB()
+	for i, tc := range cases {
+		exp := bruteMin(tc)
+		if err := runCase(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1400-1499/1470-1479/1479/verifierC.go
+++ b/1000-1999/1400-1499/1470-1479/1479/verifierC.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCmd(cmdPath, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	c := exec.CommandContext(ctx, cmdPath)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := range tests {
+		l := rng.Intn(20) + 1
+		r := l + rng.Intn(20)
+		tests[i] = fmt.Sprintf("%d %d\n", l, r)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refExe := "./solC.bin"
+	if err := exec.Command("go", "build", "-o", refExe, "1479C.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refExe)
+
+	tests := genTests()
+	for i, t := range tests {
+		want, err := runCmd(refExe, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1400-1499/1470-1479/1479/verifierD.go
+++ b/1000-1999/1400-1499/1470-1479/1479/verifierD.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type queryD struct{ u, v, l, r int }
+
+type testCaseD struct {
+	n       int
+	q       int
+	a       []int
+	edges   [][2]int
+	queries []queryD
+}
+
+func genTestsD() []testCaseD {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rng.Intn(6) + 2 // 2..7
+		a := make([]int, n+1)
+		for j := 1; j <= n; j++ {
+			a[j] = rng.Intn(n) + 1
+		}
+		edges := make([][2]int, 0, n-1)
+		for j := 2; j <= n; j++ {
+			p := rng.Intn(j-1) + 1
+			edges = append(edges, [2]int{p, j})
+		}
+		q := rng.Intn(5) + 1
+		qs := make([]queryD, q)
+		for j := 0; j < q; j++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			l := rng.Intn(n) + 1
+			r := l + rng.Intn(n+1-l)
+			qs[j] = queryD{u, v, l, r}
+		}
+		tests[i] = testCaseD{n: n, q: q, a: a, edges: edges, queries: qs}
+	}
+	return tests
+}
+
+func findPath(n int, edges [][2]int, u, v int) []int {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		a, b := e[0], e[1]
+		adj[a] = append(adj[a], b)
+		adj[b] = append(adj[b], a)
+	}
+	parent := make([]int, n+1)
+	vis := make([]bool, n+1)
+	q := []int{u}
+	vis[u] = true
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		if cur == v {
+			break
+		}
+		for _, nxt := range adj[cur] {
+			if !vis[nxt] {
+				vis[nxt] = true
+				parent[nxt] = cur
+				q = append(q, nxt)
+			}
+		}
+	}
+	path := []int{v}
+	for v != u {
+		v = parent[v]
+		path = append(path, v)
+	}
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	return path
+}
+
+func expectedAns(tc testCaseD) []int {
+	results := make([]int, tc.q)
+	for i, qu := range tc.queries {
+		p := findPath(tc.n, tc.edges, qu.u, qu.v)
+		freq := make(map[int]int)
+		for _, node := range p {
+			val := tc.a[node]
+			freq[val]++
+		}
+		ans := -1
+		for x := qu.l; x <= qu.r; x++ {
+			if freq[x]%2 == 1 {
+				ans = x
+				break
+			}
+		}
+		results[i] = ans
+	}
+	return results
+}
+
+func buildInput(tc testCaseD) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.q)
+	for i := 1; i <= tc.n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, tc.a[i])
+	}
+	sb.WriteByte('\n')
+	for _, e := range tc.edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	for _, q := range tc.queries {
+		fmt.Fprintf(&sb, "%d %d %d %d\n", q.u, q.v, q.l, q.r)
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCaseD, expect []int) error {
+	input := buildInput(tc)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != len(expect) {
+		return fmt.Errorf("expected %d outputs got %d", len(expect), len(fields))
+	}
+	for i, exp := range expect {
+		val, err := strconv.Atoi(fields[i])
+		if err != nil || val != exp {
+			return fmt.Errorf("on query %d expected %d got %s", i+1, exp, fields[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTestsD()
+	for i, tc := range cases {
+		exp := expectedAns(tc)
+		if err := runCase(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1400-1499/1470-1479/1479/verifierE.go
+++ b/1000-1999/1400-1499/1470-1479/1479/verifierE.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func clone(x []int) []int { return append([]int(nil), x...) }
+
+func removeOne(c []int, idx int) []int {
+	res := clone(c)
+	res[idx]--
+	if res[idx] == 0 {
+		return append(res[:idx], res[idx+1:]...)
+	}
+	return res
+}
+
+func removeOneAddNew(c []int, idx int) []int {
+	res := removeOne(c, idx)
+	res = append(res, 1)
+	sort.Ints(res)
+	return res
+}
+
+func removeOneAddToOther(c []int, i, j int) []int {
+	res := clone(c)
+	res[i]--
+	if res[i] == 0 {
+		res = append(res[:i], res[i+1:]...)
+		if j > i {
+			j--
+		}
+	}
+	res[j]++
+	sort.Ints(res)
+	return res
+}
+
+var memo map[string]*big.Rat
+var half = big.NewRat(1, 2)
+
+func expected(c []int) *big.Rat {
+	sort.Ints(c)
+	if len(c) == 1 {
+		return big.NewRat(0, 1)
+	}
+	key := fmt.Sprint(c)
+	if v, ok := memo[key]; ok {
+		return new(big.Rat).Set(v)
+	}
+	n := 0
+	for _, v := range c {
+		n += v
+	}
+	res := big.NewRat(1, 1)
+	for i, cnt := range c {
+		pSel := new(big.Rat).SetFrac64(int64(cnt), int64(n))
+		// create new club
+		st1 := removeOneAddNew(c, i)
+		t1 := expected(st1)
+		term1 := new(big.Rat).Mul(pSel, half)
+		term1.Mul(term1, t1)
+		sum.Add(sum, term1)
+		// join existing club
+		for j, cntj := range c {
+			pJoin := new(big.Rat).SetFrac64(int64(cntj), int64(n))
+			pJoin.Mul(pJoin, pSel)
+			pJoin.Mul(pJoin, half)
+			st2 := removeOneAddToOther(c, i, j)
+			t2 := expected(st2)
+			term2 := new(big.Rat).Mul(pJoin, t2)
+			sum.Add(sum, term2)
+		}
+	}
+	res.Add(res, sum)
+	memo[key] = res
+	return new(big.Rat).Set(res)
+}
+
+func modResult(r *big.Rat) int {
+	mod := big.NewInt(998244353)
+	num := new(big.Int).Mod(r.Num(), mod)
+	den := new(big.Int).Mod(r.Denom(), mod)
+	inv := new(big.Int).Exp(den, new(big.Int).Sub(mod, big.NewInt(2)), mod)
+	num.Mul(num, inv)
+	num.Mod(num, mod)
+	return int(num.Int64())
+}
+
+func genTestsE() [][]int {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([][]int, 100)
+	for i := range tests {
+		for {
+			m := rng.Intn(3) + 1
+			counts := make([]int, m)
+			total := 0
+			for j := range counts {
+				counts[j] = rng.Intn(3) + 1
+				total += counts[j]
+			}
+			if total <= 5 {
+				tests[i] = counts
+				break
+			}
+		}
+	}
+	return tests
+}
+
+func buildInputE(c []int) string {
+	var sb strings.Builder
+	fmt.Fprintln(&sb, len(c))
+	for i, v := range c {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, c []int, expect int) error {
+	input := buildInputE(c)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	val, err := strconv.Atoi(fields[0])
+	if err != nil || val != expect {
+		return fmt.Errorf("expected %d got %s", expect, fields[0])
+	}
+	if len(fields) > 1 {
+		return fmt.Errorf("extra output")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTestsE()
+	for i, c := range cases {
+		memo = make(map[string]*big.Rat)
+		exp := modResult(expected(c))
+		if err := runCase(bin, c, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` implementing an interactive judge harness for problem A
- add brute-force verifiers `verifierB1.go` and `verifierB2.go`
- add reference-based verifier `verifierC.go`
- add naive tree-query verifier `verifierD.go`
- add dynamic-programming verifier `verifierE.go`

## Testing
- `gofmt -w verifierA.go verifierB1.go verifierB2.go verifierC.go verifierD.go verifierE.go`
- `go vet ./...` *(fails: "directory prefix . does not contain main module")*

------
https://chatgpt.com/codex/tasks/task_e_68870efe9c788324a25c97ef3a15b016