### PR TITLE
Add verifiers for CF contest 1579

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1579/verifierA.go
+++ b/1000-1999/1500-1599/1570-1579/1579/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(s string) string {
+	cntA, cntB, cntC := 0, 0, 0
+	for _, ch := range s {
+		switch ch {
+		case 'A':
+			cntA++
+		case 'B':
+			cntB++
+		case 'C':
+			cntC++
+		}
+	}
+	if cntB == cntA+cntC {
+		return "YES\n"
+	}
+	return "NO\n"
+}
+
+func genCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	letters := []byte{'A', 'B', 'C'}
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(3)]
+	}
+	s := string(b)
+	input := fmt.Sprintf("1\n%s\n", s)
+	expect := solveA(s)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := genCaseA(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1579/verifierB.go
+++ b/1000-1999/1500-1599/1570-1579/1579/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func rotateLeft(arr []int, l, r, d int) {
+	d = d % (r - l)
+	if d == 0 {
+		return
+	}
+	tmp := append([]int(nil), arr[l:l+d]...)
+	copy(arr[l:r-d], arr[l+d:r])
+	copy(arr[r-d:r], tmp)
+}
+
+func runCaseB(bin string, n int, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid k: %v", err)
+	}
+	if k > n {
+		return fmt.Errorf("k too large")
+	}
+	if len(fields) != 1+3*k {
+		return fmt.Errorf("expected %d numbers got %d", 1+3*k, len(fields))
+	}
+	a := append([]int(nil), arr...)
+	idx := 1
+	for op := 0; op < k; op++ {
+		l, _ := strconv.Atoi(fields[idx])
+		r, _ := strconv.Atoi(fields[idx+1])
+		d, _ := strconv.Atoi(fields[idx+2])
+		idx += 3
+		if l < 1 || l >= r || r > n {
+			return fmt.Errorf("invalid operation")
+		}
+		rotateLeft(a, l-1, r, d)
+	}
+	for i := 0; i+1 < n; i++ {
+		if a[i] > a[i+1] {
+			return fmt.Errorf("array not sorted")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 2
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(21) - 10
+		}
+		if err := runCaseB(bin, n, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1579/verifierC.go
+++ b/1000-1999/1500-1599/1570-1579/1579/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(n, m, k int, grid []string) string {
+	covered := make([][]bool, n)
+	for i := range covered {
+		covered[i] = make([]bool, m)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := 0; j < m; j++ {
+			if grid[i][j] != '*' {
+				continue
+			}
+			size := 0
+			for {
+				x := i - size - 1
+				y1 := j - size - 1
+				y2 := j + size + 1
+				if x < 0 || y1 < 0 || y2 >= m {
+					break
+				}
+				if grid[x][y1] == '*' && grid[x][y2] == '*' {
+					size++
+				} else {
+					break
+				}
+			}
+			if size >= k {
+				covered[i][j] = true
+				for d := 1; d <= size; d++ {
+					covered[i-d][j-d] = true
+					covered[i-d][j+d] = true
+				}
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '*' && !covered[i][j] {
+				return "NO\n"
+			}
+		}
+	}
+	return "YES\n"
+}
+
+func genCaseC(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(19) + 1
+	k := rng.Intn(n) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = '.'
+			} else {
+				b[j] = '*'
+			}
+		}
+		grid[i] = string(b)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for _, row := range grid {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expect := solveC(n, m, k, grid)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := genCaseC(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1579/verifierD.go
+++ b/1000-1999/1500-1599/1570-1579/1579/verifierD.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type person struct {
+	cnt int
+	idx int
+}
+
+type pHeap []person
+
+func (h pHeap) Len() int            { return len(h) }
+func (h pHeap) Less(i, j int) bool  { return h[i].cnt > h[j].cnt }
+func (h pHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *pHeap) Push(x interface{}) { *h = append(*h, x.(person)) }
+func (h *pHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func maxPairs(arr []int) int {
+	h := &pHeap{}
+	heap.Init(h)
+	for i, v := range arr {
+		if v > 0 {
+			heap.Push(h, person{v, i})
+		}
+	}
+	pairs := 0
+	for h.Len() >= 2 {
+		a := heap.Pop(h).(person)
+		b := heap.Pop(h).(person)
+		pairs++
+		a.cnt--
+		b.cnt--
+		if a.cnt > 0 {
+			heap.Push(h, a)
+		}
+		if b.cnt > 0 {
+			heap.Push(h, b)
+		}
+	}
+	return pairs
+}
+
+func runCaseD(bin string, arr []int) error {
+	n := len(arr)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid k")
+	}
+	if len(fields) != 1+2*k {
+		return fmt.Errorf("expected %d numbers got %d", 1+2*k, len(fields))
+	}
+	expectK := maxPairs(arr)
+	if k != expectK {
+		return fmt.Errorf("wrong k: expected %d got %d", expectK, k)
+	}
+	counts := append([]int(nil), arr...)
+	idx := 1
+	for i := 0; i < k; i++ {
+		aIdx, _ := strconv.Atoi(fields[idx])
+		bIdx, _ := strconv.Atoi(fields[idx+1])
+		idx += 2
+		if aIdx < 1 || aIdx > n || bIdx < 1 || bIdx > n || aIdx == bIdx {
+			return fmt.Errorf("invalid pair")
+		}
+		counts[aIdx-1]--
+		counts[bIdx-1]--
+		if counts[aIdx-1] < 0 || counts[bIdx-1] < 0 {
+			return fmt.Errorf("negative count")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 2
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(5)
+		}
+		if err := runCaseD(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1579/verifierE1.go
+++ b/1000-1999/1500-1599/1570-1579/1579/verifierE1.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveE1(p []int) string {
+	n := len(p)
+	dq := make([]int, 2*n+5)
+	l := n
+	r := n
+	dq[l] = p[0]
+	for i := 1; i < n; i++ {
+		if p[i] < dq[l] {
+			l--
+			dq[l] = p[i]
+		} else {
+			r++
+			dq[r] = p[i]
+		}
+	}
+	res := dq[l : r+1]
+	var sb strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func genCaseE1(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	arr := rand.Perm(n)
+	for i := range arr {
+		arr[i]++
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := solveE1(arr)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := genCaseE1(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1579/verifierE2.go
+++ b/1000-1999/1500-1599/1570-1579/1579/verifierE2.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Fenwick struct {
+	n   int
+	bit []int
+}
+
+func NewFenwick(n int) *Fenwick {
+	return &Fenwick{n: n, bit: make([]int, n+2)}
+}
+
+func (f *Fenwick) Add(i, v int) {
+	for i <= f.n {
+		f.bit[i] += v
+		i += i & -i
+	}
+}
+
+func (f *Fenwick) Sum(i int) int {
+	if i > f.n {
+		i = f.n
+	}
+	s := 0
+	for i > 0 {
+		s += f.bit[i]
+		i -= i & -i
+	}
+	return s
+}
+
+func solveE2(arr []int) string {
+	vals := append([]int(nil), arr...)
+	sort.Ints(vals)
+	vals = unique(vals)
+	m := len(vals)
+	comp := make(map[int]int, m)
+	for i, v := range vals {
+		comp[v] = i + 1
+	}
+	ft := NewFenwick(m)
+	total := 0
+	ans := 0
+	for _, v := range arr {
+		idx := comp[v]
+		less := ft.Sum(idx - 1)
+		greater := total - ft.Sum(idx)
+		if less < greater {
+			ans += less
+		} else {
+			ans += greater
+		}
+		ft.Add(idx, 1)
+		total++
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func unique(a []int) []int {
+	if len(a) == 0 {
+		return a
+	}
+	res := []int{a[0]}
+	for _, v := range a[1:] {
+		if v != res[len(res)-1] {
+			res = append(res, v)
+		}
+	}
+	return res
+}
+
+func genCaseE2(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(21) - 10
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := solveE2(arr)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := genCaseE2(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1579/verifierF.go
+++ b/1000-1999/1500-1599/1570-1579/1579/verifierF.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveF(n, d int, arr []int) string {
+	g := gcd(n, d)
+	ans := 0
+	impossible := false
+	for start := 0; start < g && !impossible; start++ {
+		cycle := []int{}
+		j := start
+		for {
+			cycle = append(cycle, arr[j])
+			j = (j + d) % n
+			if j == start {
+				break
+			}
+		}
+		allOne := true
+		for _, v := range cycle {
+			if v == 0 {
+				allOne = false
+				break
+			}
+		}
+		if allOne {
+			impossible = true
+			break
+		}
+		cur, best := 0, 0
+		L := len(cycle)
+		for i := 0; i < 2*L; i++ {
+			if cycle[i%L] == 1 {
+				cur++
+				if cur > best {
+					best = cur
+				}
+			} else {
+				cur = 0
+			}
+		}
+		if best > ans {
+			ans = best
+		}
+	}
+	if impossible {
+		return "-1\n"
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func genCaseF(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	d := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(2)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, d))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := solveF(n, d, arr)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := genCaseF(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1579/verifierG.go
+++ b/1000-1999/1500-1599/1570-1579/1579/verifierG.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type bitset []uint64
+
+func newBitset(nbits int) bitset {
+	n := (nbits + 63) >> 6
+	return make(bitset, n)
+}
+
+func (b bitset) setAll(nbits int) {
+	for i := range b {
+		b[i] = ^uint64(0)
+	}
+	tail := nbits & 63
+	if tail != 0 {
+		b[len(b)-1] &= (uint64(1) << tail) - 1
+	}
+}
+
+func (b bitset) any() bool {
+	for _, w := range b {
+		if w != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (dst bitset) shl(src bitset, k int) {
+	n := len(src)
+	wordShift := k >> 6
+	offset := uint(k & 63)
+	for i := n - 1; i >= 0; i-- {
+		var v uint64
+		j := i - wordShift
+		if j >= 0 {
+			v = src[j] << offset
+			if offset != 0 && j-1 >= 0 {
+				v |= src[j-1] >> (64 - offset)
+			}
+		}
+		dst[i] = v
+	}
+}
+
+func (dst bitset) shr(src bitset, k int) {
+	n := len(src)
+	wordShift := k >> 6
+	offset := uint(k & 63)
+	for i := 0; i < n; i++ {
+		var v uint64
+		j := i + wordShift
+		if j < n {
+			v = src[j] >> offset
+			if offset != 0 && j+1 < n {
+				v |= src[j+1] << (64 - offset)
+			}
+		}
+		dst[i] = v
+	}
+}
+
+func feasible(a []int, d int) bool {
+	bsize := d + 1
+	dpPrev := newBitset(bsize)
+	dpPrev.setAll(bsize)
+	dpCur := newBitset(bsize)
+	tmp := newBitset(bsize)
+	for _, ai := range a {
+		tmp.shl(dpPrev, ai)
+		for i := range dpCur {
+			dpCur[i] = tmp[i]
+		}
+		tmp.shr(dpPrev, ai)
+		for i := range dpCur {
+			dpCur[i] |= tmp[i]
+		}
+		tail := bsize & 63
+		if tail != 0 {
+			mask := uint64(1)<<uint(tail) - 1
+			dpCur[len(dpCur)-1] &= mask
+		}
+		if !dpCur.any() {
+			return false
+		}
+		dpPrev, dpCur = dpCur, dpPrev
+	}
+	return true
+}
+
+func solveG(a []int) string {
+	maxa := 0
+	for _, v := range a {
+		if v > maxa {
+			maxa = v
+		}
+	}
+	lo, hi := maxa, 2*maxa
+	ans := hi
+	for lo <= hi {
+		mid := (lo + hi) >> 1
+		if feasible(a, mid) {
+			ans = mid
+			hi = mid - 1
+		} else {
+			lo = mid + 1
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func genCaseG(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := solveG(a)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := genCaseG(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest 1579
- verifiers generate 100 random tests each and check arbitrary binaries

## Testing
- `go run verifierA.go ./solA_bin`
- `go run verifierC.go ./solC_bin`
- `go build verifierB.go`
- `go build verifierD.go`
- `go build verifierE1.go`
- `go build verifierE2.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68872a5a68808324884bbe3706c459d0