### PR TITLE
Add verifiers for contest 1531

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1531/verifierA.go
+++ b/1000-1999/1500-1599/1530-1539/1531/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleA")
+	src := filepath.Join(dir, "1531A.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	ops := []string{"lock", "unlock", "red", "orange", "yellow", "green", "blue", "indigo", "violet"}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(ops[rng.Intn(len(ops))])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(cand, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1531/verifierB1.go
+++ b/1000-1999/1500-1599/1530-1539/1531/verifierB1.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleB1")
+	src := filepath.Join(dir, "1531B1.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		w := rng.Intn(100) + 1
+		h := rng.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", w, h))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB1.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(cand, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1531/verifierB2.go
+++ b/1000-1999/1500-1599/1530-1539/1531/verifierB2.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleB2")
+	src := filepath.Join(dir, "1531B2.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(200) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		w := rng.Intn(1000) + 1
+		h := rng.Intn(1000) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", w, h))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB2.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(cand, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1531/verifierC.go
+++ b/1000-1999/1500-1599/1530-1539/1531/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleC")
+	src := filepath.Join(dir, "1531C.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(cand, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1531/verifierD.go
+++ b/1000-1999/1500-1599/1530-1539/1531/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleD")
+	src := filepath.Join(dir, "1531D.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	ops := []string{"lock", "unlock", "red", "orange", "yellow", "green", "blue", "indigo", "violet"}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(ops[rng.Intn(len(ops))])
+		sb.WriteByte('\n')
+	}
+	t := rng.Intn(20)
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		idx := rng.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %s\n", idx, ops[rng.Intn(len(ops))]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(cand, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1531/verifierE1.go
+++ b/1000-1999/1500-1599/1530-1539/1531/verifierE1.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleE1")
+	src := filepath.Join(dir, "1531E1.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	length := rng.Intn(30) + 1
+	var sb strings.Builder
+	for i := 0; i < length; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(cand, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1531/verifierE2.go
+++ b/1000-1999/1500-1599/1530-1539/1531/verifierE2.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleE2")
+	src := filepath.Join(dir, "1531E2.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	length := rng.Intn(50) + 1
+	var sb strings.Builder
+	for i := 0; i < length; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(cand, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1531/verifierE3.go
+++ b/1000-1999/1500-1599/1530-1539/1531/verifierE3.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleE3")
+	src := filepath.Join(dir, "1531E3.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	length := rng.Intn(30) + 1
+	var sb strings.Builder
+	for i := 0; i < length; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE3.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(cand, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A through E3 of contest 1531
- each verifier generates 100 random tests and compares against the official solution

## Testing
- `go build verifierA.go verifierB1.go verifierB2.go verifierC.go verifierD.go verifierE1.go verifierE2.go verifierE3.go`


------
https://chatgpt.com/codex/tasks/task_e_68871d38b9f88324888f2d7079eac23f