### PR TITLE
Add verifiers for Codeforces contest 1513

### DIFF
--- a/1000-1999/1500-1599/1510-1519/1513/verifierA.go
+++ b/1000-1999/1500-1599/1510-1519/1513/verifierA.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct{ n, k int }
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTest(rng *rand.Rand) (string, []testCase) {
+	t := rng.Intn(20) + 1
+	cases := make([]testCase, t)
+	var sb strings.Builder
+	fmt.Fprintln(&sb, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(100) + 1
+		k := rng.Intn(n + 1)
+		cases[i] = testCase{n, k}
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+	}
+	return sb.String(), cases
+}
+
+func checkCase(n, k int, line string) error {
+	line = strings.TrimSpace(line)
+	if n <= 2*k {
+		if line != "-1" {
+			return fmt.Errorf("expected -1")
+		}
+		return nil
+	}
+	fields := strings.Fields(line)
+	if len(fields) != n {
+		return fmt.Errorf("expected %d numbers got %d", n, len(fields))
+	}
+	used := make([]bool, n+1)
+	arr := make([]int, n)
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("not integer: %v", err)
+		}
+		if v < 1 || v > n || used[v] {
+			return fmt.Errorf("not a permutation")
+		}
+		used[v] = true
+		arr[i] = v
+	}
+	peaks := 0
+	for i := 1; i < n-1; i++ {
+		if arr[i] > arr[i-1] && arr[i] > arr[i+1] {
+			peaks++
+		}
+	}
+	if peaks != k {
+		return fmt.Errorf("expected %d peaks got %d", k, peaks)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate, _ := filepath.Abs(os.Args[1])
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, cases := genTest(rng)
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) != len(cases) {
+			fmt.Printf("test %d: expected %d lines got %d\ninput:\n%s\n", i+1, len(cases), len(lines), input)
+			os.Exit(1)
+		}
+		for j, cs := range cases {
+			if err := checkCase(cs.n, cs.k, lines[j]); err != nil {
+				fmt.Printf("test %d case %d failed: %v\ninput:\n%s\n", i+1, j+1, err, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1500-1599/1510-1519/1513/verifierB.go
+++ b/1000-1999/1500-1599/1510-1519/1513/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef(src string) (string, error) {
+	tmp, err := os.CreateTemp("", "refB-")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTest(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintln(&sb, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(10) + 2
+		fmt.Fprintln(&sb, n)
+		arr := make([]string, n)
+		for j := 0; j < n; j++ {
+			arr[j] = fmt.Sprintf("%d", rng.Intn(1000000000))
+		}
+		fmt.Fprintln(&sb, strings.Join(arr, " "))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate, _ := filepath.Abs(os.Args[1])
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	ref, err := compileRef("1513B.go")
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		expOut, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		gotOut, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, strings.TrimSpace(expOut), strings.TrimSpace(gotOut))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1500-1599/1510-1519/1513/verifierC.go
+++ b/1000-1999/1500-1599/1510-1519/1513/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef(src string) (string, error) {
+	tmp, err := os.CreateTemp("", "refC-")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTest(rng *rand.Rand) string {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintln(&sb, t)
+	for i := 0; i < t; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		m := rng.Intn(200000) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate, _ := filepath.Abs(os.Args[1])
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	ref, err := compileRef("1513C.go")
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		expOut, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		gotOut, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, strings.TrimSpace(expOut), strings.TrimSpace(gotOut))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1500-1599/1510-1519/1513/verifierD.go
+++ b/1000-1999/1500-1599/1510-1519/1513/verifierD.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef(src string) (string, error) {
+	tmp, err := os.CreateTemp("", "refD-")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTest(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintln(&sb, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(50) + 2
+		p := rng.Intn(1000) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, p)
+		vals := make([]string, n)
+		for j := 0; j < n; j++ {
+			vals[j] = fmt.Sprintf("%d", rng.Intn(1000)+1)
+		}
+		fmt.Fprintln(&sb, strings.Join(vals, " "))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate, _ := filepath.Abs(os.Args[1])
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	ref, err := compileRef("1513D.go")
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		expOut, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		gotOut, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, strings.TrimSpace(expOut), strings.TrimSpace(gotOut))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1500-1599/1510-1519/1513/verifierE.go
+++ b/1000-1999/1500-1599/1510-1519/1513/verifierE.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef(src string) (string, error) {
+	tmp, err := os.CreateTemp("", "refE-")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintln(&sb, n)
+	vals := make([]string, n)
+	for i := 0; i < n; i++ {
+		vals[i] = fmt.Sprintf("%d", rng.Intn(100))
+	}
+	fmt.Fprintln(&sb, strings.Join(vals, " "))
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate, _ := filepath.Abs(os.Args[1])
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	ref, err := compileRef("1513E.go")
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		expOut, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		gotOut, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, strings.TrimSpace(expOut), strings.TrimSpace(gotOut))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1500-1599/1510-1519/1513/verifierF.go
+++ b/1000-1999/1500-1599/1510-1519/1513/verifierF.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef(src string) (string, error) {
+	tmp, err := os.CreateTemp("", "refF-")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	var sb strings.Builder
+	fmt.Fprintln(&sb, n)
+	a := make([]string, n)
+	b := make([]string, n)
+	for i := 0; i < n; i++ {
+		a[i] = fmt.Sprintf("%d", rng.Intn(1000)+1)
+	}
+	for i := 0; i < n; i++ {
+		b[i] = fmt.Sprintf("%d", rng.Intn(1000)+1)
+	}
+	fmt.Fprintln(&sb, strings.Join(a, " "))
+	fmt.Fprintln(&sb, strings.Join(b, " "))
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate, _ := filepath.Abs(os.Args[1])
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	ref, err := compileRef("1513F.go")
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		expOut, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		gotOut, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, strings.TrimSpace(expOut), strings.TrimSpace(gotOut))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1513
- verifiers generate 100 random test cases each and compare to the reference solutions
- problem A verifier checks permutation validity and peak count directly

## Testing
- `go build verifierA.go`

------
https://chatgpt.com/codex/tasks/task_e_6887184cef5c8324bd305a84e29af744