### PR TITLE
Fix unused variable in 120B verifier

### DIFF
--- a/0-999/100-199/120-129/120/verifierB.go
+++ b/0-999/100-199/120-129/120/verifierB.go
@@ -90,7 +90,7 @@ func main() {
 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for t := 0; t < 100; t++ {
-		input, expect := generateCase(rng)
+		input, _ := generateCase(rng)
 		candOut, cErr := runBinary(candidate, input)
 		refOut, rErr := runBinary(ref, input)
 		if cErr != nil {


### PR DESCRIPTION
## Summary
- remove unused `expect` variable in `verifierB.go` for contest 120

## Testing
- `go build 0-999/100-199/120-129/120/verifierB.go`
- `go build 120B.go`
- `go run verifierB.go ./120B`

------
https://chatgpt.com/codex/tasks/task_e_68871ebcb5308324ba0543c5df5fb34c