### PR TITLE
Add Go solution verifiers for CF 1527

### DIFF
--- a/1000-1999/1500-1599/1520-1529/1527/verifierA.go
+++ b/1000-1999/1500-1599/1520-1529/1527/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1527A.go")
+	bin := filepath.Join(os.TempDir(), "ref1527A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return out.Bytes(), nil
+}
+
+type Case struct {
+	input []byte
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 0, 102)
+	// deterministic simple case
+	{
+		var sb strings.Builder
+		sb.WriteString("10\n")
+		nums := []int{1, 2, 3, 4, 5, 6, 7, 8, 15, 1000000000}
+		for _, v := range nums {
+			fmt.Fprintf(&sb, "%d\n", v)
+		}
+		cases = append(cases, Case{[]byte(sb.String())})
+	}
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(10) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Int63n(1_000_000_000) + 1
+			fmt.Fprintf(&sb, "%d\n", n)
+		}
+		cases = append(cases, Case{[]byte(sb.String())})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runBinary(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+			fmt.Printf("wrong answer on case %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, string(c.input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1527/verifierB1.go
+++ b/1000-1999/1500-1599/1520-1529/1527/verifierB1.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1527B1.go")
+	bin := filepath.Join(os.TempDir(), "ref1527B1.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return out.Bytes(), nil
+}
+
+type Case struct{ input []byte }
+
+func genPalin(n int, rng *rand.Rand) string {
+	b := make([]byte, n)
+	for i := 0; i < (n+1)/2; i++ {
+		bit := byte('0' + rng.Intn(2))
+		b[i] = bit
+		b[n-1-i] = bit
+	}
+	hasZero := false
+	for i := 0; i < n; i++ {
+		if b[i] == '0' {
+			hasZero = true
+			break
+		}
+	}
+	if !hasZero {
+		pos := rng.Intn(n)
+		b[pos] = '0'
+		b[n-1-pos] = '0'
+	}
+	return string(b)
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 0, 101)
+	// simple deterministic case
+	{
+		var sb strings.Builder
+		sb.WriteString("1\n1\n0\n")
+		cases = append(cases, Case{[]byte(sb.String())})
+	}
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Intn(10) + 1
+			s := genPalin(n, rng)
+			fmt.Fprintf(&sb, "%d\n%s\n", n, s)
+		}
+		cases = append(cases, Case{[]byte(sb.String())})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runBinary(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+			fmt.Printf("wrong answer on case %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, string(c.input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1527/verifierB2.go
+++ b/1000-1999/1500-1599/1520-1529/1527/verifierB2.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1527B2.go")
+	bin := filepath.Join(os.TempDir(), "ref1527B2.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return out.Bytes(), nil
+}
+
+type Case struct{ input []byte }
+
+func genString(n int, rng *rand.Rand) string {
+	b := make([]byte, n)
+	hasZero := false
+	for i := 0; i < n; i++ {
+		bit := byte('0' + rng.Intn(2))
+		if bit == '0' {
+			hasZero = true
+		}
+		b[i] = bit
+	}
+	if !hasZero {
+		pos := rng.Intn(n)
+		b[pos] = '0'
+	}
+	return string(b)
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 0, 101)
+	// simple deterministic case
+	{
+		cases = append(cases, Case{[]byte("1\n1\n0\n")})
+	}
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Intn(10) + 1
+			s := genString(n, rng)
+			fmt.Fprintf(&sb, "%d\n%s\n", n, s)
+		}
+		cases = append(cases, Case{[]byte(sb.String())})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runBinary(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+			fmt.Printf("wrong answer on case %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, string(c.input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1527/verifierC.go
+++ b/1000-1999/1500-1599/1520-1529/1527/verifierC.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1527C.go")
+	bin := filepath.Join(os.TempDir(), "ref1527C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return out.Bytes(), nil
+}
+
+type Case struct{ input []byte }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 0, 101)
+	// simple deterministic case
+	{
+		cases = append(cases, Case{[]byte("1\n4\n1 2 1 1\n")})
+	}
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Intn(20) + 1
+			fmt.Fprintf(&sb, "%d\n", n)
+			for k := 0; k < n; k++ {
+				if k > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprintf(&sb, "%d", rng.Intn(10)+1)
+			}
+			sb.WriteByte('\n')
+		}
+		cases = append(cases, Case{[]byte(sb.String())})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runBinary(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+			fmt.Printf("wrong answer on case %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, string(c.input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1527/verifierD.go
+++ b/1000-1999/1500-1599/1520-1529/1527/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1527D.go")
+	bin := filepath.Join(os.TempDir(), "ref1527D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return out.Bytes(), nil
+}
+
+type Case struct{ input []byte }
+
+func genTree(n int, rng *rand.Rand) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		fmt.Fprintf(&sb, "%d %d\n", p, i)
+	}
+	return sb.String()
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 0, 101)
+	// simple deterministic case with 2 nodes
+	cases = append(cases, Case{[]byte("1\n2\n0 1\n")})
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 2 // 2..7
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(genTree(n, rng))
+		cases = append(cases, Case{[]byte(sb.String())})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runBinary(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+			fmt.Printf("wrong answer on case %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, string(c.input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1527/verifierE.go
+++ b/1000-1999/1500-1599/1520-1529/1527/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1527E.go")
+	bin := filepath.Join(os.TempDir(), "ref1527E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return out.Bytes(), nil
+}
+
+type Case struct{ input []byte }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 0, 101)
+	// simple deterministic case
+	{
+		cases = append(cases, Case{[]byte("4 2\n1 6 6 4\n")})
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		k := rng.Intn(n) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(6)+1)
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{[]byte(sb.String())})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runBinary(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+			fmt.Printf("wrong answer on case %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, string(c.input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go, verifierB1.go, verifierB2.go, verifierC.go, verifierD.go, verifierE.go in contest 1527 folder
- each verifier builds reference solution, generates 100+ random tests and checks a given binary

## Testing
- `go run verifierA.go ./solA.bin`

------
https://chatgpt.com/codex/tasks/task_e_68871c20592c8324b4bbc7f0d7c4398d