### PR TITLE
Add verifiers for contest 1571

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1571/verifierA.go
+++ b/1000-1999/1500-1599/1570-1579/1571/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleA.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1571A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(1571))
+	tests := []string{"<", ">", "=", "<>", "<<<>>>", "==<==>", "<><>", "<=><"}
+	for len(tests) < 100 {
+		l := rng.Intn(20) + 1
+		var sb strings.Builder
+		for i := 0; i < l; i++ {
+			sb.WriteByte("<>="[rng.Intn(3)])
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, s := range tests {
+		input := fmt.Sprintf("1\n%s\n", s)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput: %sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1500-1599/1570-1579/1571/verifierB.go
+++ b/1000-1999/1500-1599/1570-1579/1571/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testB struct {
+	n  int
+	a  int
+	va int
+	c  int
+	vc int
+	b  int
+}
+
+func buildOracle() (string, error) {
+	exe := "oracleB.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1571B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []testB {
+	rng := rand.New(rand.NewSource(1571))
+	tests := make([]testB, 0, 100)
+	for len(tests) < 100 {
+		a := rng.Intn(98) + 1
+		c := a + 2 + rng.Intn(100-(a+2)+1)
+		b := a + 1 + rng.Intn(c-a-1)
+		va := rng.Intn(a) + 1
+		vc := va + rng.Intn(c-va+1)
+		n := c + rng.Intn(100-c+1)
+		tests = append(tests, testB{n, a, va, c, vc, b})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%d %d\n%d %d\n%d\n", tc.n, tc.a, tc.va, tc.c, tc.vc, tc.b)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1500-1599/1570-1579/1571/verifierC.go
+++ b/1000-1999/1500-1599/1570-1579/1571/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type pair struct {
+	s string
+	t string
+	r int
+}
+
+type testC struct {
+	n     int
+	pairs []pair
+}
+
+func buildOracle() (string, error) {
+	exe := "oracleC.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1571C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randStr(rng *rand.Rand, l int) string {
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func genTests() []testC {
+	rng := rand.New(rand.NewSource(1571))
+	tests := make([]testC, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		pairs := make([]pair, n)
+		has1 := false
+		for i := 0; i < n; i++ {
+			s := randStr(rng, rng.Intn(5)+1)
+			t := randStr(rng, rng.Intn(5)+1)
+			r := rng.Intn(2)
+			if r == 1 {
+				has1 = true
+			}
+			pairs[i] = pair{s, t, r}
+		}
+		if !has1 {
+			pairs[0].r = 1
+		}
+		tests = append(tests, testC{n, pairs})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for _, p := range tc.pairs {
+			sb.WriteString(fmt.Sprintf("%s %s %d\n", p.s, p.t, p.r))
+		}
+		input := sb.String()
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1500-1599/1570-1579/1571/verifierD.go
+++ b/1000-1999/1500-1599/1570-1579/1571/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testD struct {
+	n     int
+	m     int
+	pairs [][2]int
+}
+
+func buildOracle() (string, error) {
+	exe := "oracleD.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1571D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []testD {
+	rng := rand.New(rand.NewSource(1571))
+	tests := make([]testD, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 2
+		m := rng.Intn(6) + 1
+		pairs := make([][2]int, m)
+		for i := 0; i < m; i++ {
+			f := rng.Intn(n) + 1
+			l := rng.Intn(n-1) + 1
+			if l >= f {
+				l++
+			}
+			pairs[i] = [2]int{f, l}
+		}
+		tests = append(tests, testD{n, m, pairs})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+		for _, p := range tc.pairs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+		}
+		input := sb.String()
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1500-1599/1570-1579/1571/verifierE.go
+++ b/1000-1999/1500-1599/1570-1579/1571/verifierE.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testE struct {
+	n int
+	s string
+	a string
+}
+
+func buildOracle() (string, error) {
+	exe := "oracleE.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1571E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randBracket(rng *rand.Rand, l int) string {
+	b := make([]byte, l)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = '('
+		} else {
+			b[i] = ')'
+		}
+	}
+	return string(b)
+}
+
+func randBinary(rng *rand.Rand, l int) string {
+	b := make([]byte, l)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return string(b)
+}
+
+func genTests() []testE {
+	rng := rand.New(rand.NewSource(1571))
+	tests := make([]testE, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(7) + 4
+		s := randBracket(rng, n)
+		a := randBinary(rng, n-3)
+		tests = append(tests, testE{n, s, a})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%s\n%s\n", tc.n, tc.s, tc.a)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1500-1599/1570-1579/1571/verifierF.go
+++ b/1000-1999/1500-1599/1570-1579/1571/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type comp struct {
+	k int
+	t int
+}
+
+type testF struct {
+	n     int
+	m     int
+	comps []comp
+}
+
+func buildOracle() (string, error) {
+	exe := "oracleF.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1571F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []testF {
+	rng := rand.New(rand.NewSource(1571))
+	tests := make([]testF, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(10) + 3
+		comps := make([]comp, n)
+		for i := 0; i < n; i++ {
+			k := rng.Intn(3) + 2
+			t := rng.Intn(2) + 1
+			comps[i] = comp{k, t}
+		}
+		tests = append(tests, testF{n, m, comps})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+		for _, c := range tc.comps {
+			sb.WriteString(fmt.Sprintf("%d %d\n", c.k, c.t))
+		}
+		input := sb.String()
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1500-1599/1570-1579/1571/verifierG.go
+++ b/1000-1999/1500-1599/1570-1579/1571/verifierG.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type attack struct {
+	damage int64
+	b      int
+}
+
+type warrior struct {
+	atks []attack
+}
+
+type testG struct {
+	n  int
+	m  int
+	ws []warrior
+}
+
+func buildOracle() (string, error) {
+	exe := "oracleG.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1571G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []testG {
+	rng := rand.New(rand.NewSource(1571))
+	tests := make([]testG, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(5) + 1
+		ws := make([]warrior, n)
+		for i := 0; i < n; i++ {
+			k := rng.Intn(3) + 1
+			used := make(map[int]bool)
+			atks := make([]attack, k)
+			for j := 0; j < k; j++ {
+				var b int
+				for {
+					b = rng.Intn(m + 1)
+					if !used[b] {
+						used[b] = true
+						break
+					}
+				}
+				dmg := rng.Int63n(20) + 1
+				atks[j] = attack{dmg, b}
+			}
+			// sort by b
+			for j := 0; j < k; j++ {
+				for t := j + 1; t < k; t++ {
+					if atks[t].b < atks[j].b {
+						atks[t], atks[j] = atks[j], atks[t]
+					}
+				}
+			}
+			ws[i] = warrior{atks}
+		}
+		tests = append(tests, testG{n, m, ws})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+		for _, w := range tc.ws {
+			sb.WriteString(fmt.Sprintf("%d\n", len(w.atks)))
+			for idx, a := range w.atks {
+				if idx > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", a.damage))
+			}
+			sb.WriteByte('\n')
+			for idx, a := range w.atks {
+				if idx > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", a.b))
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1500-1599/1570-1579/1571/verifierH.go
+++ b/1000-1999/1500-1599/1570-1579/1571/verifierH.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type enemy struct {
+	x int
+	y int
+	p int
+}
+
+type testH struct {
+	n  int
+	a  int
+	b  int
+	es []enemy
+}
+
+func buildOracle() (string, error) {
+	exe := "oracleH.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1571H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []testH {
+	rng := rand.New(rand.NewSource(1571))
+	tests := make([]testH, 0, 100)
+	for len(tests) < 100 {
+		a := rng.Intn(8) + 2
+		b := rng.Intn(8) + 2
+		n := rng.Intn(3) + 1
+		used := make(map[[2]int]bool)
+		es := make([]enemy, n)
+		for i := 0; i < n; i++ {
+			var x, y int
+			for {
+				x = rng.Intn(a-1) + 1
+				y = rng.Intn(b-1) + 1
+				if !used[[2]int{x, y}] {
+					used[[2]int{x, y}] = true
+					break
+				}
+			}
+			p := rng.Intn(999999) + 1
+			es[i] = enemy{x, y, p}
+		}
+		tests = append(tests, testH{n, a, b, es})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.a, tc.b))
+		for _, e := range tc.es {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", e.x, e.y, e.p))
+		}
+		input := sb.String()
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1500-1599/1570-1579/1571/verifierI.go
+++ b/1000-1999/1500-1599/1570-1579/1571/verifierI.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testI struct {
+	n int
+	L []int
+	R []int
+}
+
+func buildOracle() (string, error) {
+	exe := "oracleI.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1571I.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []testI {
+	rng := rand.New(rand.NewSource(1571))
+	tests := make([]testI, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(4) + 1
+		L := make([]int, n)
+		R := make([]int, n)
+		for i := 0; i < n; i++ {
+			L[i] = rng.Intn(10) + 1
+			R[i] = L[i] + rng.Intn(5)
+		}
+		tests = append(tests, testI{n, L, R})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for idx, v := range tc.L {
+			if idx > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for idx, v := range tc.R {
+			if idx > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1500-1599/1570-1579/1571/verifierJ.go
+++ b/1000-1999/1500-1599/1570-1579/1571/verifierJ.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testJ struct {
+	n  int
+	a  []int
+	b  []int
+	c  []int
+	q  int
+	qs [][2]int
+}
+
+func buildOracle() (string, error) {
+	exe := "oracleJ.bin"
+	cmd := exec.Command("go", "build", "-o", exe, "1571J.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return "./" + exe, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []testJ {
+	rng := rand.New(rand.NewSource(1571))
+	tests := make([]testJ, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(4) + 2
+		a := make([]int, n-1)
+		bArr := make([]int, n-1)
+		c := make([]int, n)
+		for i := 0; i < n-1; i++ {
+			a[i] = rng.Intn(10) + 1
+			bArr[i] = rng.Intn(10) + 1
+		}
+		for i := 0; i < n; i++ {
+			c[i] = rng.Intn(10) + 1
+		}
+		q := rng.Intn(3) + 1
+		qs := make([][2]int, q)
+		for i := 0; i < q; i++ {
+			l := rng.Intn(n-1) + 1
+			r := l + rng.Intn(n-l) + 1
+			qs[i] = [2]int{l, r}
+		}
+		tests = append(tests, testJ{n, a, bArr, c, q, qs})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierJ.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := genTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for idx, v := range tc.a {
+			if idx > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for idx, v := range tc.b {
+			if idx > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for idx, v := range tc.c {
+			if idx > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d\n", tc.q))
+		for _, qr := range tc.qs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", qr[0], qr[1]))
+		}
+		input := sb.String()
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A-J of contest 1571
- each verifier builds the official solution and runs 100 randomized tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`
- `go build verifierJ.go`


------
https://chatgpt.com/codex/tasks/task_e_6887282a213c8324913488d5496eb1ee