### PR TITLE
Add Go verifiers for contest 1574

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1574/verifierA.go
+++ b/1000-1999/1500-1599/1570-1579/1574/verifierA.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	input string
+	nvals []int
+}
+
+func genCase(rng *rand.Rand) TestCase {
+	t := rng.Intn(4) + 1 // up to 4 testcases per run
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(t) + "\n")
+	nvals := make([]int, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(50) + 1
+		nvals[i] = n
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+	}
+	return TestCase{sb.String(), nvals}
+}
+
+func runProg(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func checkOutput(tc TestCase, out string) error {
+	out = strings.TrimSpace(out)
+	lines := strings.Split(out, "\n")
+	idx := 0
+	for caseNum, n := range tc.nvals {
+		if idx+n > len(lines) {
+			return fmt.Errorf("not enough lines for case %d", caseNum+1)
+		}
+		seen := make(map[string]bool)
+		for i := 0; i < n; i++ {
+			seq := strings.TrimSpace(lines[idx])
+			idx++
+			if len(seq) != 2*n {
+				return fmt.Errorf("case %d line %d: expected length %d got %d", caseNum+1, i+1, 2*n, len(seq))
+			}
+			bal := 0
+			for _, ch := range seq {
+				if ch == '(' {
+					bal++
+				} else if ch == ')' {
+					bal--
+				} else {
+					return fmt.Errorf("case %d line %d: invalid char %q", caseNum+1, i+1, ch)
+				}
+				if bal < 0 {
+					return fmt.Errorf("case %d line %d: not balanced", caseNum+1, i+1)
+				}
+			}
+			if bal != 0 {
+				return fmt.Errorf("case %d line %d: not balanced", caseNum+1, i+1)
+			}
+			if seen[seq] {
+				return fmt.Errorf("case %d line %d: duplicate sequence", caseNum+1, i+1)
+			}
+			seen[seq] = true
+		}
+	}
+	if idx != len(lines) {
+		return fmt.Errorf("extra output lines")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		out, err := runProg(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if err := checkOutput(tc, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, tc.input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1574/verifierB.go
+++ b/1000-1999/1500-1599/1570-1579/1574/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := filepath.Join(os.TempDir(), "1574B_ref.bin")
+	cmd := exec.Command("go", "build", "-o", ref, "1574B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runProg(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		a := rng.Int63n(1e5) + 1
+		b := rng.Int63n(1e5) + 1
+		c := rng.Int63n(1e5) + 1
+		m := rng.Int63n(a + b + c + 1)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, c, m)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1574/verifierC.go
+++ b/1000-1999/1500-1599/1570-1579/1574/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := filepath.Join(os.TempDir(), "1574C_ref.bin")
+	cmd := exec.Command("go", "build", "-o", ref, "1574C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runProg(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		val := rng.Intn(1000) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", val)
+	}
+	sb.WriteByte('\n')
+	m := rng.Intn(10) + 1
+	fmt.Fprintf(&sb, "%d\n", m)
+	for i := 0; i < m; i++ {
+		x := rng.Intn(1000) + 1
+		y := rng.Int63n(1000) + 1
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1574/verifierD.go
+++ b/1000-1999/1500-1599/1570-1579/1574/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := filepath.Join(os.TempDir(), "1574D_ref.bin")
+	cmd := exec.Command("go", "build", "-o", ref, "1574D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runProg(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	counts := make([]int, n)
+	for i := 0; i < n; i++ {
+		c := rng.Intn(3) + 1
+		counts[i] = c
+		fmt.Fprintf(&sb, "%d", c)
+		for j := 0; j < c; j++ {
+			val := rng.Intn(20) + 1
+			fmt.Fprintf(&sb, " %d", val)
+		}
+		sb.WriteByte('\n')
+	}
+	m := rng.Intn(3)
+	fmt.Fprintf(&sb, "%d\n", m)
+	seen := make(map[string]bool)
+	for len(seen) < m {
+		var build strings.Builder
+		for i := 0; i < n; i++ {
+			idx := rng.Intn(counts[i]) + 1
+			if i > 0 {
+				build.WriteByte(' ')
+			}
+			fmt.Fprintf(&build, "%d", idx)
+		}
+		s := build.String()
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1574/verifierE.go
+++ b/1000-1999/1500-1599/1570-1579/1574/verifierE.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := filepath.Join(os.TempDir(), "1574E_ref.bin")
+	cmd := exec.Command("go", "build", "-o", ref, "1574E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runProg(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 2
+	m := rng.Intn(3) + 2
+	k := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < k; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(m) + 1
+		t := rng.Intn(3) - 1 // -1,0,1
+		fmt.Fprintf(&sb, "%d %d %d\n", x, y, t)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1574/verifierF.go
+++ b/1000-1999/1500-1599/1570-1579/1574/verifierF.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := filepath.Join(os.TempDir(), "1574F_ref.bin")
+	cmd := exec.Command("go", "build", "-o", ref, "1574F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runProg(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(2) + 1
+	m := rng.Intn(3) + 1
+	k := rng.Intn(3) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < n; i++ {
+		c := rng.Intn(m) + 1
+		fmt.Fprintf(&sb, "%d", c)
+		for j := 0; j < c; j++ {
+			val := rng.Intn(k) + 1
+			fmt.Fprintf(&sb, " %d", val)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for problems A–F of contest 1574
- each verifier builds the official solution and runs 100 random tests
- verifier for A directly checks bracket sequence validity

## Testing
- `go build 1000-1999/1500-1599/1570-1579/1574/verifierA.go`
- `go build 1000-1999/1500-1599/1570-1579/1574/verifierB.go`
- `go build 1000-1999/1500-1599/1570-1579/1574/verifierC.go`
- `go build 1000-1999/1500-1599/1570-1579/1574/verifierD.go`
- `go build 1000-1999/1500-1599/1570-1579/1574/verifierE.go`
- `go build 1000-1999/1500-1599/1570-1579/1574/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688728fc47008324a8da9eecd8fa0ce7