### PR TITLE
Add verifiers for contest 1492

### DIFF
--- a/1000-1999/1400-1499/1490-1499/1492/verifierA.go
+++ b/1000-1999/1400-1499/1490-1499/1492/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(r *rand.Rand) string {
+	p := r.Int63n(1_000_000_000_000) + 1
+	a := r.Int63n(1_000_000_000_000) + 1
+	b := r.Int63n(1_000_000_000_000) + 1
+	c := r.Int63n(1_000_000_000_000) + 1
+	return fmt.Sprintf("1\n%d %d %d %d\n", p, a, b, c)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candA")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1492A.go")
+	refPath, err := prepareBinary(refSrc, "refA")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1490-1499/1492/verifierB.go
+++ b/1000-1999/1400-1499/1490-1499/1492/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(20) + 1
+	perm := r.Perm(n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1492B.go")
+	refPath, err := prepareBinary(refSrc, "refB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1490-1499/1492/verifierC.go
+++ b/1000-1999/1400-1499/1490-1499/1492/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(20) + 3
+	m := r.Intn(n-1) + 1
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	s := make([]byte, n)
+	for i := 0; i < n; i++ {
+		s[i] = letters[r.Intn(26)]
+	}
+	idx := make([]int, m)
+	last := -1
+	for i := 0; i < m; i++ {
+		idx[i] = r.Intn(n-(m-i)) + last + 1
+		last = idx[i]
+	}
+	t := make([]byte, m)
+	for i := 0; i < m; i++ {
+		t[i] = s[idx[i]]
+	}
+	return fmt.Sprintf("%d %d\n%s\n%s\n", n, m, string(s), string(t))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candC")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1492C.go")
+	refPath, err := prepareBinary(refSrc, "refC")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1490-1499/1492/verifierD.go
+++ b/1000-1999/1400-1499/1490-1499/1492/verifierD.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(r *rand.Rand) string {
+	a := r.Intn(6) + 1
+	b := r.Intn(6) + 1
+	k := r.Intn(a + b + 1)
+	return fmt.Sprintf("%d %d %d\n", a, b, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candD")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1492D.go")
+	refPath, err := prepareBinary(refSrc, "refD")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1490-1499/1492/verifierE.go
+++ b/1000-1999/1400-1499/1490-1499/1492/verifierE.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(4) + 2
+	m := r.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", r.Intn(10)+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1492E.go")
+	refPath, err := prepareBinary(refSrc, "refE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for all problems in contest 1492
- each verifier builds the reference solution and runs 100 random test cases against a candidate binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6887128d0b588324b5dd647275f01eef