### PR TITLE
Add Go verifiers for contest 1548

### DIFF
--- a/1000-1999/1500-1599/1540-1549/1548/verifierA.go
+++ b/1000-1999/1500-1599/1540-1549/1548/verifierA.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1548A.go")
+	return runProg(ref, input)
+}
+
+type edge struct{ u, v int }
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	maxEdges := n * (n - 1) / 2
+	if maxEdges > 5 {
+		maxEdges = 5
+	}
+	m := rng.Intn(maxEdges + 1)
+	edges := make(map[edge]bool)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		e := edge{u, v}
+		if edges[e] {
+			continue
+		}
+		edges[e] = true
+		fmt.Fprintf(&sb, "%d %d\n", u, v)
+	}
+	q := rng.Intn(10) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	hasType3 := false
+	for i := 0; i < q; i++ {
+		t := rng.Intn(3) + 1
+		if i == q-1 && !hasType3 {
+			t = 3
+		}
+		if t == 1 && len(edges) == n*(n-1)/2 {
+			t = 3
+		}
+		if t == 2 && len(edges) == 0 {
+			t = 3
+		}
+		switch t {
+		case 1:
+			for {
+				u := rng.Intn(n) + 1
+				v := rng.Intn(n) + 1
+				if u == v {
+					continue
+				}
+				if u > v {
+					u, v = v, u
+				}
+				e := edge{u, v}
+				if edges[e] {
+					continue
+				}
+				edges[e] = true
+				fmt.Fprintf(&sb, "1 %d %d\n", u, v)
+				break
+			}
+		case 2:
+			idx := rng.Intn(len(edges))
+			var chosen edge
+			j := 0
+			for e := range edges {
+				if j == idx {
+					chosen = e
+					break
+				}
+				j++
+			}
+			delete(edges, chosen)
+			fmt.Fprintf(&sb, "2 %d %d\n", chosen.u, chosen.v)
+		case 3:
+			fmt.Fprintln(&sb, "3")
+			hasType3 = true
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1548/verifierB.go
+++ b/1000-1999/1500-1599/1540-1549/1548/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1548B.go")
+	return runProg(ref, input)
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(8) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		used := make(map[int64]bool)
+		for j := 0; j < n; j++ {
+			var x int64
+			for {
+				x = rng.Int63n(1000000) + 1
+				if !used[x] {
+					used[x] = true
+					break
+				}
+			}
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", x)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1548/verifierC.go
+++ b/1000-1999/1500-1599/1540-1549/1548/verifierC.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1548C.go")
+	return runProg(ref, input)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 0; i < q; i++ {
+		x := rng.Intn(3*n) + 1
+		fmt.Fprintf(&sb, "%d\n", x)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1548/verifierD1.go
+++ b/1000-1999/1500-1599/1540-1549/1548/verifierD1.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1548D1.go")
+	return runProg(ref, input)
+}
+
+func collinear(a, b, c [2]int) bool {
+	return (b[0]-a[0])*(c[1]-a[1]) == (c[0]-a[0])*(b[1]-a[1])
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 3
+	points := make([][2]int, 0, n)
+	for len(points) < n {
+		x := rng.Intn(10) * 2
+		y := rng.Intn(10) * 2
+		dup := false
+		for _, p := range points {
+			if p[0] == x && p[1] == y {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		good := true
+		for i := 0; i < len(points) && good; i++ {
+			for j := i + 1; j < len(points) && good; j++ {
+				if collinear(points[i], points[j], [2]int{x, y}) {
+					good = false
+				}
+			}
+		}
+		if !good {
+			continue
+		}
+		points = append(points, [2]int{x, y})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, p := range points {
+		fmt.Fprintf(&sb, "%d %d\n", p[0], p[1])
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1548/verifierD2.go
+++ b/1000-1999/1500-1599/1540-1549/1548/verifierD2.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1548D2.go")
+	return runProg(ref, input)
+}
+
+func collinear(a, b, c [2]int) bool {
+	return (b[0]-a[0])*(c[1]-a[1]) == (c[0]-a[0])*(b[1]-a[1])
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 3
+	points := make([][2]int, 0, n)
+	for len(points) < n {
+		x := rng.Intn(20)
+		y := rng.Intn(20)
+		dup := false
+		for _, p := range points {
+			if p[0] == x && p[1] == y {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		good := true
+		for i := 0; i < len(points) && good; i++ {
+			for j := i + 1; j < len(points) && good; j++ {
+				if collinear(points[i], points[j], [2]int{x, y}) {
+					good = false
+				}
+			}
+		}
+		if !good {
+			continue
+		}
+		points = append(points, [2]int{x, y})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, p := range points {
+		fmt.Fprintf(&sb, "%d %d\n", p[0], p[1])
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1500-1599/1540-1549/1548/verifierE.go
+++ b/1000-1999/1500-1599/1540-1549/1548/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1548E.go")
+	return runProg(ref, input)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	x := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, x)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(20)+1)
+	}
+	sb.WriteByte('\n')
+	for j := 0; j < m; j++ {
+		if j > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(20)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone verifiers for all problems of contest 1548
- each verifier runs 100 randomized tests using reference solutions
- verifiers accept Go source or binary path and support the `--` separator

## Testing
- `go run verifierA.go -- ./1548A.go`
- `go run verifierB.go -- ./1548B.go`
- `go run verifierE.go -- ./1548E.go`


------
https://chatgpt.com/codex/tasks/task_e_688721df37188324a66d0504553d3e7b