### PR TITLE
Add verifiers for contest 1505

### DIFF
--- a/1000-1999/1500-1599/1500-1509/1505/verifierA.go
+++ b/1000-1999/1500-1599/1500-1509/1505/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func solve(input string) string {
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	var out strings.Builder
+	for scanner.Scan() {
+		out.WriteString("NO\n")
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		tok := r.Intn(10) + 1
+		var sb strings.Builder
+		for j := 0; j < tok; j++ {
+			if j > 0 {
+				if r.Intn(2) == 0 {
+					sb.WriteByte(' ')
+				} else {
+					sb.WriteByte('\n')
+				}
+			}
+			l := r.Intn(5) + 1
+			for k := 0; k < l; k++ {
+				sb.WriteByte(byte('a' + r.Intn(26)))
+			}
+		}
+		sb.WriteByte('\n')
+		tests[i].input = sb.String()
+		tests[i].expect = solve(tests[i].input)
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := genTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			fmt.Println("input:")
+			fmt.Println(tc.input)
+			return
+		}
+		if got != strings.TrimSpace(tc.expect) {
+			fmt.Printf("case %d failed:\nexpected: %q\n   got: %q\n", i+1, tc.expect, got)
+			fmt.Println("input:")
+			fmt.Println(tc.input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1505/verifierB.go
+++ b/1000-1999/1500-1599/1500-1509/1505/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func solve(a int) string {
+	r := a % 9
+	if r == 0 {
+		r = 9
+	}
+	return fmt.Sprintf("%d", r)
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		a := r.Intn(1000000) + 1
+		tests[i].input = fmt.Sprintf("%d\n", a)
+		tests[i].expect = solve(a)
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := genTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			fmt.Print(tc.input)
+			return
+		}
+		if got != tc.expect {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, tc.expect, got)
+			fmt.Print(tc.input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1505/verifierC.go
+++ b/1000-1999/1500-1599/1500-1509/1505/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func solve(s string) string {
+	isPal := true
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		if s[i] != s[j] {
+			isPal = false
+			break
+		}
+	}
+	if isPal {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		l := r.Intn(10) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('A' + r.Intn(26))
+		}
+		s := string(b)
+		tests[i].input = fmt.Sprintf("%s\n", s)
+		tests[i].expect = solve(s)
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := genTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			fmt.Print(tc.input)
+			return
+		}
+		if got != tc.expect {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, tc.expect, got)
+			fmt.Print(tc.input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1505/verifierD.go
+++ b/1000-1999/1500-1599/1500-1509/1505/verifierD.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func solve(n, m int) string {
+	seen := make(map[int]bool)
+	for n > 0 {
+		d := n % m
+		if seen[d] {
+			return "NO"
+		}
+		seen[d] = true
+		n /= m
+	}
+	return "YES"
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		n := r.Intn(1024) + 1
+		m := r.Intn(15) + 2
+		tests[i].input = fmt.Sprintf("%d %d\n", n, m)
+		tests[i].expect = solve(n, m)
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := genTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			fmt.Print(tc.input)
+			return
+		}
+		if got != tc.expect {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, tc.expect, got)
+			fmt.Print(tc.input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1505/verifierE.go
+++ b/1000-1999/1500-1599/1500-1509/1505/verifierE.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func solve(H, W int, grid []string) string {
+	r, c := 0, 0
+	berries := 0
+	g := make([][]byte, H)
+	for i := range g {
+		g[i] = []byte(grid[i])
+	}
+	if g[r][c] == '*' {
+		berries++
+		g[r][c] = '.'
+	}
+	for {
+		ti, tj := -1, -1
+		best := 1 << 30
+		for i := r; i < H; i++ {
+			for j := c; j < W; j++ {
+				if g[i][j] == '*' {
+					d := (i - r) + (j - c)
+					if d < best || (d == best && (i < ti || (i == ti && j < tj))) {
+						best = d
+						ti, tj = i, j
+					}
+				}
+			}
+		}
+		if ti == -1 {
+			break
+		}
+		for r < ti {
+			r++
+			if g[r][c] == '*' {
+				berries++
+				g[r][c] = '.'
+			}
+		}
+		for c < tj {
+			c++
+			if g[r][c] == '*' {
+				berries++
+				g[r][c] = '.'
+			}
+		}
+		if g[r][c] == '*' {
+			berries++
+			g[r][c] = '.'
+		}
+	}
+	for r < H-1 {
+		r++
+		if g[r][c] == '*' {
+			berries++
+			g[r][c] = '.'
+		}
+	}
+	for c < W-1 {
+		c++
+		if g[r][c] == '*' {
+			berries++
+			g[r][c] = '.'
+		}
+	}
+	return fmt.Sprintf("%d", berries)
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		H := r.Intn(5) + 1
+		W := r.Intn(5) + 1
+		grid := make([]string, H)
+		for j := 0; j < H; j++ {
+			b := make([]byte, W)
+			for k := 0; k < W; k++ {
+				if r.Intn(2) == 0 {
+					b[k] = '.'
+				} else {
+					b[k] = '*'
+				}
+			}
+			grid[j] = string(b)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", H, W))
+		for j := 0; j < H; j++ {
+			sb.WriteString(grid[j])
+			sb.WriteByte('\n')
+		}
+		tests[i].input = sb.String()
+		tests[i].expect = solve(H, W, grid)
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := genTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			fmt.Print(tc.input)
+			return
+		}
+		if got != tc.expect {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, tc.expect, got)
+			fmt.Print(tc.input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1505/verifierF.go
+++ b/1000-1999/1500-1599/1500-1509/1505/verifierF.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func solve(a int) string {
+	if a > 0 {
+		return "1"
+	} else if a == 0 {
+		return "0"
+	}
+	return "-1"
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		a := r.Intn(201) - 100
+		tests[i].input = fmt.Sprintf("%d\n", a)
+		tests[i].expect = solve(a)
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := genTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			fmt.Print(tc.input)
+			return
+		}
+		if got != tc.expect {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, tc.expect, got)
+			fmt.Print(tc.input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1505/verifierG.go
+++ b/1000-1999/1500-1599/1500-1509/1505/verifierG.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+var enc = map[byte][5]int{
+	'a': {1, 0, 0, 1, 0},
+	'c': {2, 0, 0, 1, 1},
+	'o': {1, 1, 1, 2, 1},
+	'd': {2, 1, 0, 1, 2},
+	'e': {1, 1, 0, 1, 1},
+	'f': {2, 1, 0, 2, 1},
+	'r': {1, 2, 1, 3, 1},
+	'z': {1, 1, 2, 2, 2},
+}
+
+func decode(vals [5]int) (byte, bool) {
+	for ch, v := range enc {
+		if v == vals {
+			return ch, true
+		}
+	}
+	return '?', false
+}
+
+func solve(lines [][5]int) string {
+	var sb strings.Builder
+	for _, v := range lines {
+		ch, ok := decode(v)
+		if !ok {
+			return "?"
+		}
+		sb.WriteByte(ch)
+	}
+	return sb.String()
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	letters := []byte{'a', 'c', 'o', 'd', 'e', 'f', 'r', 'z'}
+	tests := make([]testCase, 100)
+	for i := range tests {
+		n := r.Intn(10) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		seq := make([][5]int, n)
+		for j := 0; j < n; j++ {
+			ch := letters[r.Intn(len(letters))]
+			pattern := enc[ch]
+			seq[j] = pattern
+			sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", pattern[0], pattern[1], pattern[2], pattern[3], pattern[4]))
+		}
+		tests[i].input = sb.String()
+		tests[i].expect = solve(seq)
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := genTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			fmt.Print(tc.input)
+			return
+		}
+		if got != tc.expect {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, tc.expect, got)
+			fmt.Print(tc.input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1505/verifierH.go
+++ b/1000-1999/1500-1599/1500-1509/1505/verifierH.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string) (string, error) {
+	cmd := exec.Command(bin)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	expect := "contest/171"
+	out, err := run(bin)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if out != expect {
+		fmt.Printf("expected %q got %q\n", expect, out)
+		return
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1500-1509/1505/verifierI.go
+++ b/1000-1999/1500-1599/1500-1509/1505/verifierI.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string) (string, error) {
+	cmd := exec.Command(bin)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	expect := "Seriously"
+	out, err := run(bin)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if out != expect {
+		fmt.Printf("expected %q got %q\n", expect, out)
+		return
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1505 problems A–I

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`


------
https://chatgpt.com/codex/tasks/task_e_6887161b8fb48324b687c76adae32626