### PR TITLE
Add verifiers for contest 1575

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1575/verifierA.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(5) + 1
+	used := make(map[string]bool)
+	titles := make([]string, 0, n)
+	for len(titles) < n {
+		b := make([]byte, m)
+		for i := 0; i < m; i++ {
+			b[i] = byte('A' + rand.Intn(26))
+		}
+		s := string(b)
+		if !used[s] {
+			used[s] = true
+			titles = append(titles, s)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, t := range titles {
+		sb.WriteString(t)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierA.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refA"
+	if err := exec.Command("go", "build", "-o", ref, "1575A.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierB.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierB.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(6) + 1
+	k := rand.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		x := rand.Intn(11) - 5
+		y := rand.Intn(11) - 5
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierB.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refB"
+	if err := exec.Command("go", "build", "-o", ref, "1575B.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierC.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierC.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(5) + 1
+	primes := []int{2, 3, 5, 7}
+	k := 1
+	if rand.Intn(2) == 0 {
+		k = primes[rand.Intn(len(primes))]
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(10)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierC.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refC"
+	if err := exec.Command("go", "build", "-o", ref, "1575C.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierD.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierD.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(8) + 1
+	chars := "0123456789_X"
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(chars[rand.Intn(len(chars))])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierD.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refD"
+	if err := exec.Command("go", "build", "-o", ref, "1575D.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierE.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierE.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	k := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rand.Intn(10)))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n-1; i++ {
+		u := i + 2
+		v := rand.Intn(i+1) + 1
+		t := rand.Intn(2)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", u, v, t))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierE.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refE"
+	if err := exec.Command("go", "build", "-o", ref, "1575E.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierF.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierF.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	k := rand.Intn(5) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		val := rand.Intn(k+1) - 1
+		sb.WriteString(fmt.Sprintf("%d ", val))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierF.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refF"
+	if err := exec.Command("go", "build", "-o", ref, "1575F.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierG.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierG.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rand.Intn(10)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierG.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refG"
+	if err := exec.Command("go", "build", "-o", ref, "1575G.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierH.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierH.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func randBinStr(len int) string {
+	b := make([]byte, len)
+	for i := range b {
+		b[i] = byte('0' + rand.Intn(2))
+	}
+	return string(b)
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 2
+	m := rand.Intn(n-1) + 1
+	a := randBinStr(n)
+	b := randBinStr(m)
+	return fmt.Sprintf("%d %d\n%s\n%s\n", n, m, a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierH.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refH"
+	if err := exec.Command("go", "build", "-o", ref, "1575H.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierI.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierI.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(4) + 2
+	q := rand.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rand.Intn(5)-2))
+	}
+	sb.WriteByte('\n')
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, i))
+	}
+	hasQuery := false
+	for i := 0; i < q; i++ {
+		if rand.Intn(2) == 0 {
+			u := rand.Intn(n) + 1
+			c := rand.Intn(5) - 2
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", u, c))
+		} else {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", u, v))
+			hasQuery = true
+		}
+	}
+	if !hasQuery {
+		sb.WriteString(fmt.Sprintf("2 %d %d\n", 1, n))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierI.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refI"
+	if err := exec.Command("go", "build", "-o", ref, "1575I.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierJ.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierJ.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(4) + 1
+	m := rand.Intn(4) + 1
+	k := rand.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			sb.WriteString(fmt.Sprintf("%d ", rand.Intn(3)+1))
+		}
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < k; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rand.Intn(m)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierJ.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refJ"
+	if err := exec.Command("go", "build", "-o", ref, "1575J.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierK.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierK.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(5) + 1
+	k := rand.Intn(5) + 2
+	r := rand.Intn(int(n)) + 1
+	c := rand.Intn(int(m)) + 1
+	ax := rand.Intn(int(n)) + 1
+	ay := rand.Intn(int(m)) + 1
+	bx := rand.Intn(int(n)) + 1
+	by := rand.Intn(int(m)) + 1
+	return fmt.Sprintf("%d %d %d %d %d\n%d %d %d %d\n", n, m, k, r, c, ax, ay, bx, by)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierK.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refK"
+	if err := exec.Command("go", "build", "-o", ref, "1575K.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierL.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierL.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rand.Intn(n)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierL.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refL"
+	if err := exec.Command("go", "build", "-o", ref, "1575L.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1575/verifierM.go
+++ b/1000-1999/1500-1599/1570-1579/1575/verifierM.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(3) + 1
+	m := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i <= n; i++ {
+		for j := 0; j <= m; j++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteString("0 ")
+			} else {
+				sb.WriteString("1 ")
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierM.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refM"
+	if err := exec.Command("go", "build", "-o", ref, "1575M.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier scripts for all problems in contest 1575
- each verifier builds the reference solution, generates 100 random tests and checks a candidate binary

## Testing
- `go build verifierA.go`


------
https://chatgpt.com/codex/tasks/task_e_6887294252e88324a03d173cffc2a3a1