### PR TITLE
Add verifiers for contest 1555

### DIFF
--- a/1000-1999/1500-1599/1550-1559/1555/verifierA.go
+++ b/1000-1999/1500-1599/1550-1559/1555/verifierA.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int64) int64 {
+	ans := ((n + 1) / 2) * 5
+	if ans < 15 {
+		ans = 15
+	}
+	return ans
+}
+
+func runCase(bin string, n int64) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := fmt.Sprint(expected(n))
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Int63n(1e16) + 1
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1555/verifierB.go
+++ b/1000-1999/1500-1599/1550-1559/1555/verifierB.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("g++", "-std=c++17", "-O2", "-o", oracle, "solB.cpp")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func expected(W, H, x1, y1, x2, y2, w, h int64) string {
+	const inf int64 = 1 << 60
+	ans := inf
+	if x2-x1+w <= W {
+		if v := w - x1; v > 0 && v < ans {
+			ans = v
+		} else if v := int64(0); v < ans {
+			if w-x1 <= 0 {
+				ans = 0
+			}
+		}
+		if v := x2 - (W - w); v > 0 && v < ans {
+			ans = v
+		} else if v := int64(0); v < ans {
+			if x2-(W-w) <= 0 {
+				ans = 0
+			}
+		}
+	}
+	if y2-y1+h <= H {
+		if v := h - y1; v > 0 && v < ans {
+			ans = v
+		} else if v := int64(0); v < ans {
+			if h-y1 <= 0 {
+				ans = 0
+			}
+		}
+		if v := y2 - (H - h); v > 0 && v < ans {
+			ans = v
+		} else if v := int64(0); v < ans {
+			if y2-(H-h) <= 0 {
+				ans = 0
+			}
+		}
+	}
+	if ans == inf {
+		return "-1"
+	}
+	return fmt.Sprint(ans)
+}
+
+func generate(rng *rand.Rand) (int64, int64, int64, int64, int64, int64, int64, int64) {
+	W := int64(rng.Intn(1000) + 2)
+	H := int64(rng.Intn(1000) + 2)
+	x1 := int64(rng.Intn(int(W - 1)))
+	x2 := x1 + int64(rng.Intn(int(W-x1))) + 1
+	y1 := int64(rng.Intn(int(H - 1)))
+	y2 := y1 + int64(rng.Intn(int(H-y1))) + 1
+	w := int64(rng.Intn(int(W)) + 1)
+	h := int64(rng.Intn(int(H)) + 1)
+	return W, H, x1, y1, x2, y2, w, h
+}
+
+func runCase(bin, oracle string, params []int64) error {
+	W, H, x1, y1, x2, y2, w, h := params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7]
+	input := fmt.Sprintf("1\n%d %d\n%d %d %d %d\n%d %d\n", W, H, x1, y1, x2, y2, w, h)
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		p := make([]int64, 8)
+		W, H, x1, y1, x2, y2, w, h := generate(rng)
+		p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7] = W, H, x1, y1, x2, y2, w, h
+		if err := runCase(bin, oracle, p); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1555/verifierC.go
+++ b/1000-1999/1500-1599/1550-1559/1555/verifierC.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1555C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generate(rng *rand.Rand) (int, []int64, []int64) {
+	m := rng.Intn(10) + 1
+	row1 := make([]int64, m)
+	row2 := make([]int64, m)
+	for i := range row1 {
+		row1[i] = int64(rng.Intn(20) + 1)
+		row2[i] = int64(rng.Intn(20) + 1)
+	}
+	return m, row1, row2
+}
+
+func runCase(bin, oracle string, m int, r1, r2 []int64) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprint(m))
+	sb.WriteByte('\n')
+	for i, v := range r1 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range r2 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		m, r1, r2 := generate(rng)
+		if err := runCase(bin, oracle, m, r1, r2); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1555/verifierD.go
+++ b/1000-1999/1500-1599/1550-1559/1555/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1555D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generate(rng *rand.Rand) (string, [][2]int) {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	letters := []byte{'a', 'b', 'c'}
+	for i := range b {
+		b[i] = letters[rng.Intn(3)]
+	}
+	m := rng.Intn(20) + 1
+	queries := make([][2]int, m)
+	for i := range queries {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		queries[i][0] = l
+		queries[i][1] = r
+	}
+	return string(b), queries
+}
+
+func runCase(bin, oracle string, s string, queries [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", len(s), len(queries)))
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	for _, q := range queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", q[0], q[1]))
+	}
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s, q := generate(rng)
+		if err := runCase(bin, oracle, s, q); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1555/verifierE.go
+++ b/1000-1999/1500-1599/1550-1559/1555/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1555E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generate(rng *rand.Rand) (int, int, [][3]int) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(30) + 2
+	segs := make([][3]int, n)
+	for i := range segs {
+		l := rng.Intn(m-1) + 1
+		r := rng.Intn(m-l) + l + 1
+		w := rng.Intn(100) + 1
+		segs[i] = [3]int{l, r, w}
+	}
+	return n, m, segs
+}
+
+func runCase(bin, oracle string, n, m int, segs [][3]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, s := range segs {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", s[0], s[1], s[2]))
+	}
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, segs := generate(rng)
+		if err := runCase(bin, oracle, n, m, segs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1555/verifierF.go
+++ b/1000-1999/1500-1599/1550-1559/1555/verifierF.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1555F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generate(rng *rand.Rand) (int, [][3]int) {
+	n := rng.Intn(8) + 2
+	q := rng.Intn(10) + 1
+	qs := make([][3]int, q)
+	for i := range qs {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		for v == u {
+			v = rng.Intn(n) + 1
+		}
+		x := rng.Intn(4)
+		qs[i] = [3]int{u, v, x}
+	}
+	return n, qs
+}
+
+func runCase(bin, oracle string, n int, qs [][3]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(qs)))
+	for _, q := range qs {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", q[0], q[1], q[2]))
+	}
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, qs := generate(rng)
+		if err := runCase(bin, oracle, n, qs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1555
- each verifier generates 100 random tests and checks answers via oracle programs

## Testing
- `go build 1000-1999/1500-1599/1550-1559/1555/verifierA.go`
- `go build 1000-1999/1500-1599/1550-1559/1555/verifierB.go`
- `go build 1000-1999/1500-1599/1550-1559/1555/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688723c974a083248da946df15b73221