### PR TITLE
Add verifiers for Codeforces contest 1581

### DIFF
--- a/1000-1999/1500-1599/1580-1589/1581/verifierA.go
+++ b/1000-1999/1500-1599/1580-1589/1581/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n int
+}
+
+const mod int64 = 1000000007
+
+func expectedA(n int) string {
+	fac := int64(1)
+	for i := 2; i <= 2*n; i++ {
+		fac = fac * int64(i) % mod
+	}
+	ans := fac * ((mod + 1) / 2) % mod
+	return fmt.Sprint(ans)
+}
+
+func buildInputA(tc testCaseA) string {
+	return fmt.Sprintf("1\n%d\n", tc.n)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd = exec.CommandContext(ctx, cmd.Path, cmd.Args[1:]...)
+	cmd.Stdin = strings.NewReader(input)
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCaseA(rng *rand.Rand) testCaseA {
+	return testCaseA{n: rng.Intn(100000) + 1}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCaseA
+	// deterministic cases
+	cases = append(cases, testCaseA{n: 1})
+	cases = append(cases, testCaseA{n: 2})
+	cases = append(cases, testCaseA{n: 3})
+	cases = append(cases, testCaseA{n: 5})
+	cases = append(cases, testCaseA{n: 10})
+	cases = append(cases, testCaseA{n: 100000})
+	cases = append(cases, testCaseA{n: 99999})
+	cases = append(cases, testCaseA{n: 54321})
+
+	for len(cases) < 110 {
+		cases = append(cases, randomCaseA(rng))
+	}
+
+	for i, tc := range cases {
+		input := buildInputA(tc)
+		expect := expectedA(tc.n)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1500-1599/1580-1589/1581/verifierB.go
+++ b/1000-1999/1500-1599/1580-1589/1581/verifierB.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n int64
+	m int64
+	k int64
+}
+
+func expectedB(tc testCaseB) string {
+	n, m, k := tc.n, tc.m, tc.k
+	maxEdges := n * (n - 1) / 2
+	if m < n-1 || m > maxEdges {
+		return "NO"
+	}
+	if n == 1 {
+		if m == 0 && k > 1 {
+			return "YES"
+		}
+		return "NO"
+	}
+	if n == 2 {
+		if m == 1 && k > 2 {
+			return "YES"
+		}
+		return "NO"
+	}
+	var minDiameter int64
+	if m == maxEdges {
+		minDiameter = 1
+	} else {
+		minDiameter = 2
+	}
+	if k-1 > minDiameter {
+		return "YES"
+	}
+	return "NO"
+}
+
+func buildInputB(tc testCaseB) string {
+	return fmt.Sprintf("1\n%d %d %d\n", tc.n, tc.m, tc.k)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd = exec.CommandContext(ctx, cmd.Path, cmd.Args[1:]...)
+	cmd.Stdin = strings.NewReader(input)
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCaseB(rng *rand.Rand) testCaseB {
+	n := rng.Int63n(1_000_000_000) + 1
+	maxEdges := n * (n - 1) / 2
+	if maxEdges > 1_000_000_000 {
+		maxEdges = 1_000_000_000
+	}
+	m := rng.Int63n(maxEdges + 1)
+	k := rng.Int63n(1_000_000_000) + 1
+	return testCaseB{n: n, m: m, k: k}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCaseB
+	// deterministic cases
+	cases = append(cases, testCaseB{n: 1, m: 0, k: 2})
+	cases = append(cases, testCaseB{n: 1, m: 1, k: 2})
+	cases = append(cases, testCaseB{n: 2, m: 1, k: 3})
+	cases = append(cases, testCaseB{n: 2, m: 1, k: 2})
+	cases = append(cases, testCaseB{n: 3, m: 2, k: 3})
+	cases = append(cases, testCaseB{n: 3, m: 3, k: 4})
+
+	for len(cases) < 110 {
+		cases = append(cases, randomCaseB(rng))
+	}
+
+	for i, tc := range cases {
+		input := buildInputB(tc)
+		expect := expectedB(tc)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(strings.ToUpper(out)) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` and `verifierB.go` for contest 1581
- each verifier runs at least 100 deterministic and random tests
- expected outputs are computed internally

## Testing
- `go build 1000-1999/1500-1599/1580-1589/1581/verifierA.go`
- `go build 1000-1999/1500-1599/1580-1589/1581/verifierB.go`
- `go build -o /tmp/1581A_bin 1000-1999/1500-1599/1580-1589/1581/1581A.go`
- `go run 1000-1999/1500-1599/1580-1589/1581/verifierA.go /tmp/1581A_bin`
- `go build -o /tmp/1581B_bin 1000-1999/1500-1599/1580-1589/1581/1581B.go`
- `go run 1000-1999/1500-1599/1580-1589/1581/verifierB.go /tmp/1581B_bin`

------
https://chatgpt.com/codex/tasks/task_e_68872ae683f88324a592ed2187181f46