### PR TITLE
Add Go verifiers for contest 1511

### DIFF
--- a/1000-1999/1500-1599/1510-1519/1511/verifierA.go
+++ b/1000-1999/1500-1599/1510-1519/1511/verifierA.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), fmt.Sprintf("refA_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", out, "1511A.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]string, 0, 100)
+	tests = append(tests, "1\n1\n1\n")
+	tests = append(tests, "1\n3\n1 2 3\n")
+	tests = append(tests, "1\n5\n1 1 1 1 1\n")
+	tests = append(tests, "1\n5\n2 2 2 2 2\n")
+	for len(tests) < 100 {
+		n := rng.Intn(50) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(3)+1))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(candidate, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1510-1519/1511/verifierB.go
+++ b/1000-1999/1500-1599/1510-1519/1511/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), fmt.Sprintf("refB_%d", time.Now().UnixNano()))
+	cmd := exec.Command("g++", "-std=c++17", "-O2", "solB.cpp", "-o", out)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]string, 0, 100)
+	tests = append(tests, "1\n1 1 1\n")
+	tests = append(tests, "1\n2 3 1\n")
+	tests = append(tests, "1\n9 9 9\n")
+	tests = append(tests, "1\n5 6 3\n")
+	for len(tests) < 100 {
+		a := rng.Intn(9) + 1
+		b := rng.Intn(9) + 1
+		c := rng.Intn(min(a, b)) + 1
+		tests = append(tests, fmt.Sprintf("1\n%d %d %d\n", a, b, c))
+	}
+	return tests
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(candidate, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1510-1519/1511/verifierC.go
+++ b/1000-1999/1500-1599/1510-1519/1511/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), fmt.Sprintf("refC_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", out, "1511C.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]string, 0, 100)
+	tests = append(tests, "3 3\n1 2 3\n1 2 3\n")
+	tests = append(tests, "1 1\n5\n5\n")
+	for len(tests) < 100 {
+		n := rng.Intn(50) + 1
+		q := rng.Intn(50) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(50)+1))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < q; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(50)+1))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(candidate, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1510-1519/1511/verifierD.go
+++ b/1000-1999/1500-1599/1510-1519/1511/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), fmt.Sprintf("refD_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", out, "1511D.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]string, 0, 100)
+	tests = append(tests, "1 1\n")
+	tests = append(tests, "5 2\n")
+	tests = append(tests, "10 3\n")
+	for len(tests) < 100 {
+		n := rng.Intn(50) + 1
+		k := rng.Intn(5) + 1
+		tests = append(tests, fmt.Sprintf("%d %d\n", n, k))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(candidate, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1510-1519/1511/verifierE.go
+++ b/1000-1999/1500-1599/1510-1519/1511/verifierE.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), fmt.Sprintf("refE_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", out, "1511E.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]string, 0, 100)
+	tests = append(tests, "1 1\no\n")
+	tests = append(tests, "2 2\noo\n..\n")
+	for len(tests) < 100 {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				if rng.Intn(2) == 0 {
+					sb.WriteByte('o')
+				} else {
+					sb.WriteByte('.')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(candidate, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1510-1519/1511/verifierF.go
+++ b/1000-1999/1500-1599/1510-1519/1511/verifierF.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), fmt.Sprintf("refF_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", out, "1511F.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]string, 0, 100)
+	tests = append(tests, "1 1\na\n")
+	tests = append(tests, "2 2\na b\n")
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		m := int64(rng.Intn(6) + 1)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			length := rng.Intn(3) + 1
+			word := make([]byte, length)
+			for j := 0; j < length; j++ {
+				word[j] = byte('a' + rng.Intn(3))
+			}
+			sb.WriteString(string(word))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(candidate, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1510-1519/1511/verifierG.go
+++ b/1000-1999/1500-1599/1510-1519/1511/verifierG.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), fmt.Sprintf("refG_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", out, "1511G.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]string, 0, 100)
+	tests = append(tests, "1 1\n1\n1\n1 1\n")
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(m)+1))
+		}
+		sb.WriteByte('\n')
+		q := rng.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", q))
+		for i := 0; i < q; i++ {
+			l := rng.Intn(m) + 1
+			r := rng.Intn(m-l+1) + l
+			sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(candidate, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, t)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 1511
- verifiers build the reference solution and compare output with a candidate binary
- each verifier generates at least 100 tests with random cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_688717bfc34c8324a7bb8c793f7abadb