### PR TITLE
Add verifiers for contest 1529

### DIFF
--- a/1000-1999/1500-1599/1520-1529/1529/verifierA.go
+++ b/1000-1999/1500-1599/1520-1529/1529/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(arr []int) int {
+	minVal := arr[0]
+	for _, v := range arr {
+		if v < minVal {
+			minVal = v
+		}
+	}
+	cnt := 0
+	for _, v := range arr {
+		if v > minVal {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(arr)
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1529/verifierB.go
+++ b/1000-1999/1500-1599/1520-1529/1529/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(arr []int) int {
+	sort.Ints(arr)
+	nonPos := make([]int, 0)
+	posMin := math.MaxInt32
+	for _, v := range arr {
+		if v <= 0 {
+			nonPos = append(nonPos, v)
+		} else if v < posMin {
+			posMin = v
+		}
+	}
+	minDiff := math.MaxInt32
+	for i := 1; i < len(nonPos); i++ {
+		diff := nonPos[i] - nonPos[i-1]
+		if diff < minDiff {
+			minDiff = diff
+		}
+	}
+	ans := len(nonPos)
+	if len(nonPos) <= 1 {
+		minDiff = math.MaxInt32
+	}
+	if posMin != math.MaxInt32 && posMin <= minDiff {
+		ans++
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(2000000001) - 1000000000
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(arr)
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` and `verifierB.go` for contest 1529
- each verifier generates 100 randomized tests and checks any binary

## Testing
- `go run verifierA.go -- 1529A.go`
- `go run verifierB.go -- 1529B.go`


------
https://chatgpt.com/codex/tasks/task_e_68871cac71048324b778d5e26bbe1295