### PR TITLE
Add verifiers for contest 1562

### DIFF
--- a/1000-1999/1500-1599/1560-1569/1562/verifierA.go
+++ b/1000-1999/1500-1599/1560-1569/1562/verifierA.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l := rng.Intn(1_000_000_000) + 1
+	r := l + rng.Intn(1_000_000_000-l+1)
+	input := fmt.Sprintf("1\n%d %d\n", l, r)
+	b := r/2 + 1
+	if l > b {
+		b = l
+	}
+	expected := fmt.Sprintf("%d\n", r%b)
+	return input, expected
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1562/verifierB.go
+++ b/1000-1999/1500-1599/1560-1569/1562/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var prime []bool
+
+func init() {
+	const N = 1000
+	prime = make([]bool, N+1)
+	for i := 2; i <= N; i++ {
+		prime[i] = true
+	}
+	for i := 2; i*i <= N; i++ {
+		if prime[i] {
+			for j := i * i; j <= N; j += i {
+				prime[j] = false
+			}
+		}
+	}
+}
+
+func solveCase(s string) (int, string) {
+	n := len(s)
+	cnt := make([]int, 10)
+	digits := make([]int, n)
+	for i, ch := range s {
+		d := int(ch - '0')
+		digits[i] = d
+		cnt[d]++
+	}
+	if cnt[1] > 0 || cnt[4] > 0 || cnt[6] > 0 || cnt[8] > 0 || cnt[9] > 0 {
+		switch {
+		case cnt[1] > 0:
+			return 1, "1"
+		case cnt[4] > 0:
+			return 1, "4"
+		case cnt[6] > 0:
+			return 1, "6"
+		case cnt[8] > 0:
+			return 1, "8"
+		default:
+			return 1, "9"
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			num := digits[i]*10 + digits[j]
+			if !prime[num] {
+				return 2, fmt.Sprintf("%d%d", digits[i], digits[j])
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			for k := j + 1; k < n; k++ {
+				num := digits[i]*100 + digits[j]*10 + digits[k]
+				if !prime[num] {
+					return 3, fmt.Sprintf("%d%d%d", digits[i], digits[j], digits[k])
+				}
+			}
+		}
+	}
+	return 0, ""
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	k := rng.Intn(9) + 2 // 2..10 digits
+	var digits strings.Builder
+	for i := 0; i < k; i++ {
+		digits.WriteByte(byte(rng.Intn(9) + '1'))
+	}
+	s := digits.String()
+	input := fmt.Sprintf("1\n%d\n%s\n", k, s)
+	lenAns, ans := solveCase(s)
+	expected := fmt.Sprintf("%d\n%s\n", lenAns, ans)
+	return input, expected
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1562/verifierC.go
+++ b/1000-1999/1500-1599/1560-1569/1562/verifierC.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int, s string) string {
+	idx := -1
+	for i, ch := range s {
+		if ch == '0' {
+			idx = i + 1
+		}
+	}
+	mid := n / 2
+	if idx > mid {
+		return fmt.Sprintf("1 %d 1 %d\n", idx, idx-1)
+	} else if idx < mid {
+		return fmt.Sprintf("%d %d %d %d\n", mid+1, n, mid, n-1)
+	} else {
+		return fmt.Sprintf("%d %d %d %d\n", mid+1, n, mid, n)
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(18) + 2
+	sb := make([]byte, n)
+	for i := range sb {
+		if rng.Intn(2) == 0 {
+			sb[i] = '0'
+		} else {
+			sb[i] = '1'
+		}
+	}
+	s := string(sb)
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	expected := solveCase(n, s)
+	return input, expected
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1562/verifierD1.go
+++ b/1000-1999/1500-1599/1560-1569/1562/verifierD1.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, q int, s string, queries [][2]int) string {
+	p := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		if i%2 == 0 {
+			if s[i] == '+' {
+				p[i+1] = p[i] + 1
+			} else {
+				p[i+1] = p[i] - 1
+			}
+		} else {
+			if s[i] == '+' {
+				p[i+1] = p[i] - 1
+			} else {
+				p[i+1] = p[i] + 1
+			}
+		}
+	}
+	var out strings.Builder
+	for _, qr := range queries {
+		l, r := qr[0], qr[1]
+		c := p[r] - p[l-1]
+		if c == 0 {
+			out.WriteString("0\n")
+		} else if c%2 != 0 {
+			out.WriteString("1\n")
+		} else {
+			out.WriteString("2\n")
+		}
+	}
+	return out.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	q := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	str := make([]byte, n)
+	for i := range str {
+		if rng.Intn(2) == 0 {
+			str[i] = '+'
+		} else {
+			str[i] = '-'
+		}
+	}
+	s := string(str)
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		queries[i] = [2]int{l, r}
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	input := sb.String()
+	expected := solveCase(n, q, s, queries)
+	return input, expected
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1562/verifierD2.go
+++ b/1000-1999/1500-1599/1560-1569/1562/verifierD2.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveCase(n, q int, s string, queries [][2]int) string {
+	p := make([]int, n+1)
+	v1 := make([][]int, n+1)
+	v2 := make([][]int, n+1)
+	for i := 0; i < n; i++ {
+		if i%2 == 0 {
+			if s[i] == '+' {
+				p[i+1] = p[i] + 1
+			} else {
+				p[i+1] = p[i] - 1
+			}
+		} else {
+			if s[i] == '+' {
+				p[i+1] = p[i] - 1
+			} else {
+				p[i+1] = p[i] + 1
+			}
+		}
+		if p[i+1] >= 0 {
+			v1[p[i+1]] = append(v1[p[i+1]], i+1)
+		} else {
+			v2[-p[i+1]] = append(v2[-p[i+1]], i+1)
+		}
+	}
+	var out strings.Builder
+	for _, qr := range queries {
+		l, r := qr[0], qr[1]
+		c := p[r] - p[l-1]
+		if c == 0 {
+			out.WriteString("0\n")
+			continue
+		}
+		if c%2 == 0 {
+			r0 := r
+			r = r0 - 1
+			var f int
+			if p[r] > p[l-1] {
+				f = p[l-1] + (p[r]-p[l-1]+1)/2
+			} else {
+				f = p[l-1] - (p[l-1]-p[r]+1)/2
+			}
+			var pos int
+			if f >= 0 {
+				arr := v1[f]
+				idx := sort.Search(len(arr), func(i int) bool { return arr[i] > l-1 })
+				pos = arr[idx]
+			} else {
+				arr := v2[-f]
+				idx := sort.Search(len(arr), func(i int) bool { return arr[i] > l-1 })
+				pos = arr[idx]
+			}
+			out.WriteString("2\n")
+			out.WriteString(fmt.Sprintf("%d %d\n", r0, pos))
+		} else {
+			var f int
+			if p[r] > p[l-1] {
+				f = p[l-1] + (p[r]-p[l-1]+1)/2
+			} else {
+				f = p[l-1] - (p[l-1]-p[r]+1)/2
+			}
+			var pos int
+			if f >= 0 {
+				arr := v1[f]
+				idx := sort.Search(len(arr), func(i int) bool { return arr[i] > l-1 })
+				pos = arr[idx]
+			} else {
+				arr := v2[-f]
+				idx := sort.Search(len(arr), func(i int) bool { return arr[i] > l-1 })
+				pos = arr[idx]
+			}
+			out.WriteString("1\n")
+			out.WriteString(fmt.Sprintf("%d\n", pos))
+		}
+	}
+	return out.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	q := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	str := make([]byte, n)
+	for i := range str {
+		if rng.Intn(2) == 0 {
+			str[i] = '+'
+		} else {
+			str[i] = '-'
+		}
+	}
+	s := string(str)
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		queries[i] = [2]int{l, r}
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	input := sb.String()
+	expected := solveCase(n, q, s, queries)
+	return input, expected
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1562/verifierE.go
+++ b/1000-1999/1500-1599/1560-1569/1562/verifierE.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type sub struct{ i, j int }
+
+func solveCase(n int, s string) string {
+	arr := []byte(s)
+	lcp := make([][]int, n+1)
+	for i := 0; i <= n; i++ {
+		lcp[i] = make([]int, n+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := n - 1; j >= 0; j-- {
+			if arr[i] == arr[j] {
+				lcp[i][j] = lcp[i+1][j+1] + 1
+			}
+		}
+	}
+	less := func(x, y sub) bool {
+		len1 := x.j - x.i + 1
+		len2 := y.j - y.i + 1
+		l := lcp[x.i][y.i]
+		if l >= len1 || l >= len2 {
+			if len1 == len2 {
+				return false
+			}
+			return len1 < len2
+		}
+		return arr[x.i+l] < arr[y.i+l]
+	}
+	tails := make([]sub, 0)
+	for i := 0; i < n; i++ {
+		for j := i; j < n; j++ {
+			cur := sub{i, j}
+			lo, hi := 0, len(tails)
+			for lo < hi {
+				mid := (lo + hi) / 2
+				if less(tails[mid], cur) {
+					lo = mid + 1
+				} else {
+					hi = mid
+				}
+			}
+			if lo == len(tails) {
+				tails = append(tails, cur)
+			} else {
+				tails[lo] = cur
+			}
+		}
+	}
+	return fmt.Sprintf("%d\n", len(tails))
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2 // 2..6
+	sb := make([]byte, n)
+	for i := range sb {
+		sb[i] = byte(rng.Intn(26) + 'a')
+	}
+	s := string(sb)
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	expected := solveCase(n, s)
+	return input, expected
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1562/verifierF.go
+++ b/1000-1999/1500-1599/1560-1569/1562/verifierF.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generatePerm(rng *rand.Rand, n int) []int {
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = i + 1
+	}
+	rng.Shuffle(n, func(i, j int) { a[i], a[j] = a[j], a[i] })
+	return a
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := 1
+	n := rng.Intn(9) + 1 // 1..10
+	perm := generatePerm(rng, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	var exp strings.Builder
+	for i, v := range perm {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(strconv.Itoa(v))
+	}
+	exp.WriteByte('\n')
+	return input, exp.String()
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces contest 1562 problems A-F
- each verifier runs 100 randomized test cases against a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD1.go`
- `go build verifierD2.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_688725b3c6188324bb8318aa8b62a030