### PR TITLE
Add verifiers for contest 1559

### DIFF
--- a/1000-1999/1500-1599/1550-1559/1559/verifierA.go
+++ b/1000-1999/1500-1599/1550-1559/1559/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(nums []int) string {
+	res := nums[0]
+	for _, v := range nums[1:] {
+		res &= v
+	}
+	return fmt.Sprintf("%d", res)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	vals := make([]int, n)
+	for i := 0; i < n; i++ {
+		vals[i] = rng.Intn(1_000_000_000)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(vals)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, want := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1559/verifierB.go
+++ b/1000-1999/1500-1599/1550-1559/1559/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, s string) string {
+	bs := []byte(s)
+	l := -1
+	for i := 0; i < n; i++ {
+		if bs[i] != '?' {
+			l = i
+		}
+	}
+	if l == -1 {
+		bs[0] = 'B'
+		l = 0
+	}
+	for i := l - 1; i >= 0; i-- {
+		if bs[i] == '?' {
+			if bs[i+1] == 'B' {
+				bs[i] = 'R'
+			} else {
+				bs[i] = 'B'
+			}
+		}
+	}
+	for i := l + 1; i < n; i++ {
+		if bs[i] == '?' {
+			if bs[i-1] == 'B' {
+				bs[i] = 'R'
+			} else {
+				bs[i] = 'B'
+			}
+		}
+	}
+	return string(bs)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		r := rng.Intn(3)
+		switch r {
+		case 0:
+			b[i] = 'B'
+		case 1:
+			b[i] = 'R'
+		default:
+			b[i] = '?'
+		}
+	}
+	s := string(b)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %s\n", n, s))
+	return sb.String(), expected(n, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, want := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1559/verifierC.go
+++ b/1000-1999/1500-1599/1550-1559/1559/verifierC.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ u, v int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, a []int) string {
+	x := 0
+	for i := 1; i <= n; i++ {
+		if a[i-1] == 0 {
+			x = i
+		}
+	}
+	var sb strings.Builder
+	if x == 0 {
+		fmt.Fprintf(&sb, "%d ", n+1)
+	}
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&sb, "%d ", i)
+		if i == x {
+			fmt.Fprintf(&sb, "%d ", n+1)
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(2)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(n, arr)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, want := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1559/verifierD1.go
+++ b/1000-1999/1500-1599/1550-1559/1559/verifierD1.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct{ p []int }
+
+func NewDSU(n int) *DSU {
+	d := &DSU{p: make([]int, n)}
+	for i := range d.p {
+		d.p[i] = i
+	}
+	return d
+}
+
+func (d *DSU) Find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.Find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) Union(a, b int) {
+	ra, rb := d.Find(a), d.Find(b)
+	if ra != rb {
+		d.p[ra] = rb
+	}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, e1, e2 [][2]int) string {
+	d1 := NewDSU(n)
+	d2 := NewDSU(n)
+	for _, e := range e1 {
+		d1.Union(e[0]-1, e[1]-1)
+	}
+	for _, e := range e2 {
+		d2.Union(e[0]-1, e[1]-1)
+	}
+	var ans [][2]int
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if d1.Find(i) != d1.Find(j) && d2.Find(i) != d2.Find(j) {
+				ans = append(ans, [2]int{i + 1, j + 1})
+				d1.Union(i, j)
+				d2.Union(i, j)
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(ans)))
+	for _, e := range ans {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func randomForest(n int, rng *rand.Rand) [][2]int {
+	d := NewDSU(n)
+	edges := make([][2]int, 0)
+	m := rng.Intn(n)
+	for len(edges) < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u == v || d.Find(u) == d.Find(v) {
+			continue
+		}
+		d.Union(u, v)
+		edges = append(edges, [2]int{u + 1, v + 1})
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	e1 := randomForest(n, rng)
+	e2 := randomForest(n, rng)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(e1), len(e2)))
+	for _, e := range e1 {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for _, e := range e2 {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String(), expected(n, e1, e2)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, want := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1559/verifierD2.go
+++ b/1000-1999/1500-1599/1550-1559/1559/verifierD2.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct{ p []int }
+
+func NewDSU(n int) *DSU {
+	d := &DSU{p: make([]int, n+1)}
+	for i := 1; i <= n; i++ {
+		d.p[i] = i
+	}
+	return d
+}
+
+func (d *DSU) Find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.Find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) Union(a, b int) {
+	ra, rb := d.Find(a), d.Find(b)
+	if ra != rb {
+		d.p[ra] = rb
+	}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n int, e1, e2 [][2]int) string {
+	d1 := NewDSU(n)
+	d2 := NewDSU(n)
+	for _, e := range e1 {
+		d1.Union(e[0], e[1])
+	}
+	for _, e := range e2 {
+		d2.Union(e[0], e[1])
+	}
+	type pair struct{ x, y int }
+	var res []pair
+	for i := 2; i <= n; i++ {
+		if d1.Find(i) != d1.Find(1) && d2.Find(i) != d2.Find(1) {
+			res = append(res, pair{i, 1})
+			d1.Union(i, 1)
+			d2.Union(i, 1)
+		}
+	}
+	var s1, s2 []int
+	r1 := d1.Find(1)
+	r2 := d2.Find(1)
+	for i := 2; i <= n; i++ {
+		if d1.Find(i) == i && d1.Find(i) != r1 {
+			s1 = append(s1, i)
+		}
+		if d2.Find(i) == i && d2.Find(i) != r2 {
+			s2 = append(s2, i)
+		}
+	}
+	t := len(s1)
+	if len(s2) < t {
+		t = len(s2)
+	}
+	for i := 0; i < t; i++ {
+		res = append(res, pair{s1[i], s2[i]})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(res)))
+	for _, p := range res {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func randomForest(n int, rng *rand.Rand) [][2]int {
+	d := NewDSU(n)
+	edges := make([][2]int, 0)
+	m := rng.Intn(n)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v || d.Find(u) == d.Find(v) {
+			continue
+		}
+		d.Union(u, v)
+		edges = append(edges, [2]int{u, v})
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 2
+	e1 := randomForest(n, rng)
+	e2 := randomForest(n, rng)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(e1), len(e2)))
+	for _, e := range e1 {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for _, e := range e2 {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String(), solve(n, e1, e2)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, want := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1550-1559/1559/verifierE.go
+++ b/1000-1999/1500-1599/1550-1559/1559/verifierE.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 998244353
+
+func mobius(n int) []int {
+	mu := make([]int, n+1)
+	mu[1] = 1
+	primes := []int{}
+	isComp := make([]bool, n+1)
+	for i := 2; i <= n; i++ {
+		if !isComp[i] {
+			primes = append(primes, i)
+			mu[i] = -1
+		}
+		for _, p := range primes {
+			if i*p > n {
+				break
+			}
+			isComp[i*p] = true
+			if i%p == 0 {
+				mu[i*p] = 0
+				break
+			} else {
+				mu[i*p] = -mu[i]
+			}
+		}
+	}
+	return mu
+}
+
+func countForD(d, n, m int, L, R []int) int64 {
+	limit := m / d
+	base := 0
+	diffs := make([]int, n)
+	for i := 0; i < n; i++ {
+		li := (L[i] + d - 1) / d
+		ri := R[i] / d
+		if li > ri {
+			return 0
+		}
+		base += li
+		diffs[i] = ri - li
+	}
+	limit -= base
+	if limit < 0 {
+		return 0
+	}
+	dp := make([]int64, limit+1)
+	dp[0] = 1
+	for _, r := range diffs {
+		prefix := int64(0)
+		ndp := make([]int64, limit+1)
+		for s := 0; s <= limit; s++ {
+			prefix += dp[s]
+			if prefix >= MOD {
+				prefix -= MOD
+			}
+			if s-r-1 >= 0 {
+				prefix -= dp[s-r-1]
+				if prefix < 0 {
+					prefix += MOD
+				}
+			}
+			ndp[s] = prefix
+		}
+		dp = ndp
+	}
+	var total int64
+	for _, v := range dp {
+		total += v
+		if total >= MOD {
+			total -= MOD
+		}
+	}
+	return total
+}
+
+func solve(n, m int, L, R []int) string {
+	mu := mobius(m)
+	var ans int64
+	for d := 1; d <= m; d++ {
+		if mu[d] == 0 {
+			continue
+		}
+		val := countForD(d, n, m, L, R)
+		if val == 0 {
+			continue
+		}
+		if mu[d] == 1 {
+			ans += val
+		} else {
+			ans -= val
+		}
+		ans %= MOD
+	}
+	if ans < 0 {
+		ans += MOD
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(40) + 10
+	L := make([]int, n)
+	R := make([]int, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(m) + 1
+		r := rng.Intn(m-l+1) + l
+		L[i] = l
+		R[i] = r
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", L[i], R[i]))
+	}
+	return sb.String(), solve(n, m, L, R)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, want := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 1559
- generate 100 randomized test cases per verifier
- support running solutions as binaries or `go run` on source files

## Testing
- `go run 1000-1999/1500-1599/1550-1559/1559/verifierA.go /tmp/solA`
- `go run 1000-1999/1500-1599/1550-1559/1559/verifierB.go /tmp/solB`
- `go run 1000-1999/1500-1599/1550-1559/1559/verifierC.go /tmp/solC`
- `go run 1000-1999/1500-1599/1550-1559/1559/verifierD1.go /tmp/solD1`
- `go run 1000-1999/1500-1599/1550-1559/1559/verifierD2.go /tmp/solD2`
- `go run 1000-1999/1500-1599/1550-1559/1559/verifierE.go /tmp/solE`


------
https://chatgpt.com/codex/tasks/task_e_688724e19fc08324b5c69ef550ca62f4