### PR TITLE
Add verifiers for CF round 1535

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1535/verifierA.go
+++ b/1000-1999/1500-1599/1530-1539/1535/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+type test struct {
+    input    string
+    expected string
+}
+
+func solve(input string) string {
+    r := strings.NewReader(strings.TrimSpace(input))
+    var t int
+    fmt.Fscan(r, &t)
+    var out strings.Builder
+    for ; t > 0; t-- {
+        var s1, s2, s3, s4 int
+        fmt.Fscan(r, &s1, &s2, &s3, &s4)
+        arr := []int{s1, s2, s3, s4}
+        sort.Ints(arr)
+        top1 := s1
+        if s2 > top1 {
+            top1 = s2
+        }
+        top2 := s3
+        if s4 > top2 {
+            top2 = s4
+        }
+        if (top1 == arr[3] && top2 == arr[2]) || (top1 == arr[2] && top2 == arr[3]) {
+            out.WriteString("YES\n")
+        } else {
+            out.WriteString("NO\n")
+        }
+    }
+    return out.String()
+}
+
+func generateTests() []test {
+    rand.Seed(1)
+    var tests []test
+    fixed := [][4]int{
+        {7, 3, 9, 1},
+        {5, 6, 3, 2},
+        {1, 2, 3, 4},
+        {10, 1, 8, 9},
+        {9, 8, 7, 6},
+    }
+    for _, arr := range fixed {
+        inp := fmt.Sprintf("1\n%d %d %d %d\n", arr[0], arr[1], arr[2], arr[3])
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    for len(tests) < 100 {
+        arr := [4]int{rand.Intn(100) + 1, rand.Intn(100) + 1, rand.Intn(100) + 1, rand.Intn(100) + 1}
+        inp := fmt.Sprintf("1\n%d %d %d %d\n", arr[0], arr[1], arr[2], arr[3])
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1500-1599/1530-1539/1535/verifierB.go
+++ b/1000-1999/1500-1599/1530-1539/1535/verifierB.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct {
+    input    string
+    expected string
+}
+
+func gcd(a, b int) int {
+    for b != 0 {
+        a, b = b, a%b
+    }
+    return a
+}
+
+func solve(input string) string {
+    r := strings.NewReader(strings.TrimSpace(input))
+    var t int
+    fmt.Fscan(r, &t)
+    var out strings.Builder
+    for ; t > 0; t-- {
+        var n int
+        fmt.Fscan(r, &n)
+        arr := make([]int, n)
+        for i := 0; i < n; i++ {
+            fmt.Fscan(r, &arr[i])
+        }
+        evens := make([]int, 0)
+        odds := make([]int, 0)
+        for _, v := range arr {
+            if v%2 == 0 {
+                evens = append(evens, v)
+            } else {
+                odds = append(odds, v)
+            }
+        }
+        b := append(evens, odds...)
+        count := 0
+        for i := 0; i < n; i++ {
+            for j := i + 1; j < n; j++ {
+                if gcd(b[i], 2*b[j]) > 1 {
+                    count++
+                }
+            }
+        }
+        out.WriteString(fmt.Sprintf("%d\n", count))
+    }
+    return out.String()
+}
+
+func generateTests() []test {
+    rand.Seed(2)
+    var tests []test
+    fixed := [][]int{
+        {6, 3, 5, 3},
+        {1, 1},
+        {2, 4},
+        {5, 7, 9, 11},
+    }
+    for _, arr := range fixed {
+        var sb strings.Builder
+        sb.WriteString("1\n")
+        sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+        for i, v := range arr {
+            if i > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(fmt.Sprintf("%d", v))
+        }
+        sb.WriteString("\n")
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    for len(tests) < 100 {
+        n := rand.Intn(8) + 2
+        var sb strings.Builder
+        sb.WriteString("1\n")
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for i := 0; i < n; i++ {
+            if i > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(fmt.Sprintf("%d", rand.Intn(100)+1))
+        }
+        sb.WriteString("\n")
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1500-1599/1530-1539/1535/verifierC.go
+++ b/1000-1999/1500-1599/1530-1539/1535/verifierC.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct {
+    input    string
+    expected string
+}
+
+func solve(input string) string {
+    r := strings.NewReader(strings.TrimSpace(input))
+    var t int
+    fmt.Fscan(r, &t)
+    var out strings.Builder
+    for ; t > 0; t-- {
+        var s string
+        fmt.Fscan(r, &s)
+        dp0, dp1 := 0, 0
+        var total int64
+        for i := 0; i < len(s); i++ {
+            ch := s[i]
+            expected0, expected1 := byte('0'), byte('1')
+            if i%2 == 1 {
+                expected0, expected1 = '1', '0'
+            }
+            if ch == '?' || ch == expected0 {
+                dp0++
+            } else {
+                dp0 = 0
+            }
+            if ch == '?' || ch == expected1 {
+                dp1++
+            } else {
+                dp1 = 0
+            }
+            if dp0 > dp1 {
+                total += int64(dp0)
+            } else {
+                total += int64(dp1)
+            }
+        }
+        out.WriteString(fmt.Sprintf("%d\n", total))
+    }
+    return out.String()
+}
+
+func generateTests() []test {
+    rand.Seed(3)
+    var tests []test
+    fixed := []string{"0??10", "0", "???", "1010", "?1??1"}
+    for _, s := range fixed {
+        inp := fmt.Sprintf("1\n%s\n", s)
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    for len(tests) < 100 {
+        l := rand.Intn(15) + 1
+        var sb strings.Builder
+        sb.WriteString("1\n")
+        for i := 0; i < l; i++ {
+            r := rand.Intn(3)
+            if r == 0 {
+                sb.WriteByte('0')
+            } else if r == 1 {
+                sb.WriteByte('1')
+            } else {
+                sb.WriteByte('?')
+            }
+        }
+        sb.WriteString("\n")
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1500-1599/1530-1539/1535/verifierD.go
+++ b/1000-1999/1500-1599/1530-1539/1535/verifierD.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct {
+    input    string
+    expected string
+}
+
+func solve(input string) string {
+    r := strings.NewReader(strings.TrimSpace(input))
+    var k int
+    if _, err := fmt.Fscan(r, &k); err != nil {
+        return ""
+    }
+    var s string
+    fmt.Fscan(r, &s)
+    n := (1 << k) - 1
+    posToNode := make([]int, n+1)
+    pos := 1
+    for level := k - 1; level >= 0; level-- {
+        for node := 1 << level; node <= (1<<(level+1))-1; node++ {
+            posToNode[pos] = node
+            pos++
+        }
+    }
+    nodeChar := make([]byte, n+1)
+    for p := 1; p <= n; p++ {
+        node := posToNode[p]
+        nodeChar[node] = s[p-1]
+    }
+    dp := make([]int, n+1)
+    var recalc func(int)
+    recalc = func(node int) {
+        for {
+            ch := nodeChar[node]
+            left := node * 2
+            if left > n {
+                if ch == '?' {
+                    dp[node] = 2
+                } else {
+                    dp[node] = 1
+                }
+            } else {
+                right := left + 1
+                if ch == '?' {
+                    dp[node] = dp[left] + dp[right]
+                } else if ch == '0' {
+                    dp[node] = dp[left]
+                } else {
+                    dp[node] = dp[right]
+                }
+            }
+            if node == 1 {
+                break
+            }
+            node /= 2
+        }
+    }
+    for node := n; node >= 1; node-- {
+        recalc(node)
+    }
+    var q int
+    fmt.Fscan(r, &q)
+    var out strings.Builder
+    for ; q > 0; q-- {
+        var p int
+        var c string
+        fmt.Fscan(r, &p, &c)
+        node := posToNode[p]
+        nodeChar[node] = c[0]
+        recalc(node)
+        out.WriteString(fmt.Sprintf("%d\n", dp[1]))
+    }
+    return out.String()
+}
+
+func generateTests() []test {
+    rand.Seed(4)
+    var tests []test
+    // fixed simple test
+    inp := "1\n?\n1\n1 0\n"
+    tests = append(tests, test{inp, solve(inp)})
+    for len(tests) < 100 {
+        k := rand.Intn(3) + 1 // up to 4 levels
+        n := (1 << k) - 1
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", k))
+        for i := 0; i < n; i++ {
+            r := rand.Intn(3)
+            if r == 0 {
+                sb.WriteByte('0')
+            } else if r == 1 {
+                sb.WriteByte('1')
+            } else {
+                sb.WriteByte('?')
+            }
+        }
+        sb.WriteString("\n")
+        q := rand.Intn(5) + 1
+        sb.WriteString(fmt.Sprintf("%d\n", q))
+        for i := 0; i < q; i++ {
+            p := rand.Intn(n) + 1
+            r := rand.Intn(3)
+            var ch byte
+            if r == 0 {
+                ch = '0'
+            } else if r == 1 {
+                ch = '1'
+            } else {
+                ch = '?'
+            }
+            sb.WriteString(fmt.Sprintf("%d %c\n", p, ch))
+        }
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1500-1599/1530-1539/1535/verifierE.go
+++ b/1000-1999/1500-1599/1530-1539/1535/verifierE.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct {
+    input    string
+    expected string
+}
+
+const maxQ = 300000 + 5
+
+func solve(input string) string {
+    r := strings.NewReader(strings.TrimSpace(input))
+    var q int
+    var amount [maxQ]int64
+    var cost [maxQ]int64
+    var parent [maxQ]int
+    var dsu [maxQ]int
+    fmt.Fscan(r, &q, &amount[0], &cost[0])
+    parent[0] = 0
+    dsu[0] = 0
+    var out strings.Builder
+    idx := 1
+    for ; idx <= q; idx++ {
+        var t int
+        fmt.Fscan(r, &t)
+        if t == 1 {
+            var p int
+            var a, c int64
+            fmt.Fscan(r, &p, &a, &c)
+            parent[idx] = p
+            amount[idx] = a
+            cost[idx] = c
+            dsu[idx] = idx
+        } else {
+            var v int
+            var w int64
+            fmt.Fscan(r, &v, &w)
+            bought := int64(0)
+            spent := int64(0)
+            for w > 0 {
+                x := v
+                for dsu[x] != x {
+                    dsu[x] = dsu[dsu[x]]
+                    x = dsu[x]
+                }
+                if amount[x] == 0 {
+                    if x == 0 {
+                        break
+                    }
+                    dsu[x] = parent[x]
+                    v = dsu[x]
+                    continue
+                }
+                take := w
+                if take > amount[x] {
+                    take = amount[x]
+                }
+                amount[x] -= take
+                w -= take
+                bought += take
+                spent += take * cost[x]
+                if amount[x] == 0 && x != 0 {
+                    dsu[x] = parent[x]
+                    v = dsu[x]
+                }
+            }
+            out.WriteString(fmt.Sprintf("%d %d\n", bought, spent))
+        }
+    }
+    return out.String()
+}
+
+func generateTests() []test {
+    rand.Seed(5)
+    var tests []test
+    // simple fixed test
+    inp := "1 5 2\n2 0 2\n"
+    tests = append(tests, test{inp, solve(inp)})
+    for len(tests) < 100 {
+        q := rand.Intn(10) + 1
+        a0 := rand.Intn(5) + 1
+        c0 := rand.Intn(5) + 1
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d %d %d\n", q, a0, c0))
+        idx := 1
+        for i := 0; i < q; i++ {
+            if rand.Intn(2) == 0 {
+                // add vertex
+                p := rand.Intn(idx)
+                a := rand.Intn(5) + 1
+                c := rand.Intn(5) + c0 + 1
+                sb.WriteString(fmt.Sprintf("1 %d %d %d\n", p, a, c))
+                idx++
+            } else {
+                v := rand.Intn(idx)
+                w := rand.Intn(5) + 1
+                sb.WriteString(fmt.Sprintf("2 %d %d\n", v, w))
+            }
+        }
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1500-1599/1530-1539/1535/verifierF.go
+++ b/1000-1999/1500-1599/1530-1539/1535/verifierF.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+type test struct {
+    input    string
+    expected string
+}
+
+func solve(input string) string {
+    r := strings.NewReader(strings.TrimSpace(input))
+    var n int
+    fmt.Fscan(r, &n)
+    strs := make([]string, n)
+    for i := 0; i < n; i++ {
+        fmt.Fscan(r, &strs[i])
+    }
+    groups := make(map[string][]string)
+    for _, s := range strs {
+        bs := []byte(s)
+        sort.Slice(bs, func(i, j int) bool { return bs[i] < bs[j] })
+        key := string(bs)
+        groups[key] = append(groups[key], s)
+    }
+    totalPairs := int64(n) * (int64(n) - 1) / 2
+    var intraPairs int64
+    var sumSame int64
+    for _, grp := range groups {
+        g := len(grp)
+        if g <= 1 {
+            continue
+        }
+        intraPairs += int64(g) * (int64(g) - 1) / 2
+        L := len(grp[0])
+        brute := func() {
+            arr := make([][]byte, g)
+            for i, s := range grp {
+                arr[i] = []byte(s)
+            }
+            var cnt1 int64
+            for i := 0; i < g; i++ {
+                a := arr[i]
+                for j := i + 1; j < g; j++ {
+                    b := arr[j]
+                    l := 0
+                    for l < L && a[l] == b[l] {
+                        l++
+                    }
+                    if l == L {
+                        continue
+                    }
+                    r := L - 1
+                    for r > l && a[r] == b[r] {
+                        r--
+                    }
+                    var ca [26]int
+                    for k := l; k <= r; k++ {
+                        ca[a[k]-'a']++
+                        ca[b[k]-'a']--
+                    }
+                    ok := true
+                    for _, v := range ca {
+                        if v != 0 {
+                            ok = false
+                            break
+                        }
+                    }
+                    if !ok {
+                        continue
+                    }
+                    bs := b
+                    sortedB := true
+                    for k := l; k < r; k++ {
+                        if bs[k] > bs[k+1] {
+                            sortedB = false
+                            break
+                        }
+                    }
+                    if sortedB {
+                        cnt1++
+                        continue
+                    }
+                    as := a
+                    sortedA := true
+                    for k := l; k < r; k++ {
+                        if as[k] > as[k+1] {
+                            sortedA = false
+                            break
+                        }
+                    }
+                    if sortedA {
+                        cnt1++
+                    }
+                }
+            }
+            sumSame += cnt1 + (int64(g)*(int64(g)-1)/2-cnt1)*2
+        }
+        enumeration := func() {
+            idx := make(map[string]int, g)
+            for i, s := range grp {
+                idx[s] = i
+            }
+            L := len(grp[0])
+            var cnt1 int64
+            neighborSeen := make([]bool, g)
+            sbuf := make([]byte, L)
+            for i, s := range grp {
+                bs := []byte(s)
+                for j := range neighborSeen {
+                    neighborSeen[j] = false
+                }
+                for l := 0; l < L; l++ {
+                    for r := l + 1; r < L; r++ {
+                        sortedSeg := true
+                        for k := l; k < r; k++ {
+                            if bs[k] > bs[k+1] {
+                                sortedSeg = false
+                                break
+                            }
+                        }
+                        if sortedSeg {
+                            continue
+                        }
+                        var cnt [26]int
+                        for k := l; k <= r; k++ {
+                            cnt[bs[k]-'a']++
+                        }
+                        copy(sbuf, bs)
+                        p := l
+                        for c := 0; c < 26; c++ {
+                            for t := 0; t < cnt[c]; t++ {
+                                sbuf[p] = byte('a' + c)
+                                p++
+                            }
+                        }
+                        tkey := string(sbuf)
+                        if j, ok := idx[tkey]; ok && j > i && !neighborSeen[j] {
+                            neighborSeen[j] = true
+                            cnt1++
+                        }
+                    }
+                }
+            }
+            sumSame += cnt1 + (int64(g)*(int64(g)-1)/2-cnt1)*2
+        }
+        if len(grp[0]) <= 20 {
+            enumeration()
+        } else {
+            brute()
+        }
+    }
+    sum := sumSame + (totalPairs-intraPairs)*1337
+    return fmt.Sprintf("%d\n", sum)
+}
+
+func generateTests() []test {
+    rand.Seed(6)
+    var tests []test
+    fixed := [][]string{{"ab", "ab"}, {"ba", "ab"}, {"a", "b"}}
+    for _, arr := range fixed {
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+        for _, s := range arr {
+            sb.WriteString(fmt.Sprintf("%s\n", s))
+        }
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    for len(tests) < 100 {
+        n := rand.Intn(5) + 1
+        L := rand.Intn(5) + 1
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for i := 0; i < n; i++ {
+            for j := 0; j < L; j++ {
+                sb.WriteByte(byte('a' + rand.Intn(3)))
+            }
+            sb.WriteByte('\n')
+        }
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+


### PR DESCRIPTION
## Summary
- add Go solution verifiers for problems A–F of contest 1535
- each verifier generates at least 100 tests and runs a target binary or `.go` file

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go run verifierA.go 1535A.go` *(via compiled binary `va`)*
- `go run verifierB.go 1535B.go` *(via compiled binary `vb`)*

------
https://chatgpt.com/codex/tasks/task_e_68871e50b2288324bcfb420433aaeb8f