### PR TITLE
Add verifiers for contest 1582

### DIFF
--- a/1000-1999/1500-1599/1580-1589/1582/verifierA.go
+++ b/1000-1999/1500-1599/1580-1589/1582/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%d", tag, time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type testCaseA struct {
+	a, b, c int64
+}
+
+func genCase(rng *rand.Rand) testCaseA {
+	return testCaseA{
+		a: rng.Int63n(1_000_000_000),
+		b: rng.Int63n(1_000_000_000),
+		c: rng.Int63n(1_000_000_000),
+	}
+}
+
+func solveCase(tc testCaseA) string {
+	total := tc.a + 2*tc.b + 3*tc.c
+	if total%2 == 0 {
+		return "0\n"
+	}
+	return "1\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candA")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		input := fmt.Sprintf("1\n%d %d %d\n", tc.a, tc.b, tc.c)
+		expected := solveCase(tc)
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1580-1589/1582/verifierB.go
+++ b/1000-1999/1500-1599/1580-1589/1582/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%d", tag, time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type testCaseB struct {
+	n   int
+	arr []int
+}
+
+func genCase(rng *rand.Rand) testCaseB {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(3) // values 0..2
+	}
+	return testCaseB{n: n, arr: arr}
+}
+
+func solveCase(tc testCaseB) string {
+	c0, c1 := 0, 0
+	for _, v := range tc.arr {
+		if v == 0 {
+			c0++
+		} else if v == 1 {
+			c1++
+		}
+	}
+	ans := int64(c1) * (int64(1) << c0)
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", tc.arr[j]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveCase(tc)
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1580-1589/1582/verifierC.go
+++ b/1000-1999/1500-1599/1580-1589/1582/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%d", tag, time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type testCaseC struct {
+	n int
+	s string
+}
+
+func genCase(rng *rand.Rand) testCaseC {
+	n := rng.Intn(10) + 1
+	bytes := make([]byte, n)
+	for i := 0; i < n; i++ {
+		bytes[i] = byte('a' + rng.Intn(3))
+	}
+	return testCaseC{n: n, s: string(bytes)}
+}
+
+const INF = int(1e9)
+
+func cost(s string, ch byte) int {
+	l := 0
+	r := len(s) - 1
+	cnt := 0
+	for l < r {
+		if s[l] == s[r] {
+			l++
+			r--
+		} else if s[l] == ch {
+			cnt++
+			l++
+		} else if s[r] == ch {
+			cnt++
+			r--
+		} else {
+			return INF
+		}
+	}
+	return cnt
+}
+
+func solveCase(tc testCaseC) string {
+	best := INF
+	for c := byte('a'); c <= byte('z'); c++ {
+		v := cost(tc.s, c)
+		if v < best {
+			best = v
+		}
+	}
+	if best == INF {
+		return "-1\n"
+	}
+	return fmt.Sprintf("%d\n", best)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candC")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		input := fmt.Sprintf("1\n%d\n%s\n", tc.n, tc.s)
+		expected := solveCase(tc)
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1580-1589/1582/verifierD.go
+++ b/1000-1999/1500-1599/1580-1589/1582/verifierD.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%d", tag, time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type testCaseD struct {
+	n   int
+	arr []int64
+}
+
+func genCase(rng *rand.Rand) testCaseD {
+	n := rng.Intn(9) + 2 // 2..10
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		v := int64(rng.Intn(20001) - 10000)
+		if v == 0 {
+			v = 1
+		}
+		arr[i] = v
+	}
+	return testCaseD{n: n, arr: arr}
+}
+
+func solveCase(tc testCaseD) string {
+	n := tc.n
+	a := tc.arr
+	b := make([]int64, n)
+	if n%2 == 0 {
+		for i := 0; i < n; i += 2 {
+			b[i] = -a[i+1]
+			b[i+1] = a[i]
+		}
+	} else {
+		for i := 0; i < n-3; i += 2 {
+			b[i] = -a[i+1]
+			b[i+1] = a[i]
+		}
+		i0 := n - 3
+		i1 := n - 2
+		i2 := n - 1
+		if a[i0]+a[i1] != 0 {
+			b[i0] = -a[i2]
+			b[i1] = -a[i2]
+			b[i2] = a[i0] + a[i1]
+		} else if a[i0]+a[i2] != 0 {
+			b[i0] = -a[i1]
+			b[i1] = a[i0] + a[i2]
+			b[i2] = -a[i1]
+		} else {
+			b[i0] = a[i1] + a[i2]
+			b[i1] = -a[i0]
+			b[i2] = -a[i0]
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", b[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candD")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", tc.arr[j]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveCase(tc)
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1580-1589/1582/verifierE.go
+++ b/1000-1999/1500-1599/1580-1589/1582/verifierE.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%d", tag, time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type testCaseE struct {
+	n   int
+	arr []int64
+}
+
+func genCase(rng *rand.Rand) testCaseE {
+	n := rng.Intn(8) + 2
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Int63n(20) + 1
+	}
+	return testCaseE{n: n, arr: arr}
+}
+
+const negInf int64 = -1 << 60
+
+func maxK(n int) int {
+	return int((math.Sqrt(float64(8*n+1)) - 1) / 2)
+}
+
+func solveE(n int, a []int64) int {
+	maxLen := maxK(n)
+	prefix := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] + a[i]
+	}
+
+	dp := make([][]int64, maxLen+1)
+	suf := make([][]int64, maxLen+1)
+
+	dp[1] = make([]int64, n)
+	suf[1] = make([]int64, n+1)
+	for i := 0; i <= n; i++ {
+		suf[1][i] = negInf
+	}
+	for i := n - 1; i >= 0; i-- {
+		dp[1][i] = a[i]
+		if dp[1][i] > suf[1][i+1] {
+			suf[1][i] = dp[1][i]
+		} else {
+			suf[1][i] = suf[1][i+1]
+		}
+	}
+
+	for l := 2; l <= maxLen; l++ {
+		dp[l] = make([]int64, n)
+		suf[l] = make([]int64, n+1)
+		for i := 0; i <= n; i++ {
+			suf[l][i] = negInf
+		}
+		for i := n - 1; i >= 0; i-- {
+			if i+l <= n {
+				sum := prefix[i+l] - prefix[i]
+				if suf[l-1][i+l] > sum {
+					dp[l][i] = sum
+				} else {
+					dp[l][i] = negInf
+				}
+			} else {
+				dp[l][i] = negInf
+			}
+			if dp[l][i] > suf[l][i+1] {
+				suf[l][i] = dp[l][i]
+			} else {
+				suf[l][i] = suf[l][i+1]
+			}
+		}
+	}
+
+	for k := maxLen; k >= 1; k-- {
+		if suf[k][0] > negInf {
+			return k
+		}
+	}
+	return 1
+}
+
+func solveCase(tc testCaseE) string {
+	return fmt.Sprintf("%d\n", solveE(tc.n, tc.arr))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(5))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", tc.arr[j]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveCase(tc)
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1580-1589/1582/verifierF1.go
+++ b/1000-1999/1500-1599/1580-1589/1582/verifierF1.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%d", tag, time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type testCaseF1 struct {
+	n   int
+	arr []int
+}
+
+func genCase(rng *rand.Rand) testCaseF1 {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(500)
+	}
+	return testCaseF1{n: n, arr: arr}
+}
+
+func solveF1(tc testCaseF1) string {
+	arr := tc.arr
+	const maxX = 512
+	inf := 1000
+	dp := make([]int, maxX)
+	tmp := make([]int, maxX)
+	for i := range dp {
+		dp[i] = inf
+	}
+	dp[0] = -1
+	for _, v := range arr {
+		copy(tmp, dp)
+		for x := 0; x < maxX; x++ {
+			if dp[x] < v {
+				nx := x ^ v
+				if v < tmp[nx] {
+					tmp[nx] = v
+				}
+			}
+		}
+		dp, tmp = tmp, dp
+	}
+	res := make([]int, 0)
+	for x := 0; x < maxX; x++ {
+		if dp[x] < inf {
+			res = append(res, x)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(res)))
+	for i, val := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", val))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candF1")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(6))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", tc.arr[j]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveF1(tc)
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1580-1589/1582/verifierF2.go
+++ b/1000-1999/1500-1599/1580-1589/1582/verifierF2.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%d", tag, time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type testCaseF2 struct {
+	n   int
+	arr []int
+}
+
+func genCase(rng *rand.Rand) testCaseF2 {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) // small numbers
+	}
+	return testCaseF2{n: n, arr: arr}
+}
+
+func solveF2(tc testCaseF2) string {
+	const MAXV = 5000
+	const LIMIT = 13
+	counts := make([]int, MAXV+1)
+	vals := make([]int, 0)
+	for _, x := range tc.arr {
+		if counts[x] < LIMIT {
+			counts[x]++
+			vals = append(vals, x)
+		}
+	}
+	const MAXX = 1 << 13
+	const INF = MAXV + 1
+	dp := make([]int, MAXX)
+	for i := range dp {
+		dp[i] = INF
+	}
+	dp[0] = 0
+	for _, v := range vals {
+		for x := 0; x < MAXX; x++ {
+			if dp[x] < v {
+				if v < dp[x^v] {
+					dp[x^v] = v
+				}
+			}
+		}
+	}
+	res := []int{}
+	for x := 0; x < MAXX; x++ {
+		if dp[x] < INF {
+			res = append(res, x)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(res)))
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candF2")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(7))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", tc.arr[j]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveF2(tc)
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1580-1589/1582/verifierG.go
+++ b/1000-1999/1500-1599/1580-1589/1582/verifierG.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%d", tag, time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type testCaseG struct {
+	n   int
+	arr []int
+	ops string
+}
+
+func genCase(rng *rand.Rand) testCaseG {
+	n := rng.Intn(6) + 2
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(20) + 1
+	}
+	opsBytes := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			opsBytes[i] = '*'
+		} else {
+			opsBytes[i] = '/'
+		}
+	}
+	return testCaseG{n: n, arr: arr, ops: string(opsBytes)}
+}
+
+func factorize(x int) map[int]int {
+	res := make(map[int]int)
+	d := 2
+	for d*d <= x {
+		for x%d == 0 {
+			res[d]++
+			x /= d
+		}
+		d++
+	}
+	if x > 1 {
+		res[x]++
+	}
+	return res
+}
+
+func solveG(tc testCaseG) string {
+	n := tc.n
+	factors := make([]map[int]int, n)
+	for i := 0; i < n; i++ {
+		factors[i] = factorize(tc.arr[i])
+	}
+	ans := 0
+	for l := 0; l < n; l++ {
+		counts := make(map[int]int)
+		valid := true
+		for r := l; r < n; r++ {
+			for p, c := range factors[r] {
+				if tc.ops[r] == '*' {
+					counts[p] += c
+				} else {
+					counts[p] -= c
+					if counts[p] < 0 {
+						valid = false
+					}
+				}
+			}
+			if !valid {
+				break
+			}
+			ans++
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candG")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(8))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", tc.arr[j]))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(tc.ops)
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveG(tc)
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for contest 1582 problems A–G
- each verifier generates 100 random tests and checks any binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF1.go`
- `go build verifierF2.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68872b2c977083249626d2b4d582b0b9