### PR TITLE
Add verifiers for contest 1537

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1537/verifierA.go
+++ b/1000-1999/1500-1599/1530-1539/1537/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int, arr []int) string {
+	sum := 0
+	for _, v := range arr {
+		sum += v
+	}
+	if sum == n {
+		return "0\n"
+	}
+	if sum < n {
+		return "1\n"
+	}
+	return fmt.Sprintf("%d\n", sum-n)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(20001) - 10000
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	expect := solveCase(n, arr)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(out), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1537/verifierB.go
+++ b/1000-1999/1500-1599/1530-1539/1537/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solveCase(n, m, i, j int64) string {
+	d11 := abs64(i-1) + abs64(j-1)
+	dnn := abs64(i-n) + abs64(j-m)
+	d1m := abs64(i-1) + abs64(j-m)
+	dn1 := abs64(i-n) + abs64(j-1)
+	if d11+dnn >= d1m+dn1 {
+		return fmt.Sprintf("1 1 %d %d\n", n, m)
+	}
+	return fmt.Sprintf("1 %d %d 1\n", m, n)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(20) + 1)
+	m := int64(rng.Intn(20) + 1)
+	i := int64(rng.Intn(int(n)) + 1)
+	j := int64(rng.Intn(int(m)) + 1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d %d\n", n, m, i, j)
+	expect := solveCase(n, m, i, j)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(out), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1537/verifierC.go
+++ b/1000-1999/1500-1599/1530-1539/1537/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveCase(arr []int) string {
+	n := len(arr)
+	h := append([]int(nil), arr...)
+	sort.Ints(h)
+	if n == 2 {
+		return fmt.Sprintf("%d %d\n", h[0], h[1])
+	}
+	idx := 0
+	minDiff := h[1] - h[0]
+	for i := 1; i < n-1; i++ {
+		if d := h[i+1] - h[i]; d < minDiff {
+			minDiff = d
+			idx = i
+		}
+	}
+	res := make([]int, 0, n)
+	res = append(res, h[idx])
+	for i := idx + 2; i < n; i++ {
+		res = append(res, h[i])
+	}
+	for i := 0; i < idx; i++ {
+		res = append(res, h[i])
+	}
+	res = append(res, h[idx+1])
+	var sb strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 2
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	expect := solveCase(arr)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(out), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1537/verifierD.go
+++ b/1000-1999/1500-1599/1530-1539/1537/verifierD.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n uint64) string {
+	if n%2 == 1 {
+		return "Bob\n"
+	}
+	if n&(n-1) != 0 {
+		return "Alice\n"
+	}
+	exp := bits.TrailingZeros64(n)
+	if exp%2 == 1 {
+		return "Bob\n"
+	}
+	return "Alice\n"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Uint64()%1000 + 1
+	input := fmt.Sprintf("1\n%d\n", n)
+	expect := solveCase(n)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(out), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1537/verifierE1.go
+++ b/1000-1999/1500-1599/1530-1539/1537/verifierE1.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, k int, s string) string {
+	best := ""
+	for i := 1; i <= n; i++ {
+		pref := s[:i]
+		var b strings.Builder
+		for b.Len() < k {
+			b.WriteString(pref)
+		}
+		cand := b.String()[:k]
+		if best == "" || cand < best {
+			best = cand
+		}
+	}
+	return best + "\n"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(20) + 1
+	s := randomString(rng, n)
+	input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+	expect := solveCase(n, k, s)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(out), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1537/verifierE2.go
+++ b/1000-1999/1500-1599/1530-1539/1537/verifierE2.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, k int, s string) string {
+	best := 1
+	for i := 1; i < n; i++ {
+		if s[i] > s[i%best] {
+			break
+		}
+		if s[i] < s[i%best] {
+			best = i + 1
+		}
+	}
+	prefix := s[:best]
+	res := make([]byte, k)
+	for i := 0; i < k; i++ {
+		res[i] = prefix[i%best]
+	}
+	return string(res) + "\n"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(20) + 1
+	s := randomString(rng, n)
+	input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+	expect := solveCase(n, k, s)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(out), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1530-1539/1537/verifierF.go
+++ b/1000-1999/1500-1599/1530-1539/1537/verifierF.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, m int, v, tarr []int64, edges [][2]int) string {
+	diff := make([]int64, n)
+	var sum int64
+	for i := 0; i < n; i++ {
+		diff[i] = tarr[i] - v[i]
+		sum += diff[i]
+	}
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, w := e[0], e[1]
+		adj[u] = append(adj[u], w)
+		adj[w] = append(adj[w], u)
+	}
+	color := make([]int, n)
+	for i := range color {
+		color[i] = -1
+	}
+	bip := true
+	queue := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		if color[i] != -1 {
+			continue
+		}
+		color[i] = 0
+		queue = append(queue, i)
+		for len(queue) > 0 {
+			u := queue[0]
+			queue = queue[1:]
+			for _, w := range adj[u] {
+				if color[w] == -1 {
+					color[w] = color[u] ^ 1
+					queue = append(queue, w)
+				} else if color[w] == color[u] {
+					bip = false
+				}
+			}
+		}
+	}
+	if !bip {
+		if sum%2 == 0 {
+			return "YES\n"
+		}
+		return "NO\n"
+	}
+	var diffSum int64
+	for i := 0; i < n; i++ {
+		if color[i] == 0 {
+			diffSum += diff[i]
+		} else {
+			diffSum -= diff[i]
+		}
+	}
+	if diffSum == 0 {
+		return "YES\n"
+	}
+	return "NO\n"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func generateConnectedGraph(rng *rand.Rand, n int) [][2]int {
+	// start with tree
+	edges := make([][2]int, 0, n-1)
+	for i := 1; i < n; i++ {
+		u := rng.Intn(i)
+		edges = append(edges, [2]int{u, i})
+	}
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-(n-1)+1) + (n - 1)
+	exist := make(map[[2]int]bool)
+	for _, e := range edges {
+		a, b := e[0], e[1]
+		if a > b {
+			a, b = b, a
+		}
+		exist[[2]int{a, b}] = true
+	}
+	for len(edges) < m {
+		a := rng.Intn(n)
+		b := rng.Intn(n)
+		if a == b {
+			continue
+		}
+		x, y := a, b
+		if x > y {
+			x, y = y, x
+		}
+		if exist[[2]int{x, y}] {
+			continue
+		}
+		exist[[2]int{x, y}] = true
+		edges = append(edges, [2]int{a, b})
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 2
+	edges := generateConnectedGraph(rng, n)
+	m := len(edges)
+	v := make([]int64, n)
+	tarr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		v[i] = int64(rng.Intn(21) - 10)
+		tarr[i] = int64(rng.Intn(21) - 10)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", tarr[i])
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+	}
+	expect := solveCase(n, m, v, tarr, edges)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(out), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go based verifiers for all problems of Codeforces Round 1537
- each verifier generates random tests and runs a solution binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE1.go ./solE1`
- `go run verifierE2.go ./solE2`
- `go run verifierF.go ./solF`

------
https://chatgpt.com/codex/tasks/task_e_68871ede401c8324afccbc9f34b02a4d