### PR TITLE
Add Go verifiers for contest 1482

### DIFF
--- a/1000-1999/1400-1499/1480-1489/1482/verifierA.go
+++ b/1000-1999/1400-1499/1480-1489/1482/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleA"
+	cmd := exec.Command("go", "build", "-o", oracle, "1482A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run error: %v\nstderr: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rand.Seed(1)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for i := 0; i < T; i++ {
+		a := rand.Intn(100) + 1
+		b := rand.Intn(100) + 1
+		fmt.Fprintf(&input, "%d %d\n", a, b)
+	}
+	inp := input.String()
+
+	expected, err := run("./"+oracle, inp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	got, err := run(bin, inp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if expected != got {
+		fmt.Println("mismatch")
+		fmt.Println("expected:\n" + expected)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1482/verifierB.go
+++ b/1000-1999/1400-1499/1480-1489/1482/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleB"
+	cmd := exec.Command("go", "build", "-o", oracle, "1482B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run error: %v\nstderr: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rand.Seed(2)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(4) + 1
+		fmt.Fprintln(&input, n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", rand.Intn(11))
+		}
+		input.WriteByte('\n')
+	}
+	inp := input.String()
+
+	expected, err := run("./"+oracle, inp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	got, err := run(bin, inp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if expected != got {
+		fmt.Println("mismatch")
+		fmt.Println("expected:\n" + expected)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1482/verifierC.go
+++ b/1000-1999/1400-1499/1480-1489/1482/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleC"
+	cmd := exec.Command("go", "build", "-o", oracle, "1482C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run error: %v\nstderr: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rand.Seed(3)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(4) + 1
+		m := rand.Intn(4) + 1
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		for j := 0; j < m; j++ {
+			k := rand.Intn(n) + 1
+			perm := rand.Perm(n)
+			fmt.Fprintf(&input, "%d", k)
+			for t := 0; t < k; t++ {
+				fmt.Fprintf(&input, " %d", perm[t]+1)
+			}
+			input.WriteByte('\n')
+		}
+	}
+	inp := input.String()
+
+	expected, err := run("./"+oracle, inp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	got, err := run(bin, inp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if expected != got {
+		fmt.Println("mismatch")
+		fmt.Println("expected:\n" + expected)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1482/verifierD.go
+++ b/1000-1999/1400-1499/1480-1489/1482/verifierD.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleD"
+	cmd := exec.Command("go", "build", "-o", oracle, "1482D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run error: %v\nstderr: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rand.Seed(4)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(8) + 1
+		fmt.Fprintln(&input, n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", rand.Intn(10)+1)
+		}
+		input.WriteByte('\n')
+	}
+	inp := input.String()
+
+	expected, err := run("./"+oracle, inp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	got, err := run(bin, inp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if expected != got {
+		fmt.Println("mismatch")
+		fmt.Println("expected:\n" + expected)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1482/verifierE.go
+++ b/1000-1999/1400-1499/1480-1489/1482/verifierE.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleE"
+	cmd := exec.Command("go", "build", "-o", oracle, "1482E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run error: %v\nstderr: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rand.Seed(5)
+	const T = 100
+	for i := 0; i < T; i++ {
+		n := rand.Intn(8) + 1
+		perm := rand.Perm(n)
+		var input bytes.Buffer
+		fmt.Fprintln(&input, n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", perm[j]+1)
+		}
+		input.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", rand.Intn(11)-5)
+		}
+		input.WriteByte('\n')
+		inp := input.String()
+		expected, err := run("./"+oracle, inp)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d mismatch\nexpected: %s\ngot: %s\n", i+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1482/verifierF.go
+++ b/1000-1999/1400-1499/1480-1489/1482/verifierF.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleF"
+	cmd := exec.Command("go", "build", "-o", oracle, "1482F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run error: %v\nstderr: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rand.Seed(6)
+	const T = 100
+	for i := 0; i < T; i++ {
+		n := rand.Intn(4) + 2
+		maxEdges := n * (n - 1) / 2
+		m := rand.Intn(maxEdges) + 1
+		edges := make([][3]int, 0, m)
+		used := map[[2]int]bool{}
+		for len(edges) < m {
+			u := rand.Intn(n)
+			v := rand.Intn(n)
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			key := [2]int{u, v}
+			if used[key] {
+				continue
+			}
+			used[key] = true
+			w := rand.Intn(5) + 1
+			edges = append(edges, [3]int{u + 1, v + 1, w})
+		}
+		q := rand.Intn(3) + 1
+		queries := make([][3]int, q)
+		for j := 0; j < q; j++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			l := rand.Intn(5) + 1
+			queries[j] = [3]int{u, v, l}
+		}
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		for _, e := range edges {
+			fmt.Fprintf(&input, "%d %d %d\n", e[0], e[1], e[2])
+		}
+		fmt.Fprintln(&input, q)
+		for _, qu := range queries {
+			fmt.Fprintf(&input, "%d %d %d\n", qu[0], qu[1], qu[2])
+		}
+		inp := input.String()
+		expected, err := run("./"+oracle, inp)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d mismatch\nexpected: %s\ngot: %s\n", i+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1482/verifierG.go
+++ b/1000-1999/1400-1499/1480-1489/1482/verifierG.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleG"
+	cmd := exec.Command("go", "build", "-o", oracle, "1482G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run error: %v\nstderr: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rand.Seed(7)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for i := 0; i < T; i++ {
+		fmt.Fprintln(&input, rand.Intn(100)+1)
+	}
+	inp := input.String()
+
+	expected, err := run("./"+oracle, inp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	got, err := run(bin, inp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if expected != got {
+		fmt.Println("mismatch")
+		fmt.Println("expected:\n" + expected)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1482/verifierH.go
+++ b/1000-1999/1400-1499/1480-1489/1482/verifierH.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleH"
+	cmd := exec.Command("go", "build", "-o", oracle, "1482H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run error: %v\nstderr: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randWord() string {
+	l := rand.Intn(4) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		b[i] = byte('a' + rand.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rand.Seed(8)
+	const T = 100
+	for i := 0; i < T; i++ {
+		n := rand.Intn(4) + 1
+		var input bytes.Buffer
+		fmt.Fprintln(&input, n)
+		for j := 0; j < n; j++ {
+			fmt.Fprintln(&input, randWord())
+		}
+		inp := input.String()
+		expected, err := run("./"+oracle, inp)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d mismatch\nexpected: %s\ngot: %s\n", i+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifier programs for all problems of Codeforces contest 1482
- each verifier builds a reference solution, generates 100 random tests, runs the candidate binary and compares outputs

## Testing
- `go build verifierA.go`
- `for f in verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go verifierH.go; do echo "build $f"; go build $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_68870fd0ad88832490809d0e9ab4d14e