### PR TITLE
Add verifiers for contest 1487

### DIFF
--- a/1000-1999/1400-1499/1480-1489/1487/verifierA.go
+++ b/1000-1999/1400-1499/1480-1489/1487/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveA(arr []int) int {
+	minVal := 101
+	for _, v := range arr {
+		if v < minVal {
+			minVal = v
+		}
+	}
+	cnt := 0
+	for _, v := range arr {
+		if v > minVal {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(99) + 2 // 2..100
+		arr := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(100) + 1
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(arr[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := strconv.Itoa(solveA(arr))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", t+1, err, got)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("case %d failed:\ninput:\n%sexpected %s got %s\n", t+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1487/verifierB.go
+++ b/1000-1999/1400-1499/1480-1489/1487/verifierB.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveB(n, k int64) int64 {
+	if n%2 == 0 {
+		return (k-1)%n + 1
+	}
+	m := (n - 1) / 2
+	extra := (k - 1) / m
+	return ((k - 1 + extra) % n) + 1
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for t := 0; t < 100; t++ {
+		n := rng.Int63n(1e9-1) + 2
+		k := rng.Int63n(1e9) + 1
+		input := fmt.Sprintf("1\n%d %d\n", n, k)
+		expected := strconv.FormatInt(solveB(n, k), 10)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", t+1, err, got)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("case %d failed:\ninput:%sexpected %s got %s\n", t+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1487/verifierC.go
+++ b/1000-1999/1400-1499/1480-1489/1487/verifierC.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1487C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(1))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(18) + 2 // 2..19
+		input := fmt.Sprintf("1\n%d\n", n)
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", t+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("case %d failed:\ninput:\n%sexpected %s got %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1487/verifierD.go
+++ b/1000-1999/1400-1499/1480-1489/1487/verifierD.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveD(n int64) int64 {
+	m := int64(math.Sqrt(float64(2*n - 1)))
+	ans := (m - 1) / 2
+	if ans < 0 {
+		ans = 0
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for t := 0; t < 100; t++ {
+		n := rng.Int63n(1e9) + 1
+		input := fmt.Sprintf("1\n%d\n", n)
+		expected := strconv.FormatInt(solveD(n), 10)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", t+1, err, got)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("case %d failed:\ninput:%sexpected %s got %s\n", t+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1487/verifierE.go
+++ b/1000-1999/1400-1499/1480-1489/1487/verifierE.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1487E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n1 := rng.Intn(5) + 1
+	n2 := rng.Intn(5) + 1
+	n3 := rng.Intn(5) + 1
+	n4 := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n1, n2, n3, n4))
+	for i := 0; i < n1; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rng.Intn(10)+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n2; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rng.Intn(10)+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n3; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rng.Intn(10)+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n4; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rng.Intn(10)+1))
+	}
+	sb.WriteByte('\n')
+	m1 := rng.Intn(n1*n2 + 1)
+	sb.WriteString(fmt.Sprintf("%d\n", m1))
+	for i := 0; i < m1; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", rng.Intn(n1)+1, rng.Intn(n2)+1))
+	}
+	m2 := rng.Intn(n2*n3 + 1)
+	sb.WriteString(fmt.Sprintf("%d\n", m2))
+	for i := 0; i < m2; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", rng.Intn(n2)+1, rng.Intn(n3)+1))
+	}
+	m3 := rng.Intn(n3*n4 + 1)
+	sb.WriteString(fmt.Sprintf("%d\n", m3))
+	for i := 0; i < m3; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", rng.Intn(n3)+1, rng.Intn(n4)+1))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(1))
+	for t := 0; t < 100; t++ {
+		tc := generateCase(rng)
+		input := "1\n" + tc
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", t+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("case %d failed:\ninput:\n%sexpected %s got %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1480-1489/1487/verifierF.go
+++ b/1000-1999/1400-1499/1480-1489/1487/verifierF.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1487F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randBig(rng *rand.Rand) string {
+	digits := rng.Intn(18) + 1
+	var sb strings.Builder
+	for i := 0; i < digits; i++ {
+		d := rng.Intn(10)
+		if i == 0 && d == 0 {
+			d = 1
+		}
+		sb.WriteByte(byte('0' + d))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(1))
+	for t := 0; t < 100; t++ {
+		s := randBig(rng)
+		input := s + "\n"
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", t+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("case %d failed:\ninput:%sexpected %s got %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+		// ensure output is numeric
+		if _, ok := new(big.Int).SetString(strings.TrimSpace(got), 10); !ok {
+			fmt.Printf("case %d: output not integer: %s\n", t+1, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1487
- each verifier generates 100 deterministic test cases and checks a provided binary
- complex problems use compiled solution as an oracle

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6887112ed9b883249614101926822cff