### PR TITLE
Add solution verifiers for contest 1545

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1545/verifierA.go
+++ b/1000-1999/1500-1599/1540-1549/1545/verifierA.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	arr []int
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseA) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String(), testCaseA{arr: arr}
+}
+
+func solveLocal(tc testCaseA) string {
+	a := append([]int(nil), tc.arr...)
+	b := append([]int(nil), tc.arr...)
+	sort.Ints(b)
+	cntA := make(map[int][2]int)
+	cntB := make(map[int][2]int)
+	for i, v := range a {
+		p := i % 2
+		val := cntA[v]
+		val[p]++
+		cntA[v] = val
+	}
+	for i, v := range b {
+		p := i % 2
+		val := cntB[v]
+		val[p]++
+		cntB[v] = val
+	}
+	ok := true
+	if len(cntA) != len(cntB) {
+		ok = false
+	} else {
+		for k, va := range cntA {
+			if vb, okb := cntB[k]; !okb || va != vb {
+				ok = false
+				break
+			}
+		}
+	}
+	if ok {
+		return "YES\n"
+	}
+	return "NO\n"
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1545A.go")
+	return runProg(ref, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		expect := solveLocal(tc)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s", i+1, input, expect, got)
+			os.Exit(1)
+		}
+		// also cross-check with reference implementation to ensure generator valid
+		refOut, err := runRef(input)
+		if err == nil && refOut != expect {
+			fmt.Fprintf(os.Stderr, "reference mismatch on test %d\ninput:%sref:%sour:%s", i+1, input, refOut, expect)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1545/verifierB.go
+++ b/1000-1999/1500-1599/1540-1549/1545/verifierB.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(30) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1545B.go")
+	return runProg(ref, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expect, err := runRef(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1545/verifierC.go
+++ b/1000-1999/1500-1599/1540-1549/1545/verifierC.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type matrix [][]int
+
+func latinSquare(n int) matrix {
+	m := make(matrix, n)
+	for i := 0; i < n; i++ {
+		m[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			m[i][j] = (i+j)%n + 1
+		}
+	}
+	return m
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 5 // 5..10
+	base := latinSquare(n)
+	used := make(map[string]bool)
+	var extras matrix
+	for len(extras) < n {
+		idx := len(extras)
+		arr := append([]int(nil), base[idx]...)
+		p := rng.Intn(n)
+		q := rng.Intn(n)
+		for q == p {
+			q = rng.Intn(n)
+		}
+		arr[p], arr[q] = arr[q], arr[p]
+		key := fmt.Sprint(arr)
+		if key == fmt.Sprint(base[idx]) || used[key] {
+			continue
+		}
+		used[key] = true
+		extras = append(extras, arr)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", base[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", extras[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1545C.go")
+	return runProg(ref, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expect, err := runRef(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1545/verifierD.go
+++ b/1000-1999/1500-1599/1540-1549/1545/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) string {
+	m := rng.Intn(6) + 5 // 5..10
+	k := rng.Intn(6) + 7 // 7..12
+	x := make([]int, m)
+	v := make([]int, m)
+	for i := 0; i < m; i++ {
+		x[i] = rng.Intn(100) + 1
+		v[i] = rng.Intn(20) + 1
+	}
+	positions := make([][]int, k)
+	for t := 0; t < k; t++ {
+		coords := make([]int, m)
+		for i := 0; i < m; i++ {
+			coords[i] = x[i] + t*v[i]
+		}
+		perm := rng.Perm(m)
+		row := make([]int, m)
+		for j, idx := range perm {
+			row[j] = coords[idx]
+		}
+		positions[t] = row
+	}
+	y := rng.Intn(k-2) + 1
+	idx := rng.Intn(m)
+	orig := positions[y][idx]
+	c := orig
+	for c == orig {
+		c = rng.Intn(200) + 1
+	}
+	positions[y][idx] = c
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", m, k))
+	for t := 0; t < k; t++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", positions[t][j])
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1545D.go")
+	return runProg(ref, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expect, err := runRef(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1545/verifierE1.go
+++ b/1000-1999/1500-1599/1540-1549/1545/verifierE1.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	x := rng.Intn(100) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n%d\n", n, x))
+	for i := 0; i < n; i++ {
+		tl := rng.Intn(100) + 1
+		tr := tl + rng.Intn(100)
+		l := rng.Intn(100) + 1
+		r := l + rng.Intn(100)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", tl, tr, l, r)
+	}
+	return sb.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1545E1.go")
+	return runProg(ref, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE1.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expect, err := runRef(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1545/verifierE2.go
+++ b/1000-1999/1500-1599/1540-1549/1545/verifierE2.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	x := rng.Intn(100) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n%d\n", n, x))
+	for i := 0; i < n; i++ {
+		tl := rng.Intn(100) + 1
+		tr := tl + rng.Intn(100)
+		l := rng.Intn(100) + 1
+		r := l + rng.Intn(100)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", tl, tr, l, r)
+	}
+	return sb.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1545E2.go")
+	return runProg(ref, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE2.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expect, err := runRef(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1545/verifierF.go
+++ b/1000-1999/1500-1599/1540-1549/1545/verifierF.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(20) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(n) + 1
+		b[i] = rng.Intn(n) + 1
+		c[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", b[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", c[i])
+	}
+	sb.WriteByte('\n')
+	secondExists := false
+	for op := 0; op < m; op++ {
+		typ := rng.Intn(2) + 1
+		if op == m-1 && !secondExists {
+			typ = 2
+		}
+		if typ == 1 {
+			k := rng.Intn(n) + 1
+			x := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "1 %d %d\n", k, x)
+		} else {
+			r := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "2 %d\n", r)
+			secondExists = true
+		}
+	}
+	return sb.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1545F.go")
+	return runProg(ref, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expect, err := runRef(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for each problem in contest 1545
- random generators create 100 test cases and run candidate binaries
- reference solutions from the repo are used for expected output

## Testing
- `go build ./1000-1999/1500-1599/1540-1549/1545/verifierA.go`
- `go build ./1000-1999/1500-1599/1540-1549/1545/verifierB.go`
- `go build ./1000-1999/1500-1599/1540-1549/1545/verifierC.go`
- `go build ./1000-1999/1500-1599/1540-1549/1545/verifierD.go`
- `go build ./1000-1999/1500-1599/1540-1549/1545/verifierE1.go`
- `go build ./1000-1999/1500-1599/1540-1549/1545/verifierE2.go`
- `go build ./1000-1999/1500-1599/1540-1549/1545/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6887210d13b883249acbbb5f95aecde7