### PR TITLE
Add Go verifiers for contest 1494

### DIFF
--- a/1000-1999/1400-1499/1490-1499/1494/verifierA.go
+++ b/1000-1999/1400-1499/1490-1499/1494/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsA = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candA")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleA")
+	cmd := exec.Command("go", "build", "-o", tmp, "1494A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(25)*2 + 2 // even 2..50
+	letters := []byte{'A', 'B', 'C'}
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(3)]
+	}
+	return fmt.Sprintf("1\n%s\n", string(b))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+
+	rng := rand.New(rand.NewSource(0))
+	for i := 0; i < numTestsA; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1490-1499/1494/verifierB.go
+++ b/1000-1999/1400-1499/1490-1499/1494/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsB = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candB")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleB")
+	cmd := exec.Command("go", "build", "-o", tmp, "1494B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(99) + 2
+	u := rng.Intn(n + 1)
+	r := rng.Intn(n + 1)
+	d := rng.Intn(n + 1)
+	l := rng.Intn(n + 1)
+	return fmt.Sprintf("1\n%d %d %d %d %d\n", n, u, r, d, l)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < numTestsB; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1490-1499/1494/verifierC.go
+++ b/1000-1999/1400-1499/1490-1499/1494/verifierC.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const numTestsC = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candC")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleC")
+	cmd := exec.Command("go", "build", "-o", tmp, "1494C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genArray(rng *rand.Rand, n int) []int {
+	vals := make(map[int]struct{})
+	for len(vals) < n {
+		x := rng.Intn(201) - 100
+		if x == 0 {
+			continue
+		}
+		vals[x] = struct{}{}
+	}
+	arr := make([]int, 0, n)
+	for x := range vals {
+		arr = append(arr, x)
+	}
+	sort.Ints(arr)
+	return arr
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	a := genArray(rng, n)
+	b := genArray(rng, m)
+	input := fmt.Sprintf("1\n%d %d\n", n, m)
+	for i, v := range a {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	for i, v := range b {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	return input
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < numTestsC; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1490-1499/1494/verifierD.go
+++ b/1000-1999/1400-1499/1490-1499/1494/verifierD.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsD = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candD")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleD")
+	cmd := exec.Command("go", "build", "-o", tmp, "1494D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+type node struct {
+	id     int
+	salary int
+	parent *node
+}
+
+func buildTree(rng *rand.Rand, n int) ([]*node, *node) {
+	nodes := make([]*node, n)
+	maxSalary := 0
+	for i := 0; i < n; i++ {
+		salary := rng.Intn(50) + 1
+		if salary > maxSalary {
+			maxSalary = salary
+		}
+		nodes[i] = &node{id: i, salary: salary}
+	}
+	curID := n
+	for len(nodes) > 1 {
+		i := rng.Intn(len(nodes))
+		j := rng.Intn(len(nodes) - 1)
+		if j >= i {
+			j++
+		}
+		a := nodes[i]
+		b := nodes[j]
+		salary := maxSalary + rng.Intn(50) + 1
+		if salary > maxSalary {
+			maxSalary = salary
+		}
+		p := &node{id: curID, salary: salary}
+		curID++
+		a.parent = p
+		b.parent = p
+		nodes[i] = p
+		nodes[j] = nodes[len(nodes)-1]
+		nodes = nodes[:len(nodes)-1]
+	}
+	return nodes[0:curID], nodes[0]
+}
+
+func lca(a, b *node) *node {
+	seen := map[*node]struct{}{}
+	for a != nil {
+		seen[a] = struct{}{}
+		a = a.parent
+	}
+	for b != nil {
+		if _, ok := seen[b]; ok {
+			return b
+		}
+		b = b.parent
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	leaves := make([]*node, n)
+	nodes, root := buildTree(rng, n)
+	// collect leaves
+	for _, nd := range nodes {
+		if nd.id < n {
+			leaves[nd.id] = nd
+		}
+	}
+	// compute matrix
+	mat := make([][]int, n)
+	for i := 0; i < n; i++ {
+		mat[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			if i == j {
+				mat[i][j] = leaves[i].salary
+			} else {
+				mat[i][j] = lca(leaves[i], leaves[j]).salary
+			}
+		}
+	}
+	// build input
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", mat[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	_ = root
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < numTestsD; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1490-1499/1494/verifierE.go
+++ b/1000-1999/1400-1499/1490-1499/1494/verifierE.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsE = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candE")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleE")
+	cmd := exec.Command("go", "build", "-o", tmp, "1494E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(30) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	type edge struct{ u, v int }
+	edges := make(map[edge]byte)
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	queries := 0
+	for i := 0; i < m; i++ {
+		t := rng.Intn(3)
+		if i == m-1 && queries == 0 {
+			t = 2
+		}
+		switch t {
+		case 0: // add
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n-1) + 1
+			if v >= u {
+				v++
+			}
+			e := edge{u, v}
+			if _, ok := edges[e]; ok {
+				i--
+				continue
+			}
+			c := letters[rng.Intn(len(letters))]
+			edges[e] = c
+			sb.WriteString(fmt.Sprintf("+ %d %d %c\n", u, v, c))
+		case 1: // remove
+			if len(edges) == 0 {
+				t = 0
+				i--
+				continue
+			}
+			k := rng.Intn(len(edges))
+			var e edge
+			j := 0
+			for x := range edges {
+				if j == k {
+					e = x
+					break
+				}
+				j++
+			}
+			sb.WriteString(fmt.Sprintf("- %d %d\n", e.u, e.v))
+			delete(edges, e)
+		default: // query
+			k := rng.Intn(8) + 2
+			sb.WriteString(fmt.Sprintf("? %d\n", k))
+			queries++
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < numTestsE; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1400-1499/1490-1499/1494/verifierF.go
+++ b/1000-1999/1400-1499/1490-1499/1494/verifierF.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsF = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candF")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleF")
+	cmd := exec.Command("go", "build", "-o", tmp, "1494F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(min(maxEdges, 8)-(n-1)+1) + (n - 1)
+	type edge struct{ u, v int }
+	edges := make(map[edge]struct{})
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	// tree to ensure connected
+	for i := 2; i <= n; i++ {
+		u := i
+		v := rng.Intn(i-1) + 1
+		edges[edge{u, v}] = struct{}{}
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n-1) + 1
+		if v >= u {
+			v++
+		}
+		e := edge{u, v}
+		if _, ok := edges[e]; ok {
+			continue
+		}
+		edges[e] = struct{}{}
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+	}
+	return sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+	rng := rand.New(rand.NewSource(5))
+	for i := 0; i < numTestsF; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–F of contest 1494
- each verifier builds a reference solution, generates 100 random tests and checks another binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688713191e4c83248f22df2ec48efcf7