### PR TITLE
Add verifiers for contest 1542

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1542/verifierA.go
+++ b/1000-1999/1500-1599/1540-1549/1542/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected []string
+}
+
+func buildDeterministic() []testCase {
+	cases := []testCase{}
+	// Simple Yes case
+	cases = append(cases, testCase{input: "1\n1\n2 3\n", expected: []string{"Yes"}})
+	// Simple No case
+	cases = append(cases, testCase{input: "1\n1\n1 1\n", expected: []string{"No"}})
+	return cases
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	exp := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		even, odd := 0, 0
+		for j := 0; j < 2*n; j++ {
+			v := rng.Intn(101)
+			sb.WriteString(fmt.Sprintf("%d ", v))
+			if v%2 == 0 {
+				even++
+			} else {
+				odd++
+			}
+		}
+		sb.WriteString("\n")
+		if even == odd {
+			exp[i] = "Yes"
+		} else {
+			exp[i] = "No"
+		}
+	}
+	return testCase{input: sb.String(), expected: exp}
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(tc.expected) {
+		return fmt.Errorf("expected %d tokens got %d", len(tc.expected), len(fields))
+	}
+	for i, f := range fields {
+		if !strings.EqualFold(f, tc.expected[i]) {
+			return fmt.Errorf("expected %s got %s", tc.expected[i], f)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := buildDeterministic()
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1542/verifierB.go
+++ b/1000-1999/1500-1599/1540-1549/1542/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(n, a, b int64) string {
+	if a == 1 {
+		if (n-1)%b == 0 {
+			return "Yes"
+		}
+		return "No"
+	}
+	x := int64(1)
+	for x <= n {
+		if (n-x)%b == 0 {
+			return "Yes"
+		}
+		if x > n/a {
+			break
+		}
+		x *= a
+	}
+	return "No"
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Int63n(1_000_000_000) + 1
+	a := rng.Int63n(10) + 1
+	b := rng.Int63n(10) + 1
+	input := fmt.Sprintf("1\n%d %d %d\n", n, a, b)
+	return testCase{input: input, expected: solveCase(n, a, b)}
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if !strings.EqualFold(result, tc.expected) {
+		return fmt.Errorf("expected %s got %s", tc.expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		{input: "1\n1 1 1\n", expected: solveCase(1, 1, 1)},
+		{input: "1\n10 2 3\n", expected: solveCase(10, 2, 3)},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1542/verifierC.go
+++ b/1000-1999/1500-1599/1540-1549/1542/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1e9 + 7
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b, limit int64) int64 {
+	g := gcd(a, b)
+	res := a / g * b
+	if res > limit {
+		return limit + 1
+	}
+	return res
+}
+
+func solve(n int64) int64 {
+	ans := int64(0)
+	l := int64(1)
+	for m := int64(2); l <= n; m++ {
+		nl := lcm(l, m, n)
+		cnt := n/l - n/nl
+		ans = (ans + cnt*m) % mod
+		l = nl
+	}
+	return ans % mod
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Int63n(1_000_000_000_000_0000) + 1 // up to 1e16
+	input := fmt.Sprintf("1\n%d\n", n)
+	return testCase{input: input, expected: solve(n)}
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got%mod != tc.expected%mod {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		{input: "1\n1\n", expected: solve(1)},
+		{input: "1\n4\n", expected: solve(4)},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1542/verifierD.go
+++ b/1000-1999/1500-1599/1540-1549/1542/verifierD.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modD int64 = 998244353
+
+type op struct {
+	typ byte
+	val int64
+}
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func solve(ops []op) int64 {
+	n := len(ops)
+	ans := int64(0)
+	for i := 0; i < n; i++ {
+		if ops[i].typ != '+' {
+			continue
+		}
+		x := ops[i].val
+		dp := make([][2]int64, n+1)
+		dp[0][0] = 1
+		for j := 0; j < n; j++ {
+			ndp := make([][2]int64, n+1)
+			if j == i {
+				for k := 0; k <= n; k++ {
+					ndp[k][1] = (ndp[k][1] + dp[k][0] + dp[k][1]) % modD
+				}
+				dp = ndp
+				continue
+			}
+			if ops[j].typ == '+' {
+				val := ops[j].val
+				if (j < i && val <= x) || (j > i && val < x) {
+					for k := 0; k <= n; k++ {
+						for b := 0; b < 2; b++ {
+							v := dp[k][b]
+							if v == 0 {
+								continue
+							}
+							ndp[k][b] = (ndp[k][b] + v) % modD
+							if k+1 <= n {
+								ndp[k+1][b] = (ndp[k+1][b] + v) % modD
+							}
+						}
+					}
+				} else {
+					for k := 0; k <= n; k++ {
+						for b := 0; b < 2; b++ {
+							v := dp[k][b]
+							if v == 0 {
+								continue
+							}
+							ndp[k][b] = (ndp[k][b] + 2*v) % modD
+						}
+					}
+				}
+			} else { // '-'
+				for k := 0; k <= n; k++ {
+					for b := 0; b < 2; b++ {
+						v := dp[k][b]
+						if v == 0 {
+							continue
+						}
+						ndp[k][b] = (ndp[k][b] + v) % modD
+						if k > 0 {
+							ndp[k-1][b] = (ndp[k-1][b] + v) % modD
+						} else {
+							ndp[k][0] = (ndp[k][0] + v) % modD
+						}
+					}
+				}
+			}
+			dp = ndp
+		}
+		sum := int64(0)
+		for k := 0; k <= n; k++ {
+			sum = (sum + dp[k][1]) % modD
+		}
+		ans = (ans + sum*x) % modD
+	}
+	return ans % modD
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	ops := make([]op, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			val := int64(rng.Intn(100) + 1)
+			ops[i] = op{typ: '+', val: val}
+			sb.WriteString(fmt.Sprintf("+ %d\n", val))
+		} else {
+			ops[i] = op{typ: '-'}
+			sb.WriteString("-\n")
+		}
+	}
+	return testCase{input: sb.String(), expected: solve(ops)}
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got%modD != tc.expected%modD {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1542/verifierE1.go
+++ b/1000-1999/1500-1599/1540-1549/1542/verifierE1.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func absInt(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solve(n int, mod int64) int64 {
+	maxD := n * (n - 1) / 2
+	offset := maxD
+	size := 2*maxD + 1
+	dp0 := make([]int64, size)
+	dp1 := make([]int64, size)
+	dp0[offset] = 1
+	for m := n; m >= 1; m-- {
+		next0 := make([]int64, size)
+		next1 := make([]int64, size)
+		for d := -maxD; d <= maxD; d++ {
+			idx := d + offset
+			if idx < 0 || idx >= size {
+				continue
+			}
+			v0 := dp0[idx]
+			if v0 != 0 {
+				next0[idx] = (next0[idx] + v0*int64(m)) % mod
+				for k := 1; k < m; k++ {
+					delta := -k
+					idx2 := d + delta + offset
+					if idx2 >= 0 && idx2 < size {
+						next1[idx2] = (next1[idx2] + v0*int64(m-k)) % mod
+					}
+				}
+			}
+			v1 := dp1[idx]
+			if v1 != 0 {
+				for delta := -m + 1; delta <= m-1; delta++ {
+					idx2 := d + delta + offset
+					if idx2 >= 0 && idx2 < size {
+						cnt := m - absInt(delta)
+						next1[idx2] = (next1[idx2] + v1*int64(cnt)) % mod
+					}
+				}
+			}
+		}
+		dp0, dp1 = next0, next1
+	}
+	var ans int64
+	for d := 1; d <= maxD; d++ {
+		ans = (ans + dp1[d+offset]) % mod
+	}
+	return ans % mod
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	mod := int64(rng.Intn(1_000_000_000-1) + 2)
+	input := fmt.Sprintf("%d %d\n", n, mod)
+	return testCase{input: input, expected: solve(n, mod)}
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		{input: "1 2\n", expected: solve(1, 2)},
+		{input: "4 1000000007\n", expected: solve(4, 1000000007)},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1542/verifierE2.go
+++ b/1000-1999/1500-1599/1540-1549/1542/verifierE2.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func computeG(n int, mod int64) [][]int64 {
+	g := make([][]int64, n+1)
+	g[0] = []int64{0}
+	arrPrev := []int64{1}
+	basePrev := 0
+	for L := 1; L <= n; L++ {
+		maxCurr := L * (L - 1) / 2
+		baseCurr := maxCurr
+		arrCurr := make([]int64, 2*maxCurr+1)
+		sizePrev := len(arrPrev)
+		prefix0 := make([]int64, sizePrev+1)
+		prefix1 := make([]int64, sizePrev+1)
+		for i := 0; i < sizePrev; i++ {
+			prefix0[i+1] = (prefix0[i] + arrPrev[i]) % mod
+			prefix1[i+1] = (prefix1[i] + int64(i-basePrev)*arrPrev[i]) % mod
+		}
+		getSum := func(a, b int) (int64, int64) {
+			if a < -basePrev {
+				a = -basePrev
+			}
+			if b > basePrev {
+				b = basePrev
+			}
+			if a > b {
+				return 0, 0
+			}
+			idxA := a + basePrev
+			idxB := b + basePrev
+			sum0 := (prefix0[idxB+1] - prefix0[idxA]) % mod
+			if sum0 < 0 {
+				sum0 += mod
+			}
+			sum1 := (prefix1[idxB+1] - prefix1[idxA]) % mod
+			if sum1 < 0 {
+				sum1 += mod
+			}
+			return sum0, sum1
+		}
+		for d := -maxCurr; d <= maxCurr; d++ {
+			s1, s2 := getSum(d-(L-1), d)
+			s3, s4 := getSum(d+1, d+(L-1))
+			val := (int64(L) - int64(d)) % mod * s1 % mod
+			val = (val + s2) % mod
+			val = (val + (int64(L)+int64(d))%mod*s3%mod) % mod
+			val = (val - s4) % mod
+			if val < 0 {
+				val += mod
+			}
+			arrCurr[d+baseCurr] = val
+		}
+		gL := make([]int64, L+1)
+		prefixPos := make([]int64, maxCurr+2)
+		for d := maxCurr; d >= 0; d-- {
+			prefixPos[d] = (prefixPos[d+1] + arrCurr[d+baseCurr]) % mod
+		}
+		for delta := 0; delta <= L; delta++ {
+			if delta+1 <= maxCurr {
+				gL[delta] = prefixPos[delta+1]
+			} else {
+				gL[delta] = 0
+			}
+		}
+		g[L] = gL
+		arrPrev = arrCurr
+		basePrev = baseCurr
+	}
+	return g
+}
+
+func solve(n int, mod int64) int64 {
+	g := computeG(n, mod)
+	ans := int64(0)
+	prefix := int64(1)
+	for j := 1; j <= n; j++ {
+		if j > 1 {
+			prefix = prefix * int64(n-j+2) % mod
+		}
+		m := n - j + 1
+		L := m - 1
+		for delta := 1; delta <= m-1; delta++ {
+			ans = (ans + prefix*int64(m-delta)%mod*g[L][delta]) % mod
+		}
+	}
+	return ans % mod
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	mod := int64(rng.Intn(1_000_000_000-1) + 2)
+	input := fmt.Sprintf("%d %d\n", n, mod)
+	return testCase{input: input, expected: solve(n, mod)}
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		{input: "1 2\n", expected: solve(1, 2)},
+		{input: "3 1000000007\n", expected: solve(3, 1000000007)},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 1542 (problems A–E2)
- each verifier runs candidate binaries or Go programs on 100+ tests

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE1.go ./solE1`
- `go run verifierE2.go ./solE2`


------
https://chatgpt.com/codex/tasks/task_e_6887203af9008324b0b09dc0db8ccb12