### PR TITLE
Add Go verifiers for Codeforces 1493

### DIFF
--- a/1000-1999/1400-1499/1490-1499/1493/verifierA.go
+++ b/1000-1999/1400-1499/1490-1499/1493/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	k int
+}
+
+func generateTests() []Test {
+	rand.Seed(1)
+	tests := make([]Test, 0, 100)
+	// include some edge cases
+	edge := []Test{
+		{1, 1}, {2, 1}, {2, 2}, {5, 3}, {1000, 1}, {1000, 1000}, {10, 5},
+	}
+	tests = append(tests, edge...)
+	for len(tests) < 100 {
+		n := rand.Intn(1000) + 1
+		k := rand.Intn(n) + 1
+		tests = append(tests, Test{n, k})
+	}
+	return tests
+}
+
+func solve(n, k int) string {
+	nums := []int{}
+	for i := k + 1; i <= n; i++ {
+		nums = append(nums, i)
+	}
+	for i := k/2 + 1; i < k; i++ {
+		nums = append(nums, i)
+	}
+	var b strings.Builder
+	fmt.Fprintln(&b, len(nums))
+	for i, v := range nums {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, v)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	// prepare single run input with T=len(tests)
+	var in strings.Builder
+	fmt.Fprintln(&in, len(tests))
+	for _, t := range tests {
+		fmt.Fprintf(&in, "%d %d\n", t.n, t.k)
+	}
+	expectedParts := make([]string, len(tests))
+	for i, t := range tests {
+		expectedParts[i] = solve(t.n, t.k)
+	}
+	expect := strings.Join(expectedParts, "")
+
+	got, err := run(binary, in.String())
+	if err != nil {
+		fmt.Printf("runtime error: %v\noutput:\n%s", err, got)
+		os.Exit(1)
+	}
+	// normalize newlines
+	got = strings.ReplaceAll(strings.TrimSpace(got), "\r\n", "\n")
+	expect = strings.ReplaceAll(strings.TrimSpace(expect), "\r\n", "\n")
+	if got != expect {
+		fmt.Println("wrong answer")
+		fmt.Println("input:")
+		fmt.Print(in.String())
+		fmt.Println("expected:")
+		fmt.Print(expect)
+		fmt.Println("got:")
+		fmt.Print(got)
+		os.Exit(1)
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+	time.Sleep(0) // avoid exit handling
+}

--- a/1000-1999/1400-1499/1490-1499/1493/verifierB.go
+++ b/1000-1999/1400-1499/1490-1499/1493/verifierB.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	h int
+	m int
+	s string
+}
+
+func generateTests() []Test {
+	rand.Seed(2)
+	tests := make([]Test, 0, 100)
+	edge := []Test{{24, 60, "23:59"}, {10, 60, "00:00"}, {12, 12, "11:11"}, {5, 3, "02:02"}}
+	tests = append(tests, edge...)
+	for len(tests) < 100 {
+		h := rand.Intn(99) + 1
+		m := rand.Intn(99) + 1
+		hh := rand.Intn(h)
+		mm := rand.Intn(m)
+		tests = append(tests, Test{h, m, fmt.Sprintf("%02d:%02d", hh, mm)})
+	}
+	return tests
+}
+
+var mirror = map[int]int{0: 0, 1: 1, 2: 5, 5: 2, 8: 8}
+
+func solve(h, m int, s string) string {
+	hour := int((s[0]-'0')*10 + (s[1] - '0'))
+	minute := int((s[3]-'0')*10 + (s[4] - '0'))
+	for i := 0; i < h*m; i++ {
+		h1 := hour / 10
+		h2 := hour % 10
+		m1 := minute / 10
+		m2 := minute % 10
+		d1, ok1 := mirror[m2]
+		d2, ok2 := mirror[m1]
+		d3, ok3 := mirror[h2]
+		d4, ok4 := mirror[h1]
+		if ok1 && ok2 && ok3 && ok4 {
+			rh := d1*10 + d2
+			rm := d3*10 + d4
+			if rh < h && rm < m {
+				return fmt.Sprintf("%02d:%02d", hour, minute)
+			}
+		}
+		minute++
+		if minute == m {
+			minute = 0
+			hour++
+			if hour == h {
+				hour = 0
+			}
+		}
+	}
+	return fmt.Sprintf("%02d:%02d", hour, minute)
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	var in strings.Builder
+	fmt.Fprintln(&in, len(tests))
+	for _, t := range tests {
+		fmt.Fprintf(&in, "%d %d\n%s\n", t.h, t.m, t.s)
+	}
+	expectedParts := make([]string, len(tests))
+	for i, t := range tests {
+		expectedParts[i] = solve(t.h, t.m, t.s) + "\n"
+	}
+	expect := strings.Join(expectedParts, "")
+
+	got, err := run(binary, in.String())
+	if err != nil {
+		fmt.Printf("runtime error: %v\noutput:\n%s", err, got)
+		os.Exit(1)
+	}
+	got = strings.ReplaceAll(strings.TrimSpace(got), "\r\n", "\n")
+	expect = strings.ReplaceAll(strings.TrimSpace(expect), "\r\n", "\n")
+	if got != expect {
+		fmt.Println("wrong answer")
+		fmt.Println("input:")
+		fmt.Print(in.String())
+		fmt.Println("expected:")
+		fmt.Print(expect)
+		fmt.Println("got:")
+		fmt.Print(got)
+		os.Exit(1)
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+	time.Sleep(0)
+}

--- a/1000-1999/1400-1499/1490-1499/1493/verifierC.go
+++ b/1000-1999/1400-1499/1490-1499/1493/verifierC.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	k int
+	s string
+}
+
+func generateTests() []Test {
+	rand.Seed(3)
+	tests := make([]Test, 0, 100)
+	edge := []Test{{1, 1, "a"}, {2, 1, "ab"}, {3, 3, "abc"}, {4, 2, "aaaa"}, {5, 5, "abcde"}}
+	tests = append(tests, edge...)
+	letters := []rune("abcde")
+	for len(tests) < 100 {
+		n := rand.Intn(50) + 1
+		k := rand.Intn(n) + 1
+		runes := make([]rune, n)
+		for i := 0; i < n; i++ {
+			runes[i] = letters[rand.Intn(len(letters))]
+		}
+		tests = append(tests, Test{n, k, string(runes)})
+	}
+	return tests
+}
+
+func solve(n, k int, s string) string {
+	if n%k != 0 {
+		return "-1"
+	}
+	freq := make([]int, 26)
+	for i := 0; i < n; i++ {
+		freq[s[i]-'a']++
+	}
+	good := true
+	for i := 0; i < 26; i++ {
+		if freq[i]%k != 0 {
+			good = false
+		}
+	}
+	if good {
+		return s
+	}
+	for i := n - 1; i >= 0; i-- {
+		cur := int(s[i] - 'a')
+		freq[cur]--
+		for c := cur + 1; c < 26; c++ {
+			freq[c]++
+			rem := n - i - 1
+			needSum := 0
+			for j := 0; j < 26; j++ {
+				needSum += (k - freq[j]%k) % k
+			}
+			if needSum <= rem && (rem-needSum)%k == 0 {
+				prefix := s[:i] + string(rune('a'+c))
+				rest := make([]byte, 0, rem)
+				for t := 0; t < rem-needSum; t++ {
+					rest = append(rest, 'a')
+				}
+				for j := 0; j < 26; j++ {
+					cnt := (k - freq[j]%k) % k
+					for t := 0; t < cnt; t++ {
+						rest = append(rest, byte('a'+j))
+					}
+				}
+				return prefix + string(rest)
+			}
+			freq[c]--
+		}
+	}
+	return "-1"
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	var in strings.Builder
+	fmt.Fprintln(&in, len(tests))
+	for _, t := range tests {
+		fmt.Fprintf(&in, "%d %d\n%s\n", t.n, t.k, t.s)
+	}
+	expectedParts := make([]string, len(tests))
+	for i, t := range tests {
+		expectedParts[i] = solve(t.n, t.k, t.s) + "\n"
+	}
+	expect := strings.Join(expectedParts, "")
+
+	got, err := run(binary, in.String())
+	if err != nil {
+		fmt.Printf("runtime error: %v\noutput:\n%s", err, got)
+		os.Exit(1)
+	}
+	got = strings.ReplaceAll(strings.TrimSpace(got), "\r\n", "\n")
+	expect = strings.ReplaceAll(strings.TrimSpace(expect), "\r\n", "\n")
+	if got != expect {
+		fmt.Println("wrong answer")
+		fmt.Println("input:")
+		fmt.Print(in.String())
+		fmt.Println("expected:")
+		fmt.Print(expect)
+		fmt.Println("got:")
+		fmt.Print(got)
+		os.Exit(1)
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+	time.Sleep(0)
+}

--- a/1000-1999/1400-1499/1490-1499/1493/verifierD.go
+++ b/1000-1999/1400-1499/1490-1499/1493/verifierD.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Query struct {
+	idx int
+	x   int
+}
+
+type Test struct {
+	n  int
+	q  int
+	a  []int
+	qs []Query
+}
+
+func generateTests() []Test {
+	rand.Seed(4)
+	tests := make([]Test, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(10) + 1
+		q := rand.Intn(10) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(20) + 1
+		}
+		qs := make([]Query, q)
+		for i := 0; i < q; i++ {
+			qs[i] = Query{rand.Intn(n) + 1, rand.Intn(20) + 1}
+		}
+		tests = append(tests, Test{n, q, a, qs})
+	}
+	return tests
+}
+
+const MOD int = 1000000007
+const maxVal int = 200000
+
+var spf [maxVal + 1]int
+
+func initSieve() {
+	for i := 2; i <= maxVal; i++ {
+		if spf[i] == 0 {
+			for j := i; j <= maxVal; j += i {
+				if spf[j] == 0 {
+					spf[j] = i
+				}
+			}
+		}
+	}
+}
+
+func factorize(x int) map[int]int {
+	res := make(map[int]int)
+	for x > 1 {
+		p := spf[x]
+		if p == 0 {
+			p = x
+		}
+		cnt := 0
+		for x%p == 0 {
+			x /= p
+			cnt++
+		}
+		res[p] += cnt
+	}
+	return res
+}
+
+type primeData struct {
+	indexExp map[int]int
+	cnt      map[int]int
+	minExp   int
+	missing  int
+}
+
+func modPow(a, e int) int {
+	res := 1
+	b := a % MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * b % MOD
+		}
+		b = b * b % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func minKey(m map[int]int) int {
+	min := -1
+	for k := range m {
+		if min == -1 || k < min {
+			min = k
+		}
+	}
+	if min == -1 {
+		return 0
+	}
+	return min
+}
+
+func solve(test Test) string {
+	primes := make(map[int]*primeData)
+	n := test.n
+	curGCD := 1
+	for i, val := range test.a {
+		factors := factorize(val)
+		for p, e := range factors {
+			pd := primes[p]
+			if pd == nil {
+				pd = &primeData{indexExp: make(map[int]int), cnt: make(map[int]int), missing: n}
+				primes[p] = pd
+			}
+			pd.indexExp[i] = e
+			pd.cnt[e]++
+			pd.missing--
+		}
+	}
+	for p, pd := range primes {
+		if pd.missing == 0 {
+			pd.minExp = minKey(pd.cnt)
+			curGCD = curGCD * modPow(p, pd.minExp) % MOD
+		}
+	}
+	var b strings.Builder
+	for _, q := range test.qs {
+		idx := q.idx - 1
+		factors := factorize(q.x)
+		for p, add := range factors {
+			pd := primes[p]
+			if pd == nil {
+				pd = &primeData{indexExp: make(map[int]int), cnt: make(map[int]int), missing: n}
+				primes[p] = pd
+			}
+			oldExp := pd.indexExp[idx]
+			if oldExp == 0 {
+				pd.missing--
+			} else {
+				pd.cnt[oldExp]--
+				if pd.cnt[oldExp] == 0 {
+					delete(pd.cnt, oldExp)
+				}
+			}
+			newExp := oldExp + add
+			pd.indexExp[idx] = newExp
+			pd.cnt[newExp]++
+			oldMin := pd.minExp
+			var newMin int
+			if pd.missing > 0 {
+				newMin = 0
+			} else {
+				if (oldExp == oldMin && pd.cnt[oldExp] == 0) || oldMin == 0 {
+					newMin = minKey(pd.cnt)
+				} else {
+					newMin = oldMin
+				}
+			}
+			if newMin > oldMin {
+				curGCD = curGCD * modPow(p, newMin-oldMin) % MOD
+				pd.minExp = newMin
+			} else {
+				pd.minExp = newMin
+			}
+		}
+		fmt.Fprintf(&b, "%d\n", curGCD)
+	}
+	return b.String()
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	initSieve()
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, test := range tests {
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d %d\n", test.n, test.q)
+		for _, v := range test.a {
+			fmt.Fprintf(&in, "%d ", v)
+		}
+		in.WriteByte('\n')
+		for _, q := range test.qs {
+			fmt.Fprintf(&in, "%d %d\n", q.idx, q.x)
+		}
+		expect := solve(test)
+		got, err := run(binary, in.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.ReplaceAll(strings.TrimSpace(got), "\r\n", "\n")
+		expect = strings.ReplaceAll(strings.TrimSpace(expect), "\r\n", "\n")
+		if got != expect {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, in.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+	time.Sleep(0)
+}

--- a/1000-1999/1400-1499/1490-1499/1493/verifierE.go
+++ b/1000-1999/1400-1499/1490-1499/1493/verifierE.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	l *big.Int
+	r *big.Int
+}
+
+func generateTests() []Test {
+	rand.Seed(5)
+	tests := make([]Test, 0, 100)
+	edge := []Test{{1, big.NewInt(0), big.NewInt(1)}, {5, big.NewInt(3), big.NewInt(31)}, {6, big.NewInt(10), big.NewInt(40)}}
+	tests = append(tests, edge...)
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 1
+		maxVal := new(big.Int).Lsh(big.NewInt(1), uint(n))
+		r := new(big.Int).Rand(rand.New(rand.NewSource(int64(rand.Int()))), maxVal)
+		l := new(big.Int).Rand(rand.New(rand.NewSource(int64(rand.Int()))), maxVal)
+		if l.Cmp(r) > 0 {
+			l, r = r, l
+		}
+		tests = append(tests, Test{n, l, r})
+	}
+	return tests
+}
+
+func solve(l, r *big.Int) string {
+	k := r.BitLen() - 1
+	candidate := new(big.Int)
+	found := false
+	for ; k >= 0; k-- {
+		two := new(big.Int).Lsh(big.NewInt(1), uint(k))
+		if r.Cmp(two) < 0 {
+			continue
+		}
+		minusOne := new(big.Int).Sub(two, big.NewInt(1))
+		if l.Cmp(minusOne) <= 0 {
+			candidate.Lsh(big.NewInt(1), uint(k+1))
+			candidate.Sub(candidate, big.NewInt(1))
+			found = true
+			break
+		}
+	}
+	if !found {
+		temp := new(big.Int).Sub(r, big.NewInt(1))
+		candidate.Or(r, temp)
+	}
+	if r.Cmp(candidate) > 0 {
+		return r.Text(2)
+	}
+	return candidate.Text(2)
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d\n%s\n%s\n", t.n, t.l.Text(2), t.r.Text(2))
+		expect := solve(t.l, t.r)
+		got, err := run(binary, in.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != expect {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, in.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+	time.Sleep(0)
+}

--- a/1000-1999/1400-1499/1490-1499/1493/verifierF.go
+++ b/1000-1999/1400-1499/1490-1499/1493/verifierF.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	m int
+	a [][]int
+}
+
+func generateTests() []Test {
+	rand.Seed(6)
+	tests := make([]Test, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(4) + 1
+		m := rand.Intn(4) + 1
+		a := make([][]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = make([]int, m)
+			for j := 0; j < m; j++ {
+				a[i][j] = rand.Intn(5)
+			}
+		}
+		tests = append(tests, Test{n, m, a})
+	}
+	return tests
+}
+
+func primeFactorsDistinct(x int) []int {
+	res := []int{}
+	for p := 2; p*p <= x; p++ {
+		if x%p == 0 {
+			res = append(res, p)
+			for x%p == 0 {
+				x /= p
+			}
+		}
+	}
+	if x > 1 {
+		res = append(res, x)
+	}
+	return res
+}
+
+func checkRows(a [][]int, period int) bool {
+	n := len(a)
+	m := len(a[0])
+	for i := period; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if a[i][j] != a[i-period][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func checkCols(a [][]int, period int) bool {
+	n := len(a)
+	m := len(a[0])
+	for j := period; j < m; j++ {
+		for i := 0; i < n; i++ {
+			if a[i][j] != a[i][j-period] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func numDivisors(x int) int {
+	if x == 0 {
+		return 0
+	}
+	res := 1
+	for p := 2; p*p <= x; p++ {
+		if x%p == 0 {
+			e := 0
+			for x%p == 0 {
+				x /= p
+				e++
+			}
+			res *= e + 1
+		}
+	}
+	if x > 1 {
+		res *= 2
+	}
+	return res
+}
+
+func solve(t Test) string {
+	a := t.a
+	n := t.n
+	m := t.m
+	rowPeriod := n
+	for _, p := range primeFactorsDistinct(rowPeriod) {
+		for rowPeriod%p == 0 && checkRows(a, rowPeriod/p) {
+			rowPeriod /= p
+		}
+	}
+	colPeriod := m
+	for _, p := range primeFactorsDistinct(colPeriod) {
+		for colPeriod%p == 0 && checkCols(a, colPeriod/p) {
+			colPeriod /= p
+		}
+	}
+	cntRows := numDivisors(n / rowPeriod)
+	cntCols := numDivisors(m / colPeriod)
+	return fmt.Sprintf("%d", cntRows*cntCols)
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d %d\n", t.n, t.m)
+		for x := 0; x < t.n; x++ {
+			for y := 0; y < t.m; y++ {
+				fmt.Fprintf(&in, "%d ", t.a[x][y])
+			}
+			in.WriteByte('\n')
+		}
+		expect := solve(t)
+		got, err := run(binary, in.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != expect {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, in.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+	time.Sleep(0)
+}


### PR DESCRIPTION
## Summary
- add solution verifiers in Go for contest 1493 problems A–F
- each verifier generates at least 100 random test cases
- verifiers run the target binary and compare output with built‑in solution

## Testing
- `go run verifierA.go /tmp/1493A`
- `go run verifierB.go /tmp/1493B`
- `go run verifierC.go /tmp/1493C`
- `go run verifierD.go /tmp/1493D`
- `go run verifierE.go /tmp/1493E`
- `go run verifierF.go /tmp/1493F`


------
https://chatgpt.com/codex/tasks/task_e_688712d315708324ae40e4c78481558e