### PR TITLE
Add verifiers for contest 1549

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1549/verifierA.go
+++ b/1000-1999/1500-1599/1540-1549/1549/verifierA.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	primes := []int64{5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557, 999999937}
+	for idx, p := range primes {
+		input := fmt.Sprintf("1\n%d\n", p)
+		out, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n%s", idx+1, err, out)
+			os.Exit(1)
+		}
+		var a, b int64
+		if n, _ := fmt.Sscan(out, &a, &b); n != 2 {
+			fmt.Fprintf(os.Stderr, "case %d: expected two integers, got %q\n", idx+1, out)
+			os.Exit(1)
+		}
+		if !(2 <= a && a < b && b <= p) {
+			fmt.Fprintf(os.Stderr, "case %d: invalid range a=%d b=%d for p=%d\n", idx+1, a, b, p)
+			os.Exit(1)
+		}
+		if p%a != p%b {
+			fmt.Fprintf(os.Stderr, "case %d: condition failed for p=%d a=%d b=%d\n", idx+1, p, a, b)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1549/verifierB.go
+++ b/1000-1999/1500-1599/1540-1549/1549/verifierB.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testB struct {
+	n     int
+	enemy string
+	greg  string
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, enemy, greg string) int {
+	e := []byte(enemy)
+	g := []byte(greg)
+	ans := 0
+	for i := 0; i < n; i++ {
+		if g[i] == '1' {
+			if e[i] == '0' {
+				ans++
+				e[i] = '2'
+			} else if i > 0 && e[i-1] == '1' {
+				ans++
+				e[i-1] = '2'
+			} else if i+1 < n && e[i+1] == '1' {
+				ans++
+				e[i+1] = '2'
+			}
+		}
+	}
+	return ans
+}
+
+func genTests() []testB {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []testB{
+		{2, "00", "00"},
+		{2, "11", "11"},
+		{3, "101", "010"},
+		{4, "1111", "1111"},
+		{5, "00000", "11111"},
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(100) + 2
+		var sb1, sb2 strings.Builder
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 1 {
+				sb1.WriteByte('1')
+			} else {
+				sb1.WriteByte('0')
+			}
+			if rng.Intn(2) == 1 {
+				sb2.WriteByte('1')
+			} else {
+				sb2.WriteByte('0')
+			}
+		}
+		tests = append(tests, testB{n, sb1.String(), sb2.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%s\n%s\n", tc.n, tc.enemy, tc.greg)
+		out, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		var got int
+		if n, _ := fmt.Sscan(out, &got); n != 1 {
+			fmt.Fprintf(os.Stderr, "case %d: expected single integer, got %q\n", i+1, out)
+			os.Exit(1)
+		}
+		exp := expected(tc.n, tc.enemy, tc.greg)
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1549 problems A and B
- each verifier runs 100 test cases

## Testing
- `go run 1000-1999/1500-1599/1540-1549/1549/verifierA.go /tmp/1549A`
- `go run 1000-1999/1500-1599/1540-1549/1549/verifierB.go /tmp/1549B`


------
https://chatgpt.com/codex/tasks/task_e_688722253f5c832498003a3d8f26659b