### PR TITLE
Fix 626D verifier float comparison

### DIFF
--- a/0-999/600-699/620-629/626/verifierD.go
+++ b/0-999/600-699/620-629/626/verifierD.go
@@ -3,8 +3,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -50,11 +52,19 @@ func main() {
 			fmt.Printf("case %d runtime error: %v\n", i+1, err)
 			continue
 		}
-		if got == strings.TrimSpace(t.Out) {
+		expectedVal, err1 := strconv.ParseFloat(strings.TrimSpace(t.Out), 64)
+		gotVal, err2 := strconv.ParseFloat(got, 64)
+		if err1 == nil && err2 == nil {
+			diff := math.Abs(expectedVal - gotVal)
+			if diff <= 1e-6*math.Max(1.0, math.Abs(expectedVal)) {
+				passed++
+				continue
+			}
+		} else if got == strings.TrimSpace(t.Out) {
 			passed++
-		} else {
-			fmt.Printf("case %d failed: expected %s got %s\n", i+1, t.Out, got)
+			continue
 		}
+		fmt.Printf("case %d failed: expected %s got %s\n", i+1, t.Out, got)
 	}
 	fmt.Printf("passed %d/%d\n", passed, len(tests))
 }


### PR DESCRIPTION
## Summary
- update verifier for contest 626 problem D to compare floating-point outputs with tolerance

## Testing
- `go build 0-999/600-699/620-629/626/verifierD.go`
- `go build 0-999/600-699/620-629/626/626D.go`
- `./verifierD ./626D | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68872944bcb88324b40615a63c0a9a40