### PR TITLE
Add solution verifiers for Codeforces 1508

### DIFF
--- a/1000-1999/1500-1599/1500-1509/1508/verifierA.go
+++ b/1000-1999/1500-1599/1500-1509/1508/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1508A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func randBits(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if r.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return string(b)
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		s1 := randBits(r, 2*n)
+		s2 := randBits(r, 2*n)
+		for s2 == s1 {
+			s2 = randBits(r, 2*n)
+		}
+		s3 := randBits(r, 2*n)
+		for s3 == s1 || s3 == s2 {
+			s3 = randBits(r, 2*n)
+		}
+		fmt.Fprintf(&sb, "%s\n%s\n%s\n", s1, s2, s3)
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1508/verifierB.go
+++ b/1000-1999/1500-1599/1500-1509/1508/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1508B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(8) + 1
+		limit := int64(1)
+		for j := 0; j < n-1 && limit < 1e18; j++ {
+			limit <<= 1
+		}
+		if limit > 1e18 {
+			limit = 1e18
+		}
+		k := r.Int63n(limit) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1508/verifierC.go
+++ b/1000-1999/1500-1599/1500-1509/1508/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1508C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 2 // 2..6
+	maxEdges := n * (n - 1) / 2
+	m := r.Intn(maxEdges)
+	if m == maxEdges {
+		m--
+	}
+	edges := make(map[[2]int]struct{})
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for len(edges) < m {
+		u := r.Intn(n) + 1
+		v := r.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if _, ok := edges[key]; ok {
+			continue
+		}
+		edges[key] = struct{}{}
+		w := r.Intn(1000) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", u, v, w)
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1508/verifierD.go
+++ b/1000-1999/1500-1599/1500-1509/1508/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1508D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(8) + 2 // 2..9
+	to := make([]int, n)
+	diff := 0
+	for i := 0; i < n; i++ {
+		to[i] = r.Intn(n) + 1
+		if to[i] != i+1 {
+			diff++
+		}
+	}
+	if diff == 0 {
+		idx := r.Intn(n)
+		val := r.Intn(n) + 1
+		for val == idx+1 {
+			val = r.Intn(n) + 1
+		}
+		to[idx] = val
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		x := r.Intn(100)
+		y := r.Intn(100)
+		fmt.Fprintf(&sb, "%d %d %d\n", x, y, to[i])
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1508/verifierE.go
+++ b/1000-1999/1500-1599/1500-1509/1508/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1508E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 2 // 2..6
+	perm := r.Perm(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", perm[i]+1)
+	}
+	sb.WriteByte('\n')
+	for i := 2; i <= n; i++ {
+		parent := r.Intn(i-1) + 1
+		fmt.Fprintf(&sb, "%d %d\n", parent, i)
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1508/verifierF.go
+++ b/1000-1999/1500-1599/1500-1509/1508/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1508F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(8) + 2 // 2..9
+	q := r.Intn(5) + 1
+	perm := r.Perm(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", perm[i]+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := r.Intn(n) + 1
+		rgt := r.Intn(n-l+1) + l
+		fmt.Fprintf(&sb, "%d %d\n", l, rgt)
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1508 problems A–F
- each verifier builds the official solution and runs 100 random tests against a candidate binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688716eda6cc8324a652c61d9c15a069