### PR TITLE
Add verifiers for contest 1509

### DIFF
--- a/1000-1999/1500-1599/1500-1509/1509/verifierA.go
+++ b/1000-1999/1500-1599/1500-1509/1509/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1509A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	total := 0
+	for i := 0; i < t; i++ {
+		n := rng.Intn(10) + 1
+		total += n
+		if total > 2000 {
+			n = 1
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			v := rng.Intn(100000) + 1
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1509/verifierB.go
+++ b/1000-1999/1500-1599/1500-1509/1509/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1509B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := (rng.Intn(9) + 1) * 3
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('T')
+			} else {
+				sb.WriteByte('M')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1509/verifierC.go
+++ b/1000-1999/1500-1599/1500-1509/1509/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1509C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		v := rng.Int63n(1000) + 1
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- provide Go verifiers for problems A, B and C of contest 1509
- each verifier builds the official solution and checks 100 generated tests

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`


------
https://chatgpt.com/codex/tasks/task_e_6887173406608324a9ac2c6da1eeee7c