### PR TITLE
Add Go verifiers for Codeforces contest 1560

### DIFF
--- a/1000-1999/1500-1599/1560-1569/1560/verifierA.go
+++ b/1000-1999/1500-1599/1560-1569/1560/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	k int
+}
+
+func solve(k int) int {
+	seq := make([]int, 0, 1000)
+	for x := 1; len(seq) < 1000; x++ {
+		if x%3 != 0 && x%10 != 3 {
+			seq = append(seq, x)
+		}
+	}
+	return seq[k-1]
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		tests[i].k = r.Intn(1000) + 1
+	}
+	return tests
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n", tc.k)
+		want := fmt.Sprintf("%d", solve(tc.k))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, want, got)
+			fmt.Printf("input:\n%s", input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1560/verifierB.go
+++ b/1000-1999/1500-1599/1560-1569/1560/verifierB.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	a int
+	b int
+	c int
+}
+
+func solve(a, b, c int) int {
+	diff := abs(a - b)
+	n := diff * 2
+	if diff == 0 || max3(a, b, c) > n {
+		return -1
+	}
+	if c > diff {
+		return c - diff
+	}
+	return c + diff
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func max3(x, y, z int) int {
+	if x > y {
+		if x > z {
+			return x
+		}
+		return z
+	}
+	if y > z {
+		return y
+	}
+	return z
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]testCase, 100)
+	for i := 0; i < 50; i++ {
+		diff := r.Intn(100) + 1
+		n := diff * 2
+		a := r.Intn(diff) + 1
+		b := a + diff
+		c := r.Intn(n) + 1
+		tests[i] = testCase{a, b, c}
+	}
+	for i := 50; i < 100; i++ {
+		a := r.Intn(200) + 1
+		b := r.Intn(200) + 1
+		c := r.Intn(300) + 1
+		tests[i] = testCase{a, b, c}
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d %d %d\n", tc.a, tc.b, tc.c)
+		want := fmt.Sprintf("%d", solve(tc.a, tc.b, tc.c))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, want, got)
+			fmt.Printf("input:\n%s", input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1560/verifierC.go
+++ b/1000-1999/1500-1599/1560-1569/1560/verifierC.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	k int64
+}
+
+func position(k int64) (int64, int64) {
+	root := int64(math.Sqrt(float64(k)))
+	if root*root < k {
+		root++
+	}
+	prev := (root - 1) * (root - 1)
+	diff := k - prev
+	if diff <= root {
+		return diff, root
+	}
+	return root, root*2 - diff
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(3))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		tests[i].k = int64(r.Intn(1000000) + 1)
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n", tc.k)
+		r, c := position(tc.k)
+		want := fmt.Sprintf("%d %d", r, c)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, want, got)
+			fmt.Printf("input:\n%s", input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1560/verifierD.go
+++ b/1000-1999/1500-1599/1560-1569/1560/verifierD.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func precompute() []string {
+	res := make([]string, 0, 63)
+	for i := 0; i <= 60; i++ {
+		res = append(res, fmt.Sprintf("%d", 1<<uint(i)))
+	}
+	return res
+}
+
+func lcsPrefix(a, b string) int {
+	j := 0
+	for i := 0; i < len(a) && j < len(b); i++ {
+		if a[i] == b[j] {
+			j++
+		}
+	}
+	return j
+}
+
+func solve(n string, powers []string) int {
+	minOps := len(n) + 1e9
+	for _, p := range powers {
+		l := lcsPrefix(n, p)
+		ops := len(n) - l + len(p) - l
+		if ops < minOps {
+			minOps = ops
+		}
+	}
+	return minOps
+}
+
+type testCase struct {
+	n string
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(4))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		l := r.Intn(15) + 1
+		var sb strings.Builder
+		if r.Intn(2) == 0 {
+			sb.WriteByte(byte('1' + byte(r.Intn(9))))
+		} else {
+			sb.WriteByte('1')
+		}
+		for j := 1; j < l; j++ {
+			sb.WriteByte(byte('0' + r.Intn(10)))
+		}
+		tests[i].n = sb.String()
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	powers := precompute()
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%s\n", tc.n)
+		want := fmt.Sprintf("%d", solve(tc.n, powers))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, want, got)
+			fmt.Printf("input:\n%s", input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1560/verifierE.go
+++ b/1000-1999/1500-1599/1560-1569/1560/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	t string
+}
+
+func solve(t string) (string, string) {
+	seen := make(map[byte]bool)
+	orderRev := make([]byte, 0)
+	for i := len(t) - 1; i >= 0; i-- {
+		ch := t[i]
+		if !seen[ch] {
+			seen[ch] = true
+			orderRev = append(orderRev, ch)
+		}
+	}
+	order := make([]byte, len(orderRev))
+	for i := range orderRev {
+		order[len(orderRev)-1-i] = orderRev[i]
+	}
+
+	freq := make(map[byte]int)
+	for i := 0; i < len(t); i++ {
+		freq[t[i]]++
+	}
+
+	origCount := make(map[byte]int)
+	prefLen := 0
+	for i, ch := range order {
+		c := freq[ch]
+		step := i + 1
+		if c%step != 0 {
+			return "-1", ""
+		}
+		origCount[ch] = c / step
+		prefLen += origCount[ch]
+	}
+	if prefLen > len(t) {
+		return "-1", ""
+	}
+	s := t[:prefLen]
+	cur := []byte(s)
+	built := make([]byte, 0, len(t))
+	for _, ch := range order {
+		built = append(built, cur...)
+		filtered := make([]byte, 0, len(cur))
+		for _, c := range cur {
+			if c != ch {
+				filtered = append(filtered, c)
+			}
+		}
+		cur = filtered
+	}
+	if string(built) != t {
+		return "-1", ""
+	}
+	return s, string(order)
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(5))
+	tests := make([]testCase, 100)
+	letters := "abcde"
+	for i := range tests {
+		l := r.Intn(10) + 1
+		var sb strings.Builder
+		for j := 0; j < l; j++ {
+			sb.WriteByte(letters[r.Intn(len(letters))])
+		}
+		tests[i].t = sb.String()
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%s\n", tc.t)
+		s, ord := solve(tc.t)
+		want := "-1"
+		if s != "-1" {
+			want = fmt.Sprintf("%s %s", s, ord)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, want, got)
+			fmt.Printf("input:\n%s", input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1560/verifierF1.go
+++ b/1000-1999/1500-1599/1560-1569/1560/verifierF1.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	n int
+	k int
+}
+
+func smallestForLen(length int, digits []int) string {
+	sort.Ints(digits)
+	first := -1
+	for _, d := range digits {
+		if d != 0 {
+			first = d
+			break
+		}
+	}
+	if first == -1 {
+		return ""
+	}
+	res := make([]byte, length)
+	res[0] = byte('0' + first)
+	fill := digits[0]
+	for i := 1; i < length; i++ {
+		res[i] = byte('0' + fill)
+	}
+	return string(res)
+}
+
+func attemptSameLen(n string, digits []int) (string, bool) {
+	sort.Ints(digits)
+	L := len(n)
+	res := make([]byte, L)
+	var dfs func(pos int, tight bool) bool
+	dfs = func(pos int, tight bool) bool {
+		if pos == L {
+			return true
+		}
+		nd := int(n[pos] - '0')
+		for _, d := range digits {
+			if pos == 0 && d == 0 {
+				continue
+			}
+			if tight {
+				if d < nd {
+					continue
+				}
+				res[pos] = byte('0' + d)
+				if d == nd {
+					if dfs(pos+1, true) {
+						return true
+					}
+				} else {
+					for i := pos + 1; i < L; i++ {
+						res[i] = byte('0' + digits[0])
+					}
+					return true
+				}
+			} else {
+				res[pos] = byte('0' + d)
+				for i := pos + 1; i < L; i++ {
+					res[i] = byte('0' + digits[0])
+				}
+				return true
+			}
+		}
+		return false
+	}
+	if dfs(0, true) {
+		return string(res), true
+	}
+	return "", false
+}
+
+func buildCandidate(n string, digits []int) string {
+	if cand, ok := attemptSameLen(n, digits); ok {
+		return cand
+	}
+	return smallestForLen(len(n)+1, digits)
+}
+
+func cmpLess(a, b string) bool {
+	if len(a) != len(b) {
+		return len(a) < len(b)
+	}
+	return a < b
+}
+
+func solve(n, k int) string {
+	s := strconv.Itoa(n)
+	best := ""
+	if k == 1 {
+		for d := 1; d <= 9; d++ {
+			cand := buildCandidate(s, []int{d})
+			if best == "" || cmpLess(cand, best) {
+				best = cand
+			}
+		}
+	} else {
+		for i := 0; i <= 9; i++ {
+			for j := i; j <= 9; j++ {
+				digits := []int{i}
+				if j != i {
+					digits = append(digits, j)
+				}
+				if len(digits) == 1 && digits[0] == 0 {
+					continue
+				}
+				cand := buildCandidate(s, digits)
+				if cand == "" {
+					continue
+				}
+				if best == "" || cmpLess(cand, best) {
+					best = cand
+				}
+			}
+		}
+	}
+	return best
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(6))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		tests[i].n = r.Intn(1000000) + 1
+		tests[i].k = r.Intn(2) + 1
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF1.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d %d\n", tc.n, tc.k)
+		want := solve(tc.n, tc.k)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, want, got)
+			fmt.Printf("input:\n%s", input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1560-1569/1560/verifierF2.go
+++ b/1000-1999/1500-1599/1560-1569/1560/verifierF2.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	n int
+	k int
+}
+
+func countDistinct(mask int) int {
+	return bits.OnesCount(uint(mask))
+}
+
+func nextBeautiful(n int, k int) int {
+	s := strconv.Itoa(n)
+	L := len(s)
+	prefixMask := make([]int, L+1)
+	for i := 0; i < L; i++ {
+		d := int(s[i] - '0')
+		prefixMask[i+1] = prefixMask[i] | (1 << d)
+	}
+	if countDistinct(prefixMask[L]) <= k {
+		return n
+	}
+	best := int64(1<<63 - 1)
+	for j := L - 1; j >= 0; j-- {
+		mask := prefixMask[j]
+		if countDistinct(mask) > k {
+			continue
+		}
+		start := int(s[j]-'0') + 1
+		for d := start; d < 10; d++ {
+			m2 := mask | (1 << d)
+			if countDistinct(m2) > k {
+				continue
+			}
+			fill := byte('0')
+			for t := 0; t < 10; t++ {
+				m3 := m2
+				if (m3 & (1 << t)) == 0 {
+					m3 |= 1 << t
+				}
+				if countDistinct(m3) <= k {
+					fill = byte('0' + t)
+					break
+				}
+			}
+			cand := s[:j] + string('0'+byte(d)) + strings.Repeat(string(fill), L-j-1)
+			if val, err := strconv.ParseInt(cand, 10, 64); err == nil {
+				if val < best {
+					best = val
+				}
+			}
+		}
+	}
+	if best != int64(1<<63-1) {
+		return int(best)
+	}
+	if k == 1 {
+		ans := 0
+		for i := 0; i < L+1; i++ {
+			ans = ans*10 + 1
+		}
+		return ans
+	}
+	pow := 1
+	for i := 0; i < L; i++ {
+		pow *= 10
+	}
+	return pow
+}
+
+func genTests() []testCase {
+	r := rand.New(rand.NewSource(7))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		tests[i].n = r.Intn(1000000) + 1
+		tests[i].k = r.Intn(10) + 1
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF2.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d %d\n", tc.n, tc.k)
+		want := fmt.Sprintf("%d", nextBeautiful(tc.n, tc.k))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\n", i+1, want, got)
+			fmt.Printf("input:\n%s", input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add automated solution verifiers for contest 1560 problems A–F2
- each verifier runs 100 generated test cases against a provided binary or Go file

## Testing
- `go build verifierA.go && ./verifierA 1560A.go`
- `go build verifierB.go && ./verifierB 1560B.go`
- `go build verifierC.go && ./verifierC 1560C.go`
- `go build verifierD.go && ./verifierD 1560D.go`
- `go build verifierE.go && ./verifierE 1560E.go`
- `go build verifierF1.go && ./verifierF1 1560F1.go`
- `go build verifierF2.go && ./verifierF2 1560F2.go`


------
https://chatgpt.com/codex/tasks/task_e_68872527c7148324965166f125db912d