### PR TITLE
Add verifiers for contest 1504

### DIFF
--- a/1000-1999/1500-1599/1500-1509/1504/verifierA.go
+++ b/1000-1999/1500-1599/1500-1509/1504/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isPalindrome(s string) bool {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		if s[i] != s[j] {
+			return false
+		}
+	}
+	return true
+}
+
+func insertOneA(s, t string) bool {
+	if len(t) != len(s)+1 {
+		return false
+	}
+	for k := 0; k < len(t); k++ {
+		if t[k] == 'a' {
+			if t[:k]+t[k+1:] == s {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func validateOutput(s, out string) bool {
+	out = strings.TrimSpace(out)
+	if out == "NO" {
+		for i := 0; i < len(s); i++ {
+			if s[i] != 'a' {
+				return false
+			}
+		}
+		return true
+	}
+	parts := strings.Split(strings.ReplaceAll(out, "\r", ""), "\n")
+	if len(parts) != 2 || strings.ToUpper(strings.TrimSpace(parts[0])) != "YES" {
+		return false
+	}
+	t := strings.TrimSpace(parts[1])
+	if !insertOneA(s, t) {
+		return false
+	}
+	if isPalindrome(t) {
+		return false
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := []string{"a", "aa", "b", "ab", "aba", "bbb", "caa", "abc", "zz", "aba", "aaaa", "ba", "cab"}
+	rng := rand.New(rand.NewSource(42))
+	letters := "abc"
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteByte(letters[rng.Intn(len(letters))])
+		}
+		tests = append(tests, sb.String())
+	}
+	for idx, s := range tests {
+		input := fmt.Sprintf("1\n%s\n", s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if !validateOutput(s, got) {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid output for input %q\nGot:\n%s\n", idx+1, s, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1504/verifierB.go
+++ b/1000-1999/1500-1599/1500-1509/1504/verifierB.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func canTransform(a, b string) bool {
+	n := len(a)
+	balanced := make([]bool, n)
+	diff := 0
+	for i := 0; i < n; i++ {
+		if a[i] == '1' {
+			diff++
+		} else {
+			diff--
+		}
+		if diff == 0 {
+			balanced[i] = true
+		}
+	}
+	flip := false
+	for i := n - 1; i >= 0; i-- {
+		ch := a[i]
+		if flip {
+			if ch == '1' {
+				ch = '0'
+			} else {
+				ch = '1'
+			}
+		}
+		if ch == b[i] {
+			continue
+		}
+		if !balanced[i] {
+			return false
+		}
+		flip = !flip
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	type pair struct{ a, b string }
+	cases := []pair{
+		{"0", "0"},
+		{"0", "1"},
+		{"01", "10"},
+		{"10", "10"},
+		{"1100", "0011"},
+		{"01", "01"},
+		{"11", "00"},
+		{"1010", "0101"},
+		{"000", "111"},
+	}
+	rng := rand.New(rand.NewSource(42))
+	for len(cases) < 100 {
+		n := rng.Intn(20) + 1
+		var sa, sb strings.Builder
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 0 {
+				sa.WriteByte('0')
+			} else {
+				sa.WriteByte('1')
+			}
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		cases = append(cases, pair{sa.String(), sb.String()})
+	}
+	for idx, p := range cases {
+		wantYes := canTransform(p.a, p.b)
+		expected := "NO"
+		if wantYes {
+			expected = "YES"
+		}
+		input := fmt.Sprintf("1\n%d\n%s\n%s\n", len(p.a), p.a, p.b)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: a=%q b=%q expected %q got %q\n", idx+1, p.a, p.b, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A and B of contest 1504
- each verifier runs 100+ generated test cases
- verifiers support passing either a binary or `.go` source

## Testing
- `go run verifierA.go ./1504A_bin`
- `go run verifierB.go ./1504B_bin`

------
https://chatgpt.com/codex/tasks/task_e_688715d58a7483249c7c6b4d254c35ee