### PR TITLE
Add solution verifiers for contest 1584

### DIFF
--- a/1000-1999/1500-1599/1580-1589/1584/verifierA.go
+++ b/1000-1999/1500-1599/1580-1589/1584/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testA struct{ u, v int64 }
+
+func genTests() []testA {
+	rand.Seed(158401)
+	tests := make([]testA, 100)
+	for i := range tests {
+		u := rand.Int63n(1_000_000_000) + 1
+		v := rand.Int63n(1_000_000_000) + 1
+		tests[i] = testA{u, v}
+	}
+	return tests
+}
+
+func solve(tc testA) (int64, int64) {
+	return -tc.u * tc.u, tc.v * tc.v
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.u, tc.v)
+	}
+
+	expected := make([][2]int64, len(tests))
+	for i, tc := range tests {
+		expected[i][0], expected[i][1] = solve(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		for j := 0; j < 2; j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if val != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1500-1599/1580-1589/1584/verifierB.go
+++ b/1000-1999/1500-1599/1580-1589/1584/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testB struct{ n, m int64 }
+
+func genTests() []testB {
+	rand.Seed(158402)
+	tests := make([]testB, 100)
+	for i := range tests {
+		n := rand.Int63n(30000) + 1
+		m := rand.Int63n(30000) + 1
+		if n == 1 && m == 1 {
+			m = 2
+		}
+		tests[i] = testB{n, m}
+	}
+	return tests
+}
+
+func solve(tc testB) int64 {
+	area := tc.n * tc.m
+	return (area + 2) / 3
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.m)
+	}
+
+	expected := make([]int64, len(tests))
+	for i, tc := range tests {
+		expected[i] = solve(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1500-1599/1580-1589/1584/verifierC.go
+++ b/1000-1999/1500-1599/1580-1589/1584/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testC struct {
+	n int
+	a []int
+	b []int
+}
+
+func genTests() []testC {
+	rand.Seed(158403)
+	tests := make([]testC, 100)
+	for i := range tests {
+		n := rand.Intn(100) + 1
+		a := make([]int, n)
+		b := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rand.Intn(201) - 100
+			b[j] = rand.Intn(201) - 100
+		}
+		tests[i] = testC{n, a, b}
+	}
+	return tests
+}
+
+func solve(tc testC) string {
+	a := append([]int(nil), tc.a...)
+	b := append([]int(nil), tc.b...)
+	sort.Ints(a)
+	sort.Ints(b)
+	for i := 0; i < tc.n; i++ {
+		if b[i] != a[i] && b[i] != a[i]+1 {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		for i, v := range tc.b {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([]string, len(tests))
+	for i, tc := range tests {
+		expected[i] = solve(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got := strings.ToUpper(scanner.Text())
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1500-1599/1580-1589/1584/verifierD.go
+++ b/1000-1999/1500-1599/1580-1589/1584/verifierD.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem D is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1500-1599/1580-1589/1584/verifierE.go
+++ b/1000-1999/1500-1599/1580-1589/1584/verifierE.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1584E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(50) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(1000)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		in := genCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1580-1589/1584/verifierF.go
+++ b/1000-1999/1500-1599/1580-1589/1584/verifierF.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1584F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func genString(rng *rand.Rand, maxLen int) string {
+	n := rng.Intn(maxLen) + 1
+	b := make([]byte, n)
+	count := make(map[byte]int)
+	for i := 0; i < n; i++ {
+		for {
+			ch := letters[rng.Intn(len(letters))]
+			if count[ch] < 2 {
+				b[i] = ch
+				count[ch]++
+				break
+			}
+		}
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(genString(rng, 6))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		in := genCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1580-1589/1584/verifierG.go
+++ b/1000-1999/1500-1599/1580-1589/1584/verifierG.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleG")
+	cmd := exec.Command("go", "build", "-o", oracle, "1584G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	R := rng.Intn(20) + 1
+	points := make(map[[2]int]bool)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, R))
+	for len(points) < n {
+		x := rng.Intn(41) - 20
+		y := rng.Intn(41) - 20
+		key := [2]int{x, y}
+		if points[key] {
+			continue
+		}
+		points[key] = true
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		in := genCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A-G in contest 1584
- each verifier generates at least 100 tests and checks a candidate binary
- interactive problem D has a placeholder verifier

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68872bb8a5a08324a293d4fa54970a1e