### PR TITLE
Add verifiers for contest 1541

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1541/verifierA.go
+++ b/1000-1999/1500-1599/1540-1549/1541/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(99) + 2 // 2..100
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString("1\n")
+	in.WriteString(fmt.Sprintf("%d\n", n))
+
+	perm := make([]int, n)
+	for i := 0; i < n; i++ {
+		perm[i] = i + 1
+	}
+	for i := 1; i < n; i += 2 {
+		perm[i], perm[i-1] = perm[i-1], perm[i]
+	}
+	if n%2 == 1 {
+		perm[n-1], perm[n-2] = perm[n-2], perm[n-1]
+	}
+	for i, v := range perm {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprintf(&out, "%d", v)
+	}
+	out.WriteByte('\n')
+
+	return testCase{input: in.String(), expected: out.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	// basic fixed case
+	cases := []testCase{{input: "1\n2\n", expected: "2 1\n"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1541/verifierB.go
+++ b/1000-1999/1500-1599/1540-1549/1541/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(49) + 2 // 2..50
+	used := make(map[int]bool)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		for {
+			v := rng.Intn(2*n) + 1
+			if !used[v] {
+				used[v] = true
+				arr[i] = v
+				break
+			}
+		}
+	}
+	var in strings.Builder
+	in.WriteString("1\n")
+	in.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		fmt.Fprintf(&in, "%d", v)
+	}
+	in.WriteByte('\n')
+
+	// compute expected answer
+	ans := 0
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if arr[i]*arr[j] == (i+1)+(j+1) {
+				ans++
+			}
+		}
+	}
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("%d\n", ans))
+	return testCase{input: in.String(), expected: out.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	// simple fixed case with a known pair
+	cases := []testCase{{input: "1\n2\n1 3\n", expected: "1\n"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` to check solutions for problem A
- add `verifierB.go` to check solutions for problem B

Both verifiers generate at least 100 randomized tests and include a fixed
baseline case. They run a provided binary and compare its output with the
expected result.

## Testing
- `go build 1000-1999/1500-1599/1540-1549/1541/verifierA.go`
- `go build 1000-1999/1500-1599/1540-1549/1541/verifierB.go`
- `go run 1000-1999/1500-1599/1540-1549/1541/verifierA.go ./1541A`
- `go run 1000-1999/1500-1599/1540-1549/1541/verifierB.go ./1541B`


------
https://chatgpt.com/codex/tasks/task_e_68871ff4e93083249a06e5ffde163c7e