### PR TITLE
Add verifiers for CF 1557

### DIFF
--- a/1000-1999/1500-1599/1550-1559/1557/verifierA.go
+++ b/1000-1999/1500-1599/1550-1559/1557/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testA struct {
+	n   int
+	arr []float64
+}
+
+func solveA(tc testA) float64 {
+	maxv := tc.arr[0]
+	sum := 0.0
+	for _, v := range tc.arr {
+		if v > maxv {
+			maxv = v
+		}
+		sum += v
+	}
+	sum -= maxv
+	return sum/float64(tc.n-1) + maxv
+}
+
+func generateA(rng *rand.Rand) testA {
+	n := rng.Intn(9) + 2
+	arr := make([]float64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = float64(rng.Intn(200) - 100)
+	}
+	return testA{n, arr}
+}
+
+func runCase(bin string, tc testA) (string, error) {
+	var input strings.Builder
+	fmt.Fprintf(&input, "1\n%d\n", tc.n)
+	for i, v := range tc.arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprintf(&input, "%d", int(v))
+	}
+	input.WriteByte('\n')
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testA, 0, 102)
+	// two edge cases
+	cases = append(cases, testA{2, []float64{1, 2}})
+	cases = append(cases, testA{3, []float64{-7, -6, -6}})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateA(rng))
+	}
+
+	for i, tc := range cases {
+		expect := solveA(tc)
+		out, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var got float64
+		fmt.Sscan(out, &got)
+		if math.Abs(got-expect) > 1e-6*math.Max(1, math.Abs(expect)) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.8f got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1557/verifierB.go
+++ b/1000-1999/1500-1599/1550-1559/1557/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testB struct {
+	n, k int
+	arr  []int
+}
+
+func solveB(tc testB) string {
+	sorted := make([]int, tc.n)
+	copy(sorted, tc.arr)
+	sort.Ints(sorted)
+	pos := make(map[int]int, tc.n)
+	for i, v := range tc.arr {
+		pos[v] = i
+	}
+	segments := 1
+	for i := 0; i < tc.n-1; i++ {
+		if pos[sorted[i]]+1 != pos[sorted[i+1]] {
+			segments++
+		}
+	}
+	if segments <= tc.k {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateB(rng *rand.Rand) testB {
+	n := rng.Intn(8) + 2
+	k := rng.Intn(n) + 1
+	perm := rng.Perm(n * 3)
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = perm[i]
+	}
+	return testB{n, k, arr}
+}
+
+func runCase(bin string, tc testB) (string, error) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", tc.n, tc.k)
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testB, 0, 102)
+	// add edge cases
+	cases = append(cases, testB{5, 4, []int{6, 3, 4, 2, 1}})
+	cases = append(cases, testB{3, 1, []int{3, 2, 1}})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateB(rng))
+	}
+	for i, tc := range cases {
+		expect := solveB(tc)
+		out, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1557/verifierC.go
+++ b/1000-1999/1500-1599/1550-1559/1557/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+
+func modPow(a, b int64) int64 {
+	a %= MOD
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		b >>= 1
+	}
+	return res
+}
+
+func solveC(n, k int64) int64 {
+	if n%2 == 1 {
+		base := (modPow(2, n-1) + 1) % MOD
+		return modPow(base, k)
+	}
+	a := (modPow(2, n-1) - 1 + MOD) % MOD
+	pow2n := modPow(2, n)
+	ans := int64(1)
+	cur := int64(1)
+	for i := int64(1); i <= k; i++ {
+		ans = (a*ans + cur) % MOD
+		cur = cur * pow2n % MOD
+	}
+	return ans
+}
+
+func generateC(rng *rand.Rand) (int64, int64) {
+	n := int64(rng.Intn(30) + 1)
+	k := int64(rng.Intn(30) + 1)
+	return n, k
+}
+
+func runCase(bin string, n, k int64) (string, error) {
+	input := fmt.Sprintf("1\n%d %d\n", n, k)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	type pair struct{ n, k int64 }
+	cases := make([]pair, 0, 102)
+	cases = append(cases, pair{1, 1})
+	cases = append(cases, pair{2, 2})
+	for i := 0; i < 100; i++ {
+		n, k := generateC(rng)
+		cases = append(cases, pair{n, k})
+	}
+	for i, tc := range cases {
+		expect := solveC(tc.n, tc.k)
+		out, err := runCase(bin, tc.n, tc.k)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != fmt.Sprint(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1557/verifierD.go
+++ b/1000-1999/1500-1599/1550-1559/1557/verifierD.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type segment struct {
+	x, l, r int
+}
+
+type Node struct {
+	key, prio   int
+	left, right *Node
+}
+
+func split(root *Node, key int) (l, r *Node) {
+	if root == nil {
+		return nil, nil
+	}
+	if root.key < key {
+		l1, r1 := split(root.right, key)
+		root.right = l1
+		return root, r1
+	}
+	l1, r1 := split(root.left, key)
+	root.left = r1
+	return l1, root
+}
+
+func merge(l, r *Node) *Node {
+	if l == nil {
+		return r
+	}
+	if r == nil {
+		return l
+	}
+	if l.prio > r.prio {
+		l.right = merge(l.right, r)
+		return l
+	}
+	r.left = merge(l, r.left)
+	return r
+}
+
+func insert(root *Node, node *Node) *Node {
+	if root == nil {
+		return node
+	}
+	if node.prio > root.prio {
+		l, r := split(root, node.key)
+		node.left, node.right = l, r
+		return node
+	}
+	if node.key < root.key {
+		root.left = insert(root.left, node)
+	} else {
+		root.right = insert(root.right, node)
+	}
+	return root
+}
+
+func erase(root *Node, key int) *Node {
+	if root == nil {
+		return nil
+	}
+	if key == root.key {
+		return merge(root.left, root.right)
+	}
+	if key < root.key {
+		root.left = erase(root.left, key)
+	} else {
+		root.right = erase(root.right, key)
+	}
+	return root
+}
+
+func predecessor(root *Node, key int) int {
+	res := -1000000000
+	for root != nil {
+		if root.key < key {
+			if root.key > res {
+				res = root.key
+			}
+			root = root.right
+		} else {
+			root = root.left
+		}
+	}
+	return res
+}
+
+func successor(root *Node, key int) int {
+	res := 1000000000
+	for root != nil {
+		if root.key > key {
+			if root.key < res {
+				res = root.key
+			}
+			root = root.left
+		} else {
+			root = root.right
+		}
+	}
+	return res
+}
+
+func solveD(n int, segs []segment) string {
+	rand.Seed(1)
+	cover := make([]int, n)
+	type evt struct{ pos, x, t int }
+	endpoints := make([]evt, 0, len(segs)*2)
+	for _, s := range segs {
+		x := s.x - 1
+		l := s.l - 1
+		r := s.r
+		endpoints = append(endpoints, evt{l, x, -1})
+		endpoints = append(endpoints, evt{r, x, 1})
+	}
+	sort.Slice(endpoints, func(i, j int) bool { return endpoints[i].pos < endpoints[j].pos })
+	var root *Node
+	root = insert(root, &Node{key: -1, prio: rand.Int()})
+	root = insert(root, &Node{key: n, prio: rand.Int()})
+	edges := make([][2]int, 0, len(segs)*4)
+	add := make([]int, 0)
+	del := make([]int, 0)
+	for l := 0; l < len(endpoints); {
+		r := l
+		for r < len(endpoints) && endpoints[r].pos == endpoints[l].pos {
+			r++
+		}
+		add = add[:0]
+		del = del[:0]
+		for i := l; i < r; i++ {
+			e := endpoints[i]
+			if e.t == -1 {
+				if cover[e.x] == 0 {
+					add = append(add, e.x)
+				}
+				cover[e.x]++
+			} else {
+				cover[e.x]--
+				if cover[e.x] == 0 {
+					del = append(del, e.x)
+				}
+			}
+		}
+		for _, x := range del {
+			root = erase(root, x)
+		}
+		for _, x := range add {
+			root = insert(root, &Node{key: x, prio: rand.Int()})
+			p := predecessor(root, x)
+			s := successor(root, x)
+			edges = append(edges, [2]int{p, x})
+			edges = append(edges, [2]int{x, s})
+		}
+		l = r
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i][0] != edges[j][0] {
+			return edges[i][0] < edges[j][0]
+		}
+		return edges[i][1] < edges[j][1]
+	})
+	dp := make([]int, n+2)
+	g := make([]int, n+2)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		ui, vi := u+1, v+1
+		if dp[ui]+1 > dp[vi] {
+			dp[vi] = dp[ui] + 1
+			g[vi] = ui
+		}
+	}
+	res := n + 1 - dp[n+1]
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", res))
+	list := make([]int, 0, res)
+	for i := n + 1; i > 0; {
+		prev := g[i]
+		for j := prev + 1; j < i; j++ {
+			list = append(list, j)
+		}
+		i = prev
+	}
+	for _, v := range list {
+		sb.WriteString(fmt.Sprintf("%d\n", v))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateD(rng *rand.Rand) (int, []segment) {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(10)
+	segs := make([]segment, m)
+	for i := 0; i < m; i++ {
+		x := rng.Intn(n) + 1
+		l := rng.Intn(50) + 1
+		r := l + rng.Intn(50)
+		segs[i] = segment{x, l, r}
+	}
+	return n, segs
+}
+
+func runCase(bin string, n int, segs []segment) (string, error) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(segs)))
+	for _, s := range segs {
+		fmt.Fprintf(&sb, "%d %d %d\n", s.x, s.l, s.r)
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]struct {
+		n    int
+		segs []segment
+	}, 0, 102)
+	// small fixed cases
+	cases = append(cases, struct {
+		n    int
+		segs []segment
+	}{1, nil})
+	cases = append(cases, struct {
+		n    int
+		segs []segment
+	}{2, []segment{{1, 1, 1}}})
+	for i := 0; i < 100; i++ {
+		n, segs := generateD(rng)
+		cases = append(cases, struct {
+			n    int
+			segs []segment
+		}{n, segs})
+	}
+	for i, tc := range cases {
+		expect := solveD(tc.n, tc.segs)
+		out, err := runCase(bin, tc.n, tc.segs)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\n\nGot:\n%s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1557/verifierE.go
+++ b/1000-1999/1500-1599/1550-1559/1557/verifierE.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(t int) string {
+	var sb strings.Builder
+	for i := 0; i < t; i++ {
+		for j := 1; j <= 64 && j <= 130; j++ {
+			x := (j-1)%8 + 1
+			y := (j-1)%8 + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func runCase(bin string, t int) (string, error) {
+	input := fmt.Sprintf("%d\n", t)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]int, 0, 102)
+	cases = append(cases, 1)
+	cases = append(cases, 2)
+	for i := 0; i < 100; i++ {
+		cases = append(cases, rng.Intn(60)+1)
+	}
+	for i, tcase := range cases {
+		expect := solveE(tcase)
+		out, err := runCase(bin, tcase)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\n\nGot:\n%s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go solution verifiers for contest 1557 problems A–E
- each verifier generates 100+ random test cases and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6887245592ec83248f732b4c93c17046