### PR TITLE
Add solution verifiers for Codeforces contest 1539

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1539/verifierA.go
+++ b/1000-1999/1500-1599/1530-1539/1539/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int64
+	x int64
+	t int64
+}
+
+func (tc Test) Input() string {
+	return fmt.Sprintf("1\n%d %d %d\n", tc.n, tc.x, tc.t)
+}
+
+func expected(tc Test) string {
+	q := tc.t / tc.x
+	if q > tc.n-1 {
+		q = tc.n - 1
+	}
+	ans := q*tc.n - q*(q+1)/2
+	return fmt.Sprintf("%d", ans)
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Int63n(1000) + 1
+	x := rng.Int63n(1000) + 1
+	t := rng.Int63n(1000) + 1
+	return Test{n, x, t}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1500-1599/1530-1539/1539/verifierB.go
+++ b/1000-1999/1500-1599/1530-1539/1539/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	q int
+	s string
+	L []int
+	R []int
+}
+
+func (tc Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.q))
+	sb.WriteString(tc.s)
+	sb.WriteByte('\n')
+	for i := 0; i < tc.q; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.L[i], tc.R[i]))
+	}
+	return sb.String()
+}
+
+func expected(tc Test) string {
+	pref := make([]int, tc.n+1)
+	for i := 1; i <= tc.n; i++ {
+		pref[i] = pref[i-1] + int(tc.s[i-1]-'a'+1)
+	}
+	var out strings.Builder
+	for i := 0; i < tc.q; i++ {
+		ans := pref[tc.R[i]] - pref[tc.L[i]-1]
+		out.WriteString(fmt.Sprintf("%d\n", ans))
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(30) + 1
+	q := rng.Intn(30) + 1
+	bytes := make([]byte, n)
+	for i := 0; i < n; i++ {
+		bytes[i] = byte('a' + rng.Intn(26))
+	}
+	s := string(bytes)
+	L := make([]int, q)
+	R := make([]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		L[i] = l
+		R[i] = r
+	}
+	return Test{n, q, s, L, R}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1500-1599/1530-1539/1539/verifierC.go
+++ b/1000-1999/1500-1599/1530-1539/1539/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	k int64
+	x int64
+	a []int64
+}
+
+func (tc Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.k, tc.x))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func expected(tc Test) string {
+	levels := append([]int64(nil), tc.a...)
+	sort.Slice(levels, func(i, j int) bool { return levels[i] < levels[j] })
+	gaps := make([]int64, 0)
+	for i := 1; i < tc.n; i++ {
+		diff := levels[i] - levels[i-1]
+		if diff > tc.x {
+			gaps = append(gaps, (diff-1)/tc.x)
+		}
+	}
+	sort.Slice(gaps, func(i, j int) bool { return gaps[i] < gaps[j] })
+	groups := len(gaps) + 1
+	k := tc.k
+	for _, g := range gaps {
+		if k >= g {
+			k -= g
+			groups--
+		} else {
+			break
+		}
+	}
+	return fmt.Sprintf("%d", groups)
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(20) + 1
+	k := rng.Int63n(10)
+	x := rng.Int63n(10) + 1
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Int63n(50)
+	}
+	return Test{n: n, k: k, x: x, a: a}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1500-1599/1530-1539/1539/verifierD.go
+++ b/1000-1999/1500-1599/1530-1539/1539/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type item struct {
+	a int64
+	b int64
+}
+
+type Test struct {
+	n     int
+	items []item
+}
+
+func (tc Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for _, it := range tc.items {
+		sb.WriteString(fmt.Sprintf("%d %d\n", it.a, it.b))
+	}
+	return sb.String()
+}
+
+func expected(tc Test) string {
+	items := make([]item, tc.n)
+	copy(items, tc.items)
+	sort.Slice(items, func(i, j int) bool { return items[i].b < items[j].b })
+	l := 0
+	r := tc.n - 1
+	var bought, cost int64
+	for l <= r {
+		for l <= r && items[l].a == 0 {
+			l++
+		}
+		for l <= r && items[r].a == 0 {
+			r--
+		}
+		if l > r {
+			break
+		}
+		if bought >= items[l].b {
+			cost += items[l].a
+			bought += items[l].a
+			items[l].a = 0
+			l++
+			continue
+		}
+		need := items[l].b - bought
+		if items[r].a <= need {
+			cost += items[r].a * 2
+			bought += items[r].a
+			items[r].a = 0
+			r--
+		} else {
+			cost += need * 2
+			bought += need
+			items[r].a -= need
+		}
+	}
+	return fmt.Sprintf("%d", cost)
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(20) + 1
+	items := make([]item, n)
+	for i := 0; i < n; i++ {
+		items[i] = item{a: rng.Int63n(20), b: rng.Int63n(50)}
+	}
+	return Test{n: n, items: items}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1500-1599/1530-1539/1539/verifierE.go
+++ b/1000-1999/1500-1599/1530-1539/1539/verifierE.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct {
+	k  int
+	xl int
+	xr int
+	yl int
+	yr int
+}
+
+type Test struct {
+	n  int
+	m  int
+	qs []query
+}
+
+func (tc Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for _, q := range tc.qs {
+		sb.WriteString(fmt.Sprintf("%d\n", q.k))
+		sb.WriteString(fmt.Sprintf("%d %d\n", q.xl, q.xr))
+		sb.WriteString(fmt.Sprintf("%d %d\n", q.yl, q.yr))
+	}
+	return sb.String()
+}
+
+type state struct {
+	l int
+	r int
+}
+
+func expected(tc Test) string {
+	dp := map[state][]int{{0, 0}: {}}
+	for _, q := range tc.qs {
+		next := make(map[state][]int)
+		for st, path := range dp {
+			// replace left
+			nl := q.k
+			nr := st.r
+			if nl >= q.xl && nl <= q.xr && nr >= q.yl && nr <= q.yr {
+				if _, ok := next[state{nl, nr}]; !ok {
+					np := append(append([]int(nil), path...), 0)
+					next[state{nl, nr}] = np
+				}
+			}
+			// replace right
+			nl = st.l
+			nr = q.k
+			if nl >= q.xl && nl <= q.xr && nr >= q.yl && nr <= q.yr {
+				if _, ok := next[state{nl, nr}]; !ok {
+					np := append(append([]int(nil), path...), 1)
+					next[state{nl, nr}] = np
+				}
+			}
+		}
+		if len(next) == 0 {
+			return "No"
+		}
+		dp = next
+	}
+	for _, path := range dp {
+		var sb strings.Builder
+		sb.WriteString("Yes\n")
+		for i, v := range path {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		return sb.String()
+	}
+	return "No"
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genQuery(rng *rand.Rand, m int) query {
+	k := rng.Intn(m + 1)
+	xl := rng.Intn(m + 1)
+	xr := xl + rng.Intn(m-xl+1)
+	yl := rng.Intn(m + 1)
+	yr := yl + rng.Intn(m-yl+1)
+	return query{k, xl, xr, yl, yr}
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(20) + 1
+	qs := make([]query, n)
+	for i := 0; i < n; i++ {
+		qs[i] = genQuery(rng, m)
+	}
+	return Test{n: n, m: m, qs: qs}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1500-1599/1530-1539/1539/verifierF.go
+++ b/1000-1999/1500-1599/1530-1539/1539/verifierF.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	a []int
+}
+
+func (tc Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func expected(tc Test) string {
+	n := tc.n
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = tc.a[i-1]
+	}
+	leftLess := make([]int, n+2)
+	rightLess := make([]int, n+2)
+	leftGreater := make([]int, n+2)
+	rightGreater := make([]int, n+2)
+	stack := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		for len(stack) > 0 && a[stack[len(stack)-1]] >= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) > 0 {
+			leftLess[i] = stack[len(stack)-1]
+		} else {
+			leftLess[i] = 0
+		}
+		stack = append(stack, i)
+	}
+	stack = stack[:0]
+	for i := n; i >= 1; i-- {
+		for len(stack) > 0 && a[stack[len(stack)-1]] >= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) > 0 {
+			rightLess[i] = stack[len(stack)-1]
+		} else {
+			rightLess[i] = n + 1
+		}
+		stack = append(stack, i)
+	}
+	stack = stack[:0]
+	for i := 1; i <= n; i++ {
+		for len(stack) > 0 && a[stack[len(stack)-1]] <= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) > 0 {
+			leftGreater[i] = stack[len(stack)-1]
+		} else {
+			leftGreater[i] = 0
+		}
+		stack = append(stack, i)
+	}
+	stack = stack[:0]
+	for i := n; i >= 1; i-- {
+		for len(stack) > 0 && a[stack[len(stack)-1]] <= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) > 0 {
+			rightGreater[i] = stack[len(stack)-1]
+		} else {
+			rightGreater[i] = n + 1
+		}
+		stack = append(stack, i)
+	}
+	res := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		lenMin := rightLess[i] - leftLess[i] - 1
+		distMin := lenMin / 2
+		lenMax := rightGreater[i] - leftGreater[i] - 1
+		distMax := (lenMax+1)/2 - 1
+		if distMin > distMax {
+			res[i] = distMin
+		} else {
+			res[i] = distMax
+		}
+	}
+	var out strings.Builder
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			out.WriteByte(' ')
+		}
+		out.WriteString(fmt.Sprintf("%d", res[i]))
+	}
+	return out.String()
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(50)
+	}
+	return Test{n: n, a: arr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		tc := genTest(rng)
+		expect := expected(tc)
+		got, err := runProg(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}


### PR DESCRIPTION
## Summary
- implemented Go verifiers for problems A–F of contest 1539
- each verifier generates 100 random test cases and checks a provided binary

## Testing
- `gofmt -w 1000-1999/1500-1599/1530-1539/1539/verifierA.go 1000-1999/1500-1599/1530-1539/1539/verifierB.go 1000-1999/1500-1599/1530-1539/1539/verifierC.go 1000-1999/1500-1599/1530-1539/1539/verifierD.go 1000-1999/1500-1599/1530-1539/1539/verifierE.go 1000-1999/1500-1599/1530-1539/1539/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68871f68dfa88324983e2c337c05b446