### PR TITLE
Add Go verifiers for Codeforces contest 1543

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1543/verifierA.go
+++ b/1000-1999/1500-1599/1540-1549/1543/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+func solve(a, b int64) (int64, int64) {
+	if a == b {
+		return 0, 0
+	}
+	if a < b {
+		a, b = b, a
+	}
+	diff := a - b
+	rem := a % diff
+	moves := rem
+	if diff-rem < moves {
+		moves = diff - rem
+	}
+	return diff, moves
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(42)
+	const T = 100
+	tests := make([][2]int64, T)
+	for i := 0; i < T; i++ {
+		a := rand.Int63n(1e12)
+		b := rand.Int63n(1e12)
+		tests[i] = [2]int64{a, b}
+	}
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc[0], tc[1])
+	}
+	expected := make([]string, T)
+	for i, tc := range tests {
+		d, m := solve(tc[0], tc[1])
+		expected[i] = fmt.Sprintf("%d %d", d, m)
+	}
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	idx := 0
+	for idx < T {
+		if !scanner.Scan() {
+			fmt.Fprintln(os.Stderr, "insufficient output")
+			os.Exit(1)
+		}
+		diffStr := scanner.Text()
+		if !scanner.Scan() {
+			fmt.Fprintln(os.Stderr, "insufficient output")
+			os.Exit(1)
+		}
+		movesStr := scanner.Text()
+		got := diffStr + " " + movesStr
+		if got != expected[idx] {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", idx+1, expected[idx], got)
+			os.Exit(1)
+		}
+		idx++
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output after", T, "tests")
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1543/verifierB.go
+++ b/1000-1999/1500-1599/1540-1549/1543/verifierB.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+type testB struct {
+	n   int
+	arr []int64
+}
+
+func solve(arr []int64) int64 {
+	n := int64(len(arr))
+	var sum int64
+	for _, v := range arr {
+		sum += v
+	}
+	r := sum % n
+	return r * (n - r)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(42)
+	const T = 100
+	tests := make([]testB, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(50) + 1
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = rand.Int63n(1e9)
+		}
+		tests[i] = testB{n: n, arr: arr}
+	}
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for j, v := range tc.arr {
+			if j+1 == len(tc.arr) {
+				fmt.Fprintf(&input, "%d\n", v)
+			} else {
+				fmt.Fprintf(&input, "%d ", v)
+			}
+		}
+	}
+	expected := make([]int64, T)
+	for i, tc := range tests {
+		expected[i] = solve(tc.arr)
+	}
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i := 0; i < T; i++ {
+		if !scanner.Scan() {
+			fmt.Fprintln(os.Stderr, "insufficient output")
+			os.Exit(1)
+		}
+		gotStr := scanner.Text()
+		var got int64
+		fmt.Sscan(gotStr, &got)
+		if got != expected[i] {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %d got %d\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output after", T, "tests")
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1543/verifierC.go
+++ b/1000-1999/1500-1599/1540-1549/1543/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+const eps = 1e-9
+
+var v float64
+
+func f(c, m, p float64) float64 {
+	if math.Abs(p-1) < eps {
+		return 1.0
+	}
+	if math.Abs(c) < eps {
+		mv := math.Min(m, v)
+		e2 := f(c, m-mv, p+mv)
+		return 1 + m*e2
+	}
+	if math.Abs(m) < eps {
+		mv := math.Min(c, v)
+		e1 := f(c-mv, m, p+mv)
+		return 1 + c*e1
+	}
+	mc := math.Min(c, v)
+	mm := math.Min(m, v)
+	e1 := f(c-mc, m+mc/2, p+mc/2)
+	e2 := f(c+mm/2, m-mm, p+mm/2)
+	return 1 + c*e1 + m*e2
+}
+
+func solve(c, m, p, vv float64) float64 {
+	v = vv
+	return f(c, m, p)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(42)
+	const T = 100
+	type tc struct{ c, m, p, v float64 }
+	tests := make([]tc, T)
+	for i := 0; i < T; i++ {
+		c := rand.Float64()
+		m := rand.Float64() * (1 - c)
+		p := 1 - c - m
+		v := rand.Float64()*0.8 + 0.1
+		tests[i] = tc{c, m, p, v}
+	}
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for _, tcase := range tests {
+		fmt.Fprintf(&input, "%.6f %.6f %.6f %.6f\n", tcase.c, tcase.m, tcase.p, tcase.v)
+	}
+	expected := make([]float64, T)
+	for i, tcase := range tests {
+		expected[i] = solve(tcase.c, tcase.m, tcase.p, tcase.v)
+	}
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i := 0; i < T; i++ {
+		if !scanner.Scan() {
+			fmt.Fprintln(os.Stderr, "insufficient output")
+			os.Exit(1)
+		}
+		gotStr := scanner.Text()
+		var got float64
+		fmt.Sscan(gotStr, &got)
+		if math.Abs(got-expected[i]) > 1e-6*math.Max(1, math.Abs(expected[i])) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %.8f got %.8f\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output after", T, "tests")
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1543/verifierD1.go
+++ b/1000-1999/1500-1599/1540-1549/1543/verifierD1.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+type testD1 struct {
+	n int
+	x int
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(42)
+	const T = 100
+	tests := make([]testD1, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(10) + 1
+		x := rand.Intn(n)
+		tests[i] = testD1{n: n, x: x}
+	}
+	cmd := exec.Command(binary)
+	stdin, _ := cmd.StdinPipe()
+	stdout, _ := cmd.StdoutPipe()
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintln(os.Stderr, "start error:", err)
+		os.Exit(1)
+	}
+	writer := bufio.NewWriter(stdin)
+	reader := bufio.NewReader(stdout)
+	fmt.Fprintln(writer, T)
+	for _, tc := range tests {
+		fmt.Fprintf(writer, "%d %d\n", tc.n, 2)
+	}
+	writer.Flush()
+	for _, tc := range tests {
+		x := tc.x
+		for i := 0; i < tc.n; i++ {
+			var q int
+			if _, err := fmt.Fscan(reader, &q); err != nil {
+				fmt.Fprintln(os.Stderr, "failed to read query:", err)
+				cmd.Process.Kill()
+				os.Exit(1)
+			}
+			if q == x {
+				fmt.Fprintln(writer, 1)
+				writer.Flush()
+				break
+			} else {
+				fmt.Fprintln(writer, 0)
+				writer.Flush()
+				x ^= q
+			}
+		}
+	}
+	stdin.Close()
+	writer.Flush()
+	if err := cmd.Wait(); err != nil {
+		fmt.Fprintln(os.Stderr, "binary exited with error:", err)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1543/verifierD2.go
+++ b/1000-1999/1500-1599/1540-1549/1543/verifierD2.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+func xorK(a, b, k int) int {
+	res := 0
+	mul := 1
+	for a > 0 || b > 0 {
+		res += ((a%k + b%k) % k) * mul
+		a /= k
+		b /= k
+		mul *= k
+	}
+	return res
+}
+
+type testD2 struct {
+	n int
+	k int
+	x int
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(42)
+	const T = 100
+	tests := make([]testD2, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(99) + 2
+		x := rand.Intn(n)
+		tests[i] = testD2{n: n, k: k, x: x}
+	}
+	cmd := exec.Command(binary)
+	stdin, _ := cmd.StdinPipe()
+	stdout, _ := cmd.StdoutPipe()
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintln(os.Stderr, "start error:", err)
+		os.Exit(1)
+	}
+	writer := bufio.NewWriter(stdin)
+	reader := bufio.NewReader(stdout)
+	fmt.Fprintln(writer, T)
+	for _, tc := range tests {
+		fmt.Fprintf(writer, "%d %d\n", tc.n, tc.k)
+	}
+	writer.Flush()
+	for _, tc := range tests {
+		x := tc.x
+		for i := 0; i < tc.n; i++ {
+			var q int
+			if _, err := fmt.Fscan(reader, &q); err != nil {
+				fmt.Fprintln(os.Stderr, "failed to read query:", err)
+				cmd.Process.Kill()
+				os.Exit(1)
+			}
+			if q == x {
+				fmt.Fprintln(writer, 1)
+				writer.Flush()
+				break
+			} else {
+				fmt.Fprintln(writer, 0)
+				writer.Flush()
+				x = xorK(x, q, tc.k)
+			}
+		}
+	}
+	stdin.Close()
+	writer.Flush()
+	if err := cmd.Wait(); err != nil {
+		fmt.Fprintln(os.Stderr, "binary exited with error:", err)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1543/verifierE.go
+++ b/1000-1999/1500-1599/1540-1549/1543/verifierE.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+type edge struct{ u, v int }
+
+func genEdges(n int) [][2]int {
+	N := 1 << n
+	edges := make([][2]int, 0, n*N/2)
+	for i := 0; i < N; i++ {
+		for b := 0; b < n; b++ {
+			j := i ^ (1 << b)
+			if i < j {
+				edges = append(edges, [2]int{i, j})
+			}
+		}
+	}
+	return edges
+}
+
+func permEdges(edges [][2]int, perm []int) [][2]int {
+	res := make([][2]int, len(edges))
+	for i, e := range edges {
+		res[i] = [2]int{perm[e[0]], perm[e[1]]}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(42)
+	const T = 100
+	type tc struct {
+		n     int
+		edges [][2]int
+	}
+	tests := make([]tc, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(3) + 1
+		base := genEdges(n)
+		perm := rand.Perm(1 << n)
+		pe := permEdges(base, perm)
+		tests[i] = tc{n: n, edges: pe}
+	}
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for _, e := range tc.edges {
+			fmt.Fprintf(&input, "%d %d\n", e[0], e[1])
+		}
+	}
+	inpBytes := input.Bytes()
+	// run official solver
+	solCmd := exec.Command("go", "run", "1543E.go")
+	solCmd.Stdin = bytes.NewReader(inpBytes)
+	var solOut bytes.Buffer
+	solCmd.Stdout = &solOut
+	solCmd.Stderr = os.Stderr
+	if err := solCmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to run official solver:", err)
+		os.Exit(1)
+	}
+	// run candidate
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(inpBytes)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if !bytes.Equal(bytes.TrimSpace(out.Bytes()), bytes.TrimSpace(solOut.Bytes())) {
+		fmt.Fprintln(os.Stderr, "output mismatch with official solution")
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to test binaries for problem A using 100 random cases
- add verifierB.go for problem B
- add verifierC.go including recursive expectation solver
- add verifierD1.go and verifierD2.go that simulate the interactive judge
- add verifierE.go which compares candidate output with the reference solution

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD1.go`
- `go build verifierD2.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_68872080fa18832484441a16c58e4690