### PR TITLE
Add solution verifiers for contest 1528

### DIFF
--- a/1000-1999/1500-1599/1520-1529/1528/verifierA.go
+++ b/1000-1999/1500-1599/1520-1529/1528/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 2 // 2..6
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 1; i <= n; i++ {
+		l := rand.Intn(50) + 1
+		r := l + rand.Intn(50)
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+	}
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		fmt.Fprintf(&sb, "%d %d\n", i, p)
+	}
+	return sb.String()
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	// build reference solution
+	ref := "refA.bin"
+	if out, err := exec.Command("go", "build", "-o", ref, "1528A.go").CombinedOutput(); err != nil {
+		fmt.Println("failed to build reference:", string(out))
+		return
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		input := genTest()
+		expect, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Println("reference run error on test", i, err)
+			return
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Println("candidate run error on test", i, err)
+			return
+		}
+		if expect != got {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, input, expect, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1528/verifierB.go
+++ b/1000-1999/1500-1599/1520-1529/1528/verifierB.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(1000) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref := "refB.bin"
+	if out, err := exec.Command("go", "build", "-o", ref, "1528B.go").CombinedOutput(); err != nil {
+		fmt.Println("failed to build reference:", string(out))
+		return
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		input := genTest()
+		expect, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Println("reference run error on test", i, err)
+			return
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Println("candidate run error on test", i, err)
+			return
+		}
+		if expect != got {
+			fmt.Printf("mismatch on test %d\ninput:%sexpected:%s\ngot:%s\n", i, input, expect, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1528/verifierC.go
+++ b/1000-1999/1500-1599/1520-1529/1528/verifierC.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(6) + 2 // 2..7
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 2; i <= n; i++ {
+		parent := rand.Intn(i-1) + 1
+		fmt.Fprintf(&sb, "%d ", parent)
+	}
+	sb.WriteByte('\n')
+	for i := 2; i <= n; i++ {
+		parent := rand.Intn(i-1) + 1
+		fmt.Fprintf(&sb, "%d ", parent)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref := "refC.bin"
+	if out, err := exec.Command("go", "build", "-o", ref, "1528C.go").CombinedOutput(); err != nil {
+		fmt.Println("failed to build reference:", string(out))
+		return
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		input := genTest()
+		expect, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Println("reference run error on test", i, err)
+			return
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Println("candidate run error on test", i, err)
+			return
+		}
+		if expect != got {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, input, expect, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1528/verifierD.go
+++ b/1000-1999/1500-1599/1520-1529/1528/verifierD.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(3) + 2 // 2..4
+	m := n
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		used := make(map[int]bool)
+		b := rand.Intn(n)
+		used[b] = true
+		c := rand.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", i, b, c)
+	}
+	return sb.String()
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref := "refD.bin"
+	if out, err := exec.Command("go", "build", "-o", ref, "1528D.go").CombinedOutput(); err != nil {
+		fmt.Println("failed to build reference:", string(out))
+		return
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		input := genTest()
+		expect, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Println("reference run error on test", i, err)
+			return
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Println("candidate run error on test", i, err)
+			return
+		}
+		if expect != got {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, input, expect, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1528/verifierE.go
+++ b/1000-1999/1500-1599/1520-1529/1528/verifierE.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(20) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref := "refE.bin"
+	if out, err := exec.Command("go", "build", "-o", ref, "1528E.go").CombinedOutput(); err != nil {
+		fmt.Println("failed to build reference:", string(out))
+		return
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		input := genTest()
+		expect, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Println("reference run error on test", i, err)
+			return
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Println("candidate run error on test", i, err)
+			return
+		}
+		if expect != got {
+			fmt.Printf("mismatch on test %d\ninput:%sexpected:%s\ngot:%s\n", i, input, expect, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1520-1529/1528/verifierF.go
+++ b/1000-1999/1500-1599/1520-1529/1528/verifierF.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(20) + 1
+	k := rand.Intn(10) + 1
+	return fmt.Sprintf("%d %d\n", n, k)
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref := "refF.bin"
+	if out, err := exec.Command("go", "build", "-o", ref, "1528F.go").CombinedOutput(); err != nil {
+		fmt.Println("failed to build reference:", string(out))
+		return
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		input := genTest()
+		expect, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Println("reference run error on test", i, err)
+			return
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Println("candidate run error on test", i, err)
+			return
+		}
+		if expect != got {
+			fmt.Printf("mismatch on test %d\ninput:%sexpected:%s\ngot:%s\n", i, input, expect, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verification scripts for problems A–F of contest 1528
- each verifier builds a reference solution and compares another binary against 100 randomized tests

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68871c6668448324add0b02473207f04