### PR TITLE
Add Go solution verifiers for contest 1530

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1530/verifierA.go
+++ b/1000-1999/1500-1599/1530-1539/1530/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testA struct{ n int }
+
+func genTestsA() []testA {
+	rand.Seed(1530001)
+	tests := make([]testA, 100)
+	for i := range tests {
+		tests[i].n = rand.Intn(1_000_000_000) + 1
+	}
+	return tests
+}
+
+func solveA(tc testA) int {
+	n := tc.n
+	maxD := 0
+	for n > 0 {
+		d := n % 10
+		if d > maxD {
+			maxD = d
+		}
+		n /= 10
+	}
+	return maxD
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+	}
+
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveA(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\n%s\n", err, stderr.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil || val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1500-1599/1530-1539/1530/verifierB.go
+++ b/1000-1999/1500-1599/1530-1539/1530/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testB struct{ h, w int }
+
+func genTestsB() []testB {
+	rand.Seed(1530002)
+	tests := make([]testB, 100)
+	for i := range tests {
+		tests[i].h = rand.Intn(18) + 3 // 3..20
+		tests[i].w = rand.Intn(18) + 3
+	}
+	return tests
+}
+
+func solveB(tc testB) []string {
+	h, w := tc.h, tc.w
+	grid := make([]string, h)
+	var sb strings.Builder
+	for i := 0; i < h; i++ {
+		sb.Reset()
+		for j := 0; j < w; j++ {
+			var val byte
+			if (i == 0 || i == h-1) && (j == 0 || j == w-1) {
+				val = '1'
+			} else if i == 0 || i == h-1 {
+				if j == 1 || j == w-2 {
+					val = '0'
+				} else if j%2 == 0 {
+					val = '1'
+				} else {
+					val = '0'
+				}
+			} else if j == 0 || j == w-1 {
+				if i == 1 || i == h-2 {
+					val = '0'
+				} else if i%2 == 0 {
+					val = '1'
+				} else {
+					val = '0'
+				}
+			} else {
+				val = '0'
+			}
+			sb.WriteByte(val)
+		}
+		grid[i] = sb.String()
+	}
+	return grid
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.h, tc.w)
+	}
+
+	var expected bytes.Buffer
+	for _, tc := range tests {
+		grid := solveB(tc)
+		for _, row := range grid {
+			expected.WriteString(row)
+			expected.WriteByte('\n')
+		}
+		expected.WriteByte('\n')
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\n%s\n", err, stderr.String())
+		os.Exit(1)
+	}
+
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(expected.String())
+	if got != want {
+		fmt.Fprintln(os.Stderr, "wrong answer")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1500-1599/1530-1539/1530/verifierC.go
+++ b/1000-1999/1500-1599/1530-1539/1530/verifierC.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+)
+
+type testC struct {
+	n    int
+	a, b []int
+}
+
+func genTestsC() []testC {
+	rand.Seed(1530003)
+	tests := make([]testC, 100)
+	for i := range tests {
+		n := rand.Intn(9) + 1 // 1..10
+		a := make([]int, n)
+		b := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rand.Intn(101)
+		}
+		for j := 0; j < n; j++ {
+			b[j] = rand.Intn(101)
+		}
+		tests[i] = testC{n: n, a: a, b: b}
+	}
+	return tests
+}
+
+func solveC(tc testC) int {
+	n := tc.n
+	a := append([]int(nil), tc.a...)
+	b := append([]int(nil), tc.b...)
+	sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+	sort.Slice(b, func(i, j int) bool { return b[i] > b[j] })
+	prefA := make([]int, n+1)
+	prefB := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		prefA[i+1] = prefA[i] + a[i]
+		prefB[i+1] = prefB[i] + b[i]
+	}
+	extra := 0
+	for {
+		k := n + extra
+		take := k - k/4
+		var sumA int
+		if take <= extra {
+			sumA = take * 100
+		} else {
+			rem := take - extra
+			if rem > n {
+				rem = n
+			}
+			sumA = extra*100 + prefA[rem]
+		}
+		var sumB int
+		if take > n {
+			sumB = prefB[n]
+		} else {
+			sumB = prefB[take]
+		}
+		if sumA >= sumB {
+			return extra
+		}
+		extra++
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		for i, v := range tc.b {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveC(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\n%s\n", err, stderr.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil || val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1500-1599/1530-1539/1530/verifierD.go
+++ b/1000-1999/1500-1599/1530-1539/1530/verifierD.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testD struct {
+	n int
+	a []int
+}
+
+func genTestsD() []testD {
+	rand.Seed(1530004)
+	tests := make([]testD, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		a := make([]int, n+1)
+		for j := 1; j <= n; j++ {
+			a[j] = rand.Intn(n) + 1
+		}
+		tests[i] = testD{n: n, a: a}
+	}
+	return tests
+}
+
+func solveD(tc testD) (int, []int) {
+	n := tc.n
+	a := tc.a
+	ans := make([]int, n+1)
+	vis := make([]bool, n+1)
+	matched := 0
+	for i := 1; i <= n; i++ {
+		if !vis[a[i]] {
+			vis[a[i]] = true
+			ans[i] = a[i]
+			matched++
+		}
+	}
+	st := make([]int, 0, n)
+	for i := n; i >= 1; i-- {
+		if !vis[i] {
+			st = append(st, i)
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if ans[i] == 0 {
+			last := st[len(st)-1]
+			st = st[:len(st)-1]
+			ans[i] = last
+		}
+	}
+	las := 0
+	for i := 1; i <= n; i++ {
+		if ans[i] == i {
+			if las == 0 {
+				las = i
+			} else {
+				ans[i], ans[las] = ans[las], ans[i]
+			}
+		}
+	}
+	if las != 0 {
+		for i := 1; i <= n; i++ {
+			if a[i] == a[las] {
+				ans[i], ans[las] = ans[las], ans[i]
+				break
+			}
+		}
+	}
+	res := make([]int, n)
+	for i := 1; i <= n; i++ {
+		res[i-1] = ans[i]
+	}
+	return matched, res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for j := 1; j <= tc.n; j++ {
+			if j > 1 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, tc.a[j])
+		}
+		input.WriteByte('\n')
+	}
+
+	expMatch := make([]int, len(tests))
+	expAns := make([][]int, len(tests))
+	for i, tc := range tests {
+		m, arr := solveD(tc)
+		expMatch[i] = m
+		expAns[i] = arr
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\n%s\n", err, stderr.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil || val != expMatch[i] {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+		for j := 0; j < tests[i].n; j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			v, err := strconv.Atoi(scanner.Text())
+			if err != nil || v != expAns[i][j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1500-1599/1530-1539/1530/verifierE.go
+++ b/1000-1999/1500-1599/1530-1539/1530/verifierE.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testE struct{ s string }
+
+func genTestsE() []testE {
+	rand.Seed(1530005)
+	tests := make([]testE, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			b[j] = byte('a' + rand.Intn(26))
+		}
+		tests[i].s = string(b)
+	}
+	return tests
+}
+
+func solveE(tc testE) string {
+	s := tc.s
+	freq := make([]int, 26)
+	for i := 0; i < len(s); i++ {
+		freq[s[i]-'a']++
+	}
+	distinct := 0
+	for i := 0; i < 26; i++ {
+		if freq[i] > 0 {
+			distinct++
+		}
+	}
+	if distinct == 1 {
+		return s
+	}
+	unique := -1
+	for i := 0; i < 26; i++ {
+		if freq[i] == 1 {
+			unique = i
+			break
+		}
+	}
+	if unique != -1 {
+		var b strings.Builder
+		b.WriteByte(byte('a' + unique))
+		freq[unique]--
+		for i := 0; i < 26; i++ {
+			for freq[i] > 0 {
+				b.WriteByte(byte('a' + i))
+				freq[i]--
+			}
+		}
+		return b.String()
+	}
+	first := 0
+	for freq[first] == 0 {
+		first++
+	}
+	n := len(s)
+	cntFirst := freq[first]
+	if cntFirst-2 <= n-cntFirst {
+		var b strings.Builder
+		b.WriteByte(byte('a' + first))
+		b.WriteByte(byte('a' + first))
+		freq[first] -= 2
+		others := make([]byte, 0, n-cntFirst)
+		for i := first + 1; i < 26; i++ {
+			for j := 0; j < freq[i]; j++ {
+				others = append(others, byte('a'+i))
+			}
+		}
+		sort.Slice(others, func(i, j int) bool { return others[i] < others[j] })
+		pos := 0
+		for pos < len(others) {
+			b.WriteByte(others[pos])
+			pos++
+			if freq[first] > 0 {
+				b.WriteByte(byte('a' + first))
+				freq[first]--
+			}
+		}
+		for freq[first] > 0 {
+			b.WriteByte(byte('a' + first))
+			freq[first]--
+		}
+		return b.String()
+	}
+	second := first + 1
+	for freq[second] == 0 {
+		second++
+	}
+	if distinct == 2 {
+		var b strings.Builder
+		b.WriteByte(byte('a' + first))
+		for i := 0; i < freq[second]; i++ {
+			b.WriteByte(byte('a' + second))
+		}
+		for i := 0; i < freq[first]-1; i++ {
+			b.WriteByte(byte('a' + first))
+		}
+		return b.String()
+	}
+	third := second + 1
+	for freq[third] == 0 {
+		third++
+	}
+	var b strings.Builder
+	b.WriteByte(byte('a' + first))
+	b.WriteByte(byte('a' + second))
+	freq[first]--
+	freq[second]--
+	for freq[first] > 0 {
+		b.WriteByte(byte('a' + first))
+		freq[first]--
+	}
+	b.WriteByte(byte('a' + third))
+	freq[third]--
+	for i := 0; i < 26; i++ {
+		for freq[i] > 0 {
+			b.WriteByte(byte('a' + i))
+			freq[i]--
+		}
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.s)
+	}
+
+	expected := make([]string, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveE(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\n%s\n", err, stderr.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if scanner.Text() != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1500-1599/1530-1539/1530/verifierF.go
+++ b/1000-1999/1500-1599/1530-1539/1530/verifierF.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type testF struct {
+	n int
+	a [][]int
+}
+
+func genTestsF() []testF {
+	rand.Seed(1530006)
+	tests := make([]testF, 100)
+	for i := range tests {
+		n := rand.Intn(4) + 1 // small for speed
+		mat := make([][]int, n)
+		for j := 0; j < n; j++ {
+			mat[j] = make([]int, n)
+			for k := 0; k < n; k++ {
+				mat[j][k] = rand.Intn(10001)
+			}
+		}
+		tests[i] = testF{n: n, a: mat}
+	}
+	return tests
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1530F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTestsF()
+	for idx, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintln(&input, tc.n)
+		for i := 0; i < tc.n; i++ {
+			for j := 0; j < tc.n; j++ {
+				if j > 0 {
+					input.WriteByte(' ')
+				}
+				fmt.Fprint(&input, tc.a[i][j])
+			}
+			input.WriteByte('\n')
+		}
+
+		cmdO := exec.Command(oracle)
+		cmdO.Stdin = bytes.NewReader(input.Bytes())
+		outO, err := cmdO.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle run error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		expected := strings.TrimSpace(string(outO))
+
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		outB, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n%s\n", idx+1, err, outB)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(string(outB))
+		if got != expected {
+			fmt.Printf("test %d failed\nexpected: %s\n got: %s\n", idx+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1500-1599/1530-1539/1530/verifierG.go
+++ b/1000-1999/1500-1599/1530-1539/1530/verifierG.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type testG struct {
+	n, k int
+	a, b string
+}
+
+func genTestsG() []testG {
+	rand.Seed(1530007)
+	tests := make([]testG, 100)
+	for i := range tests {
+		n := rand.Intn(6) + 1
+		k := rand.Intn(n + 1)
+		ab := make([]byte, n)
+		bb := make([]byte, n)
+		for j := 0; j < n; j++ {
+			ab[j] = byte('0' + rand.Intn(2))
+			bb[j] = byte('0' + rand.Intn(2))
+		}
+		tests[i] = testG{n: n, k: k, a: string(ab), b: string(bb)}
+	}
+	return tests
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleG")
+	cmd := exec.Command("go", "build", "-o", oracle, "1530G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTestsG()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n%s\n%s\n", tc.n, tc.k, tc.a, tc.b)
+	}
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = bytes.NewReader(input.Bytes())
+	outO, err := cmdO.CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle run error: %v\n", err)
+		os.Exit(1)
+	}
+	expected := strings.TrimSpace(string(outO))
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	outB, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\n%s\n", err, outB)
+		os.Exit(1)
+	}
+	got := strings.TrimSpace(string(outB))
+	if got != expected {
+		fmt.Println("wrong answer")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1530/verifierH.go
+++ b/1000-1999/1500-1599/1530-1539/1530/verifierH.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testH struct {
+	n   int
+	arr []int
+}
+
+func genTestsH() []testH {
+	rand.Seed(1530008)
+	tests := make([]testH, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rand.Intn(100) + 1
+		}
+		tests[i] = testH{n: n, arr: arr}
+	}
+	return tests
+}
+
+func lowerBound(a []int, x int) int {
+	l, r := 0, len(a)
+	for l < r {
+		m := (l + r) / 2
+		if a[m] < x {
+			l = m + 1
+		} else {
+			r = m
+		}
+	}
+	return l
+}
+
+func lis(arr []int) int {
+	b := make([]int, 0)
+	for _, x := range arr {
+		i := lowerBound(b, x)
+		if i == len(b) {
+			b = append(b, x)
+		} else {
+			b[i] = x
+		}
+	}
+	return len(b)
+}
+
+func solveH(tc testH) int {
+	best := lis(tc.arr)
+	rev := make([]int, len(tc.arr))
+	for i := 0; i < len(tc.arr); i++ {
+		rev[i] = tc.arr[len(tc.arr)-1-i]
+	}
+	if v := lis(rev); v > best {
+		best = v
+	}
+	return best
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsH()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for i, v := range tc.arr {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveH(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\n%s\n", err, stderr.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil || val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}


### PR DESCRIPTION
## Summary
- add standalone verifiers `verifierA.go` to `verifierH.go` in contest 1530
- each verifier generates 100 random tests and validates an external binary
- complex problems F and G build a local oracle from the reference Go solutions

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_68871cf282e4832498ce210b11c094aa