### PR TITLE
Add Go verifiers for contest 1550

### DIFF
--- a/1000-1999/1500-1599/1550-1559/1550/verifierA.go
+++ b/1000-1999/1500-1599/1550-1559/1550/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	sVals    []int
+	expected []int
+}
+
+func ceilSqrt(x int) int {
+	if x <= 0 {
+		return 0
+	}
+	r := int(math.Sqrt(float64(x)))
+	if r*r < x {
+		r++
+	}
+	return r
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(10) + 1
+	sVals := make([]int, t)
+	expected := make([]int, t)
+	for i := 0; i < t; i++ {
+		val := rng.Intn(5000) + 1
+		sVals[i] = val
+		expected[i] = ceilSqrt(val)
+	}
+	return testCase{sVals: sVals, expected: expected}
+}
+
+func (tc testCase) input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.sVals)))
+	for _, v := range tc.sVals {
+		sb.WriteString(fmt.Sprintf("%d\n", v))
+	}
+	return sb.String()
+}
+
+func (tc testCase) output() string {
+	var sb strings.Builder
+	for i, v := range tc.expected {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.output())
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1550/verifierB.go
+++ b/1000-1999/1500-1599/1550-1559/1550/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n        int
+	a        int
+	b        int
+	s        string
+	expected int
+}
+
+func computeExpected(n, a, b int, s string) int {
+	if b >= 0 {
+		return (a + b) * n
+	}
+	zeroGroups := 0
+	oneGroups := 0
+	prev := byte(0)
+	for i := 0; i < n; i++ {
+		if i == 0 || s[i] != prev {
+			if s[i] == '0' {
+				zeroGroups++
+			} else {
+				oneGroups++
+			}
+			prev = s[i]
+		}
+	}
+	ops := 1 + minInt(zeroGroups, oneGroups)
+	return a*n + b*ops
+}
+
+func minInt(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	a := rng.Intn(201) - 100
+	b := rng.Intn(201) - 100
+	sb := strings.Builder{}
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	s := sb.String()
+	exp := computeExpected(n, a, b, s)
+	return testCase{n: n, a: a, b: b, s: s, expected: exp}
+}
+
+func (tc testCase) input() string {
+	return fmt.Sprintf("1\n%d %d %d\n%s\n", tc.n, tc.a, tc.b, tc.s)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1550/verifierC.go
+++ b/1000-1999/1500-1599/1550-1559/1550/verifierC.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr      []int
+	expected int64
+}
+
+func isGood(arr []int) bool {
+	m := len(arr)
+	for i := 0; i < m; i++ {
+		for j := i + 1; j < m; j++ {
+			for k := j + 1; k < m; k++ {
+				x, y, z := arr[i], arr[j], arr[k]
+				if y >= minInt(x, z) && y <= maxInt(x, z) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func computeExpected(a []int) int64 {
+	n := len(a)
+	var ans int64
+	for l := 0; l < n; l++ {
+		sub := make([]int, 0, 4)
+		for r := l; r < n && r < l+4; r++ {
+			sub = append(sub, a[r])
+			if isGood(sub) {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(10) + 1
+	}
+	exp := computeExpected(arr)
+	return testCase{arr: arr, expected: exp}
+}
+
+func (tc testCase) input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.arr)))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1550/verifierD.go
+++ b/1000-1999/1500-1599/1550-1559/1550/verifierD.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+type testCase struct {
+	n        int
+	l        int
+	r        int
+	expected int64
+}
+
+func brute(n, l, r int) int64 {
+	arr := make([]int, n)
+	maxF := -1
+	var count int64
+	var dfs func(pos int)
+	dfs = func(pos int) {
+		if pos == n {
+			for i := 0; i < n; i++ {
+				if arr[i] == i+1 {
+					return
+				}
+			}
+			f := 0
+			for i := 0; i < n; i++ {
+				for j := i + 1; j < n; j++ {
+					if arr[i]+arr[j] == (i+1)+(j+1) {
+						f++
+					}
+				}
+			}
+			if f > maxF {
+				maxF = f
+				count = 1
+			} else if f == maxF {
+				count++
+			}
+			return
+		}
+		for v := l; v <= r; v++ {
+			arr[pos] = v
+			dfs(pos + 1)
+		}
+	}
+	dfs(0)
+	return count % mod
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 2     // 2..5
+	width := rng.Intn(3) + 2 // 2..4 values
+	l := rng.Intn(7) - 3
+	r := l + width - 1
+	exp := brute(n, l, r)
+	return testCase{n: n, l: l, r: r, expected: exp}
+}
+
+func (tc testCase) input() string {
+	return fmt.Sprintf("1\n%d %d %d\n", tc.n, tc.l, tc.r)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1550/verifierE.go
+++ b/1000-1999/1500-1599/1550-1559/1550/verifierE.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func possible(s []byte, n, k, L int) bool {
+	if L == 0 {
+		return true
+	}
+	if k*L > n {
+		return false
+	}
+	const INF = int(1e9)
+	next := make([][]int, k)
+	prefix := make([]int, n+1)
+	for c := 0; c < k; c++ {
+		prefix[0] = 0
+		target := byte('a' + c)
+		for i := 0; i < n; i++ {
+			if s[i] != '?' && s[i] != target {
+				prefix[i+1] = prefix[i] + 1
+			} else {
+				prefix[i+1] = prefix[i]
+			}
+		}
+		nxt := make([]int, n+1)
+		nxt[n] = INF
+		for i := n - 1; i >= 0; i-- {
+			nxt[i] = nxt[i+1]
+			if i+L <= n && prefix[i+L]-prefix[i] == 0 {
+				nxt[i] = i
+			}
+		}
+		next[c] = nxt
+	}
+	dp := make([]int, 1<<k)
+	for i := range dp {
+		dp[i] = INF
+	}
+	dp[0] = 0
+	for mask := 0; mask < (1 << k); mask++ {
+		pos := dp[mask]
+		if pos > n {
+			continue
+		}
+		for c := 0; c < k; c++ {
+			if mask&(1<<c) != 0 {
+				continue
+			}
+			start := next[c][pos]
+			if start == INF {
+				continue
+			}
+			end := start + L
+			if end <= n && end < dp[mask|(1<<c)] {
+				dp[mask|(1<<c)] = end
+			}
+		}
+	}
+	return dp[(1<<k)-1] <= n
+}
+
+func computeExpected(n, k int, s string) int {
+	bytes := []byte(s)
+	low, high := 0, n
+	ans := 0
+	for low <= high {
+		mid := (low + high) / 2
+		if possible(bytes, n, k, mid) {
+			ans = mid
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	return ans
+}
+
+type testCase struct {
+	n        int
+	k        int
+	s        string
+	expected int
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	k := rng.Intn(3) + 1 // 1..3 letters
+	n := rng.Intn(10) + k
+	bytes := make([]byte, n)
+	for i := 0; i < n; i++ {
+		r := rng.Intn(k + 1)
+		if r == k {
+			bytes[i] = '?'
+		} else {
+			bytes[i] = byte('a' + r)
+		}
+	}
+	s := string(bytes)
+	exp := computeExpected(n, k, s)
+	return testCase{n: n, k: k, s: s, expected: exp}
+}
+
+func (tc testCase) input() string {
+	return fmt.Sprintf("%d %d\n%s\n", tc.n, tc.k, tc.s)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1550/verifierF.go
+++ b/1000-1999/1500-1599/1550-1559/1550/verifierF.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	u, v int
+	w    int
+}
+
+type Query struct {
+	i, k int
+	idx  int
+}
+
+type DSU struct {
+	parent []int
+	size   []int
+}
+
+func NewDSU(n int) *DSU {
+	d := &DSU{parent: make([]int, n), size: make([]int, n)}
+	for i := 0; i < n; i++ {
+		d.parent[i] = i
+		d.size[i] = 1
+	}
+	return d
+}
+
+func (d *DSU) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) union(x, y int) {
+	x = d.find(x)
+	y = d.find(y)
+	if x == y {
+		return
+	}
+	if d.size[x] < d.size[y] {
+		x, y = y, x
+	}
+	d.parent[y] = x
+	d.size[x] += d.size[y]
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func weight(x, y, d int) int {
+	diff := abs(x - y)
+	return abs(diff - d)
+}
+
+func computeExpected(n, q, s, dVal int, a []int, queries []Query) []string {
+	edges := make([]Edge, 0, 8*n)
+	for i := 0; i < n-1; i++ {
+		edges = append(edges, Edge{u: i, v: i + 1, w: weight(a[i], a[i+1], dVal)})
+	}
+	for i := 0; i < n; i++ {
+		x := a[i]
+		j := sort.SearchInts(a, x+dVal)
+		if j < n {
+			edges = append(edges, Edge{u: i, v: j, w: weight(x, a[j], dVal)})
+		}
+		if j-1 >= 0 {
+			edges = append(edges, Edge{u: i, v: j - 1, w: weight(x, a[j-1], dVal)})
+		}
+		j = sort.SearchInts(a, x-dVal)
+		if j < n {
+			edges = append(edges, Edge{u: i, v: j, w: weight(x, a[j], dVal)})
+		}
+		if j-1 >= 0 {
+			edges = append(edges, Edge{u: i, v: j - 1, w: weight(x, a[j-1], dVal)})
+		}
+	}
+	sort.Slice(edges, func(i, j int) bool { return edges[i].w < edges[j].w })
+	sort.Slice(queries, func(i, j int) bool { return queries[i].k < queries[j].k })
+	dsu := NewDSU(n)
+	ans := make([]string, q)
+	eidx := 0
+	for _, qu := range queries {
+		for eidx < len(edges) && edges[eidx].w <= qu.k {
+			dsu.union(edges[eidx].u, edges[eidx].v)
+			eidx++
+		}
+		if dsu.find(s) == dsu.find(qu.i) {
+			ans[qu.idx] = "Yes"
+		} else {
+			ans[qu.idx] = "No"
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(6) + 2
+	q := rng.Intn(5) + 1
+	s := rng.Intn(n) + 1
+	dVal := rng.Intn(10) + 1
+	a := make([]int, n)
+	a[0] = rng.Intn(5)
+	for i := 1; i < n; i++ {
+		a[i] = a[i-1] + rng.Intn(5) + 1
+	}
+	queries := make([]Query, q)
+	for i := 0; i < q; i++ {
+		queries[i].i = rng.Intn(n)
+		queries[i].k = rng.Intn(15)
+		queries[i].idx = i
+	}
+	exp := computeExpected(n, q, s-1, dVal, a, append([]Query(nil), queries...))
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, q, s, dVal))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", queries[i].i+1, queries[i].k))
+	}
+	return sb.String(), exp
+}
+
+func runCase(bin string, input string, expected []string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(expected) {
+		return fmt.Errorf("expected %d lines got %d", len(expected), len(fields))
+	}
+	for i, f := range fields {
+		if f != expected[i] {
+			return fmt.Errorf("expected %v got %v", expected, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement verifierA.go for problem A with random tests
- implement verifierB.go for problem B
- implement verifierC.go for problem C
- implement verifierD.go for problem D using brute force
- implement verifierE.go for problem E
- implement verifierF.go for problem F

## Testing
- `go build 1000-1999/1500-1599/1550-1559/1550/verifierA.go`
- `go build 1000-1999/1500-1599/1550-1559/1550/verifierB.go`
- `go build 1000-1999/1500-1599/1550-1559/1550/verifierC.go`
- `go build 1000-1999/1500-1599/1550-1559/1550/verifierD.go`
- `go build 1000-1999/1500-1599/1550-1559/1550/verifierE.go`
- `go build 1000-1999/1500-1599/1550-1559/1550/verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6887226b54bc8324ae2e98c769cacbcc