### PR TITLE
Add verifiers for contest 1578

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1578/verifierA.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(2) + 1
+	m := r.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	letters := "abc"
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if r.Intn(2) == 0 {
+				sb.WriteByte('.')
+			} else {
+				sb.WriteByte(letters[r.Intn(len(letters))])
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierB.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	m := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		e := r.Intn(2) + 1
+		v := r.Intn(n) + 1
+		u := r.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e, v, u))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierC.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierC.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(3) + 1
+	var sb strings.Builder
+	// build a chain tree with n nodes
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, n-1))
+	for i := 1; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", i, i+1))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierD.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := r.Intn(21) - 10
+		y := r.Intn(21) - 10
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierE.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierE.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		h := r.Intn(20) + 1
+		p := r.Intn(20) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", h, p))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierF.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierF.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(4) + 3
+	radius := float64(r.Intn(5) + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		ang := 2 * math.Pi * float64(i) / float64(n)
+		x := int(math.Round(radius * math.Cos(ang)))
+		y := int(math.Round(radius * math.Sin(ang)))
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierG.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierG.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleG")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		w := r.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", w))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierH.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierH.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleH")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genType(r *rand.Rand, depth int) string {
+	if depth > 3 || r.Intn(2) == 0 {
+		if r.Intn(2) == 0 {
+			return "()"
+		}
+		return "(" + genType(r, depth+1) + ")"
+	}
+	left := "(" + genType(r, depth+1) + ")"
+	if r.Intn(2) == 0 {
+		return left
+	}
+	return left + "->" + genType(r, depth+1)
+}
+
+func genCase(r *rand.Rand) string {
+	return genType(r, 0) + "\n"
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierI.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierI.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleI")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578I.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string) (string, error) {
+	cmd := exec.Command(bin)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	expect, err := run(oracle)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	for i := 1; i <= 100; i++ {
+		got, err := run(bin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "run %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "run %d failed: expected %s got %s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierJ.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierJ.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleJ")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578J.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		parent := r.Intn(i) // 0..i-1
+		m := r.Intn(100)
+		sb.WriteString(fmt.Sprintf("%d %d\n", parent, m))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierK.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierK.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleK")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578K.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	p := r.Intn(4) + 1
+	n := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", p, n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d\n", r.Intn(p)+1))
+	}
+	k := r.Intn(n + 1)
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	for i := 0; i < k; i++ {
+		a := r.Intn(n) + 1
+		b := r.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierK.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierL.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierL.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleL")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578L.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(4) + 2
+	maxEdges := n * (n - 1) / 2
+	m := r.Intn(maxEdges) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d\n", r.Intn(10)+1))
+	}
+	for i := 0; i < m; i++ {
+		u := r.Intn(n) + 1
+		v := r.Intn(n) + 1
+		for v == u {
+			v = r.Intn(n) + 1
+		}
+		w := r.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", u, v, w))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierL.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1500-1599/1570-1579/1578/verifierM.go
+++ b/1000-1999/1500-1599/1570-1579/1578/verifierM.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleM")
+	cmd := exec.Command("go", "build", "-o", oracle, "1578M.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string) (string, error) {
+	cmd := exec.Command(bin)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierM.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	expect, err := run(oracle)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	for i := 1; i <= 100; i++ {
+		got, err := run(bin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "run %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "run %d failed: expected %s got %s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–M of contest 1578
- each verifier builds the reference solution and checks 100 random cases

## Testing
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierA.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierB.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierC.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierD.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierE.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierF.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierG.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierH.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierI.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierJ.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierK.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierL.go`
- `go build 1000-1999/1500-1599/1570-1579/1578/verifierM.go`


------
https://chatgpt.com/codex/tasks/task_e_68872a14667083249dd5d5c5969fe308