### PR TITLE
Add Go verifiers for Codeforces contest 1538

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1538/verifierA.go
+++ b/1000-1999/1500-1599/1530-1539/1538/verifierA.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type TestCase struct {
+    n   int
+    arr []int
+}
+
+func solve(n int, arr []int) int {
+    minIdx, maxIdx := 0, 0
+    for i := 1; i < n; i++ {
+        if arr[i] < arr[minIdx] {
+            minIdx = i
+        }
+        if arr[i] > arr[maxIdx] {
+            maxIdx = i
+        }
+    }
+    minPos := minIdx + 1
+    maxPos := maxIdx + 1
+    if minPos > maxPos {
+        minPos, maxPos = maxPos, minPos
+    }
+    fromLeft := maxPos
+    fromRight := n - minPos + 1
+    mixed1 := minPos + (n - maxPos + 1)
+    mixed2 := maxPos + (n - minPos + 1)
+    ans := fromLeft
+    if fromRight < ans {
+        ans = fromRight
+    }
+    if mixed1 < ans {
+        ans = mixed1
+    }
+    if mixed2 < ans {
+        ans = mixed2
+    }
+    return ans
+}
+
+func generateTests() []TestCase {
+    rand.Seed(42)
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        n := rand.Intn(99) + 2 // 2..100
+        perm := rand.Perm(n)
+        arr := make([]int, n)
+        for j, v := range perm {
+            arr[j] = v + 1
+        }
+        tests[i] = TestCase{n: n, arr: arr}
+    }
+    return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    if err := cmd.Run(); err != nil {
+        return "", err
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for idx, tc := range tests {
+        input := fmt.Sprintf("1\n%d\n", tc.n)
+        for i, v := range tc.arr {
+            if i+1 == tc.n {
+                input += fmt.Sprintf("%d\n", v)
+            } else {
+                input += fmt.Sprintf("%d ", v)
+            }
+        }
+        want := fmt.Sprintf("%d", solve(tc.n, tc.arr))
+        got, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("all tests passed")
+}
+

--- a/1000-1999/1500-1599/1530-1539/1538/verifierB.go
+++ b/1000-1999/1500-1599/1530-1539/1538/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type TestCase struct {
+    n   int
+    arr []int
+}
+
+func solve(n int, arr []int) int {
+    sum := 0
+    for _, v := range arr {
+        sum += v
+    }
+    if sum%n != 0 {
+        return -1
+    }
+    avg := sum / n
+    ans := 0
+    for _, v := range arr {
+        if v > avg {
+            ans++
+        }
+    }
+    return ans
+}
+
+func generateTests() []TestCase {
+    rand.Seed(43)
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        n := rand.Intn(20) + 1 // 1..20
+        arr := make([]int, n)
+        for j := range arr {
+            arr[j] = rand.Intn(21) // 0..20
+        }
+        tests[i] = TestCase{n: n, arr: arr}
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    if err := cmd.Run(); err != nil {
+        return "", err
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for idx, tc := range tests {
+        input := fmt.Sprintf("1\n%d\n", tc.n)
+        for i, v := range tc.arr {
+            if i+1 == tc.n {
+                input += fmt.Sprintf("%d\n", v)
+            } else {
+                input += fmt.Sprintf("%d ", v)
+            }
+        }
+        want := fmt.Sprintf("%d", solve(tc.n, tc.arr))
+        got, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("all tests passed")
+}
+

--- a/1000-1999/1500-1599/1530-1539/1538/verifierC.go
+++ b/1000-1999/1500-1599/1530-1539/1538/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+    "time"
+)
+
+type TestCase struct {
+    n   int
+    l   int64
+    r   int64
+    arr []int64
+}
+
+func countPairs(arr []int64, limit int64) int64 {
+    var cnt int64
+    j := len(arr) - 1
+    for i := 0; i < len(arr); i++ {
+        for j > i && arr[i]+arr[j] > limit {
+            j--
+        }
+        if j <= i {
+            break
+        }
+        cnt += int64(j - i)
+    }
+    return cnt
+}
+
+func solve(tc TestCase) int64 {
+    b := append([]int64(nil), tc.arr...)
+    sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+    return countPairs(b, tc.r) - countPairs(b, tc.l-1)
+}
+
+func generateTests() []TestCase {
+    rand.Seed(44)
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        n := rand.Intn(20) + 1
+        l := rand.Int63n(50) + 1
+        r := l + rand.Int63n(50)
+        arr := make([]int64, n)
+        for j := range arr {
+            arr[j] = rand.Int63n(100) + 1
+        }
+        tests[i] = TestCase{n: n, l: l, r: r, arr: arr}
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    if err := cmd.Run(); err != nil {
+        return "", err
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for idx, tc := range tests {
+        input := fmt.Sprintf("1\n%d %d %d\n", tc.n, tc.l, tc.r)
+        for i, v := range tc.arr {
+            if i+1 == tc.n {
+                input += fmt.Sprintf("%d\n", v)
+            } else {
+                input += fmt.Sprintf("%d ", v)
+            }
+        }
+        want := fmt.Sprintf("%d", solve(tc))
+        got, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("all tests passed")
+}
+

--- a/1000-1999/1500-1599/1530-1539/1538/verifierD.go
+++ b/1000-1999/1500-1599/1530-1539/1538/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type TestCase struct {
+    a int64
+    b int64
+    k int
+}
+
+func primeCount(x int64) int {
+    cnt := 0
+    for x%2 == 0 {
+        cnt++
+        x /= 2
+    }
+    for i := int64(3); i*i <= x; i += 2 {
+        for x%i == 0 {
+            cnt++
+            x /= i
+        }
+    }
+    if x > 1 {
+        cnt++
+    }
+    return cnt
+}
+
+func solve(tc TestCase) string {
+    cntA := primeCount(tc.a)
+    cntB := primeCount(tc.b)
+    maxOps := cntA + cntB
+    if tc.k == 1 {
+        if tc.a != tc.b && (tc.a%tc.b == 0 || tc.b%tc.a == 0) {
+            return "Yes"
+        }
+        return "No"
+    }
+    if tc.k >= 2 && tc.k <= maxOps {
+        return "Yes"
+    }
+    return "No"
+}
+
+func generateTests() []TestCase {
+    rand.Seed(45)
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        a := rand.Int63n(1000000) + 1
+        b := rand.Int63n(1000000) + 1
+        k := rand.Intn(6) + 1
+        tests[i] = TestCase{a: a, b: b, k: k}
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    if err := cmd.Run(); err != nil {
+        return "", err
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for idx, tc := range tests {
+        input := fmt.Sprintf("1\n%d %d %d\n", tc.a, tc.b, tc.k)
+        want := solve(tc)
+        got, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != want {
+            fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("all tests passed")
+}
+

--- a/1000-1999/1500-1599/1530-1539/1538/verifierE.go
+++ b/1000-1999/1500-1599/1530-1539/1538/verifierE.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type Var struct {
+    pref string
+    suff string
+    cnt  int
+}
+
+type Statement struct {
+    line string
+}
+
+func countHaha(s string) int {
+    c := 0
+    for i := 0; i+3 < len(s); i++ {
+        if s[i:i+4] == "haha" {
+            c++
+        }
+    }
+    return c
+}
+
+func merge(a, b Var) Var {
+    res := Var{}
+    res.cnt = a.cnt + b.cnt + countHaha(a.suff+b.pref)
+    pref := a.pref + b.pref
+    if len(pref) > 3 {
+        pref = pref[:3]
+    }
+    res.pref = pref
+    suff := a.suff + b.suff
+    if len(suff) > 3 {
+        suff = suff[len(suff)-3:]
+    }
+    res.suff = suff
+    return res
+}
+
+func solve(statements []string) int {
+    vars := make(map[string]Var)
+    last := ""
+    for _, line := range statements {
+        parts := strings.Fields(line)
+        x := parts[0]
+        if parts[1] == ":=" {
+            s := parts[2]
+            v := Var{pref: s, suff: s, cnt: countHaha(s)}
+            if len(v.pref) > 3 {
+                v.pref = v.pref[:3]
+            }
+            if len(v.suff) > 3 {
+                v.suff = v.suff[len(v.suff)-3:]
+            }
+            vars[x] = v
+        } else { // =
+            a := parts[2]
+            b := parts[4]
+            v := merge(vars[a], vars[b])
+            vars[x] = v
+        }
+        last = x
+    }
+    return vars[last].cnt
+}
+
+type TestCase struct {
+    lines []string
+}
+
+func genString() string {
+    n := rand.Intn(5) + 1
+    bytes := make([]byte, n)
+    for i := range bytes {
+        bytes[i] = byte('a' + rand.Intn(26))
+    }
+    return string(bytes)
+}
+
+func generateTests() []TestCase {
+    rand.Seed(46)
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        n := rand.Intn(5) + 1
+        lines := make([]string, n)
+        names := []string{}
+        for j := 0; j < n; j++ {
+            name := genString()
+            names = append(names, name)
+            if rand.Intn(2) == 0 || j == 0 {
+                s := genString()
+                lines[j] = fmt.Sprintf("%s := %s", name, s)
+            } else {
+                a := names[rand.Intn(len(names))]
+                b := names[rand.Intn(len(names))]
+                lines[j] = fmt.Sprintf("%s = %s + %s", name, a, b)
+            }
+        }
+        tests[i] = TestCase{lines: lines}
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    if err := cmd.Run(); err != nil {
+        return "", err
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for idx, tc := range tests {
+        input := fmt.Sprintf("1\n%d\n", len(tc.lines))
+        for _, ln := range tc.lines {
+            input += ln + "\n"
+        }
+        want := fmt.Sprintf("%d", solve(tc.lines))
+        got, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("all tests passed")
+}
+

--- a/1000-1999/1500-1599/1530-1539/1538/verifierF.go
+++ b/1000-1999/1500-1599/1530-1539/1538/verifierF.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type TestCase struct {
+    l int64
+    r int64
+}
+
+func solve(tc TestCase) int64 {
+    var ans int64
+    for p := int64(1); p <= tc.r; p *= 10 {
+        ans += tc.r/p - tc.l/p
+    }
+    return ans
+}
+
+func generateTests() []TestCase {
+    rand.Seed(47)
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        l := rand.Int63n(1_000_000_000)
+        r := l + rand.Int63n(1_000_000_000-l)+1
+        tests[i] = TestCase{l: l, r: r}
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    if err := cmd.Run(); err != nil {
+        return "", err
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for idx, tc := range tests {
+        input := fmt.Sprintf("1\n%d %d\n", tc.l, tc.r)
+        want := fmt.Sprintf("%d", solve(tc))
+        got, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("all tests passed")
+}
+

--- a/1000-1999/1500-1599/1530-1539/1538/verifierG.go
+++ b/1000-1999/1500-1599/1530-1539/1538/verifierG.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type TestCase struct {
+    x int64
+    y int64
+    a int64
+    b int64
+}
+
+func min(a, b int64) int64 {
+    if a < b {
+        return a
+    }
+    return b
+}
+
+func feasible(k, x, y, a, b int64) bool {
+    if a < b {
+        a, b = b, a
+        x, y = y, x
+    }
+    if a == b {
+        return k <= min(x, y)/a
+    }
+    diff := a - b
+    if k*(a+b) > x+y {
+        return false
+    }
+    lower := (k*a - y + diff - 1) / diff
+    if lower < 0 {
+        lower = 0
+    }
+    upper := (x - k*b) / diff
+    if upper > k {
+        upper = k
+    }
+    if upper < 0 {
+        return false
+    }
+    return lower <= upper
+}
+
+func maxSets(x, y, a, b int64) int64 {
+    if x < y {
+        x, y = y, x
+    }
+    if a < b {
+        a, b = b, a
+    }
+    if a == b {
+        return min(x, y) / a
+    }
+    hi := (x + y) / (a + b)
+    lo := int64(0)
+    var res int64
+    for lo <= hi {
+        mid := (lo + hi) / 2
+        if feasible(mid, x, y, a, b) {
+            res = mid
+            lo = mid + 1
+        } else {
+            hi = mid - 1
+        }
+    }
+    return res
+}
+
+func solve(tc TestCase) int64 {
+    return maxSets(tc.x, tc.y, tc.a, tc.b)
+}
+
+func generateTests() []TestCase {
+    rand.Seed(48)
+    tests := make([]TestCase, 100)
+    for i := range tests {
+        x := rand.Int63n(100000) + 1
+        y := rand.Int63n(100000) + 1
+        a := rand.Int63n(1000) + 1
+        b := rand.Int63n(1000) + 1
+        tests[i] = TestCase{x: x, y: y, a: a, b: b}
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    if err := cmd.Run(); err != nil {
+        return "", err
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierG.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for idx, tc := range tests {
+        input := fmt.Sprintf("1\n%d %d %d %d\n", tc.x, tc.y, tc.a, tc.b)
+        want := fmt.Sprintf("%d", solve(tc))
+        got, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("all tests passed")
+}
+


### PR DESCRIPTION
## Summary
- add new Go programs `verifierA.go` … `verifierG.go` for contest 1538
- each verifier generates 100 random test cases and checks a provided binary against expected results

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`


------
https://chatgpt.com/codex/tasks/task_e_68871f22c9208324a78a863a2d6d6bb8