### PR TITLE
Add Go verifiers for contest 1523

### DIFF
--- a/1000-1999/1500-1599/1520-1529/1523/verifierA.go
+++ b/1000-1999/1500-1599/1520-1529/1523/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsA = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candA")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleA")
+	cmd := exec.Command("go", "build", "-o", tmp, "1523A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(19) + 2 // 2..20
+	m := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return fmt.Sprintf("1\n%d %d\n%s\n", n, m, string(b))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+
+	rng := rand.New(rand.NewSource(0))
+	for i := 0; i < numTestsA; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1523/verifierB.go
+++ b/1000-1999/1500-1599/1520-1529/1523/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsB = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candB")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleB")
+	cmd := exec.Command("go", "build", "-o", tmp, "1523B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10)*2 + 2 // even 2..20
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(21) - 10
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < numTestsB; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1523/verifierC.go
+++ b/1000-1999/1500-1599/1520-1529/1523/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsC = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candC")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleC")
+	cmd := exec.Command("go", "build", "-o", tmp, "1523C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	stack := []int{1}
+	nums := []int{1}
+	for i := 1; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			stack = append(stack, 1)
+			nums = append(nums, 1)
+		} else {
+			if len(stack) > 1 {
+				pop := rng.Intn(len(stack) - 1)
+				stack = stack[:len(stack)-pop]
+			}
+			stack[len(stack)-1]++
+			nums = append(nums, stack[len(stack)-1])
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < numTestsC; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1523/verifierD.go
+++ b/1000-1999/1500-1599/1520-1529/1523/verifierD.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const numTestsD = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candD")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleD")
+	cmd := exec.Command("go", "build", "-o", tmp, "1523D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(10) + 1
+	p := rng.Intn(m) + 1
+	lines := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		ones := rng.Intn(p + 1)
+		idx := rng.Perm(m)[:ones]
+		for _, x := range idx {
+			b[x] = '1'
+		}
+		for j := 0; j < m; j++ {
+			if b[j] == 0 {
+				b[j] = '0'
+			}
+		}
+		lines[i] = string(b)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, p))
+	for _, s := range lines {
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func parseInput(input string) (n, m int, grid []string) {
+	sc := bufio.NewScanner(strings.NewReader(input))
+	sc.Split(bufio.ScanWords)
+	sc.Scan()
+	n, _ = strconv.Atoi(sc.Text())
+	sc.Scan()
+	m, _ = strconv.Atoi(sc.Text())
+	sc.Scan() // skip p
+	grid = make([]string, n)
+	for i := 0; i < n; i++ {
+		sc.Scan()
+		grid[i] = sc.Text()
+	}
+	return
+}
+
+func checkCase(input, want, got string) error {
+	n, m, grid := parseInput(input)
+	if len(got) != m {
+		return fmt.Errorf("output length %d expected %d", len(got), m)
+	}
+	onesWant := strings.Count(want, "1")
+	onesGot := strings.Count(got, "1")
+	if onesGot != onesWant {
+		return fmt.Errorf("expected %d ones, got %d", onesWant, onesGot)
+	}
+	half := (n + 1) / 2
+	for j := 0; j < m; j++ {
+		if got[j] == '1' {
+			cnt := 0
+			for i := 0; i < n; i++ {
+				if grid[i][j] == '1' {
+					cnt++
+				}
+			}
+			if cnt < half {
+				return fmt.Errorf("bit %d liked by %d < %d", j+1, cnt, half)
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < numTestsD; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if err := checkCase(input, want, got); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, err, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1523/verifierE.go
+++ b/1000-1999/1500-1599/1520-1529/1523/verifierE.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsE = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candE")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleE")
+	cmd := exec.Command("go", "build", "-o", tmp, "1523E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(50) + 1
+	k := rng.Intn(n) + 1
+	return fmt.Sprintf("1\n%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < numTestsE; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1523/verifierF.go
+++ b/1000-1999/1500-1599/1520-1529/1523/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsF = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candF")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleF")
+	cmd := exec.Command("go", "build", "-o", tmp, "1523F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) // 0..4
+	m := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(10) + 1
+		y := rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	for j := 0; j < m; j++ {
+		x := rng.Intn(10) + 1
+		y := rng.Intn(10) + 1
+		t := rng.Intn(20) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", x, y, t))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+
+	rng := rand.New(rand.NewSource(5))
+	for i := 0; i < numTestsF; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1523/verifierG.go
+++ b/1000-1999/1500-1599/1520-1529/1523/verifierG.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsG = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candG")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleG")
+	cmd := exec.Command("go", "build", "-o", tmp, "1523G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+
+	rng := rand.New(rand.NewSource(6))
+	for i := 0; i < numTestsG; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1523/verifierH.go
+++ b/1000-1999/1500-1599/1520-1529/1523/verifierH.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsH = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "candH")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func buildOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleH")
+	cmd := exec.Command("go", "build", "-o", tmp, "1523H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	q := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		maxk := min(30, r-l)
+		var k int
+		if maxk > 0 {
+			k = rng.Intn(maxk + 1)
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", l, r, k))
+	}
+	return sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, c2, err := buildOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer c2()
+
+	rng := rand.New(rand.NewSource(7))
+	for i := 0; i < numTestsH; i++ {
+		input := genCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go – compile candidate and reference solution and compare on 100 random tests
- add verifierB.go – similar setup for problem B
- add verifierC.go – generate valid sequences for problem C
- add verifierD.go – custom checker ensures candidate output is maximal
- add verifierE.go – verifies combinatorial results
- add verifierF.go – handles pathfinding problem
- add verifierG.go – tests interval algorithm
- add verifierH.go – verifies queries for final problem

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_68871b0836248324a453e7cc2b8a30da