### PR TITLE
Add Go verifiers for contest 1593

### DIFF
--- a/1000-1999/1500-1599/1590-1599/1593/verifierA.go
+++ b/1000-1999/1500-1599/1590-1599/1593/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a, b, c int) string {
+	m := a
+	if b > m {
+		m = b
+	}
+	if c > m {
+		m = c
+	}
+	cnt := 0
+	if a == m {
+		cnt++
+	}
+	if b == m {
+		cnt++
+	}
+	if c == m {
+		cnt++
+	}
+	ansA := m + 1 - a
+	ansB := m + 1 - b
+	ansC := m + 1 - c
+	if cnt == 1 {
+		if a == m {
+			ansA = 0
+		}
+		if b == m {
+			ansB = 0
+		}
+		if c == m {
+			ansC = 0
+		}
+	}
+	return fmt.Sprintf("%d %d %d", ansA, ansB, ansC)
+}
+
+func generateCase(rng *rand.Rand) (int, int, int) {
+	a := rng.Intn(1_000_000_001)
+	b := rng.Intn(1_000_000_001)
+	c := rng.Intn(1_000_000_001)
+	return a, b, c
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a, b, c := generateCase(rng)
+		input := fmt.Sprintf("1\n%d %d %d\n", a, b, c)
+		expectedOutput := expected(a, b, c)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedOutput {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, expectedOutput, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1593/verifierB.go
+++ b/1000-1999/1500-1599/1590-1599/1593/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) string {
+	ans := len(s)
+	targets := []string{"00", "25", "50", "75"}
+	for _, p := range targets {
+		p0 := p[0]
+		p1 := p[1]
+		pos1 := -1
+		for i := len(s) - 1; i >= 0; i-- {
+			if s[i] == p1 {
+				pos1 = i
+				break
+			}
+		}
+		if pos1 == -1 {
+			continue
+		}
+		pos0 := -1
+		for i := pos1 - 1; i >= 0; i-- {
+			if s[i] == p0 {
+				pos0 = i
+				break
+			}
+		}
+		if pos0 == -1 {
+			continue
+		}
+		moves := (len(s) - pos1 - 1) + (pos1 - pos0 - 1)
+		if moves < ans {
+			ans = moves
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(15) + 2
+	digits := make([]byte, n)
+	for i := range digits {
+		digits[i] = byte(rng.Intn(10)) + '0'
+	}
+	targets := []string{"00", "25", "50", "75"}
+	pair := targets[rng.Intn(len(targets))]
+	i := rng.Intn(n - 1)
+	j := rng.Intn(n-i-1) + i + 1
+	digits[i] = pair[0]
+	digits[j] = pair[1]
+	if digits[0] == '0' {
+		digits[0] = '1'
+	}
+	return string(digits)
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := generateCase(rng)
+		input := fmt.Sprintf("1\n%s\n", s)
+		expectedOutput := expected(s)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedOutput {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, expectedOutput, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1593/verifierC.go
+++ b/1000-1999/1500-1599/1590-1599/1593/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(n int64, xs []int64) string {
+	sort.Slice(xs, func(i, j int) bool { return xs[i] > xs[j] })
+	var dist int64
+	saved := 0
+	for _, x := range xs {
+		need := n - x
+		if dist+need < n {
+			saved++
+			dist += need
+		} else {
+			break
+		}
+	}
+	return fmt.Sprintf("%d", saved)
+}
+
+func generateCase(rng *rand.Rand) (int64, []int64) {
+	n := rng.Int63n(1000) + 2
+	k := rng.Intn(7) + 1
+	xs := make([]int64, k)
+	for i := 0; i < k; i++ {
+		xs[i] = rng.Int63n(n-1) + 1
+	}
+	return n, xs
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, xs := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d %d\n", n, len(xs))
+		for j, x := range xs {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", x)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expectedOutput := expected(n, append([]int64(nil), xs...))
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedOutput {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, expectedOutput, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1593/verifierD1.go
+++ b/1000-1999/1500-1599/1590-1599/1593/verifierD1.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func expected(a []int) string {
+	if len(a) <= 1 {
+		return "-1"
+	}
+	allEqual := true
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[0] {
+			allEqual = false
+			break
+		}
+	}
+	if allEqual {
+		return "-1"
+	}
+	g := 0
+	for i := 1; i < len(a); i++ {
+		diff := a[i] - a[0]
+		if diff < 0 {
+			diff = -diff
+		}
+		g = gcd(g, diff)
+	}
+	return fmt.Sprintf("%d", g)
+}
+
+func generateCase(rng *rand.Rand) []int {
+	n := rng.Intn(7) + 2
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(41) - 20
+	}
+	return a
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d\n", len(arr))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expectedOutput := expected(arr)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedOutput {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, expectedOutput, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1593/verifierD2.go
+++ b/1000-1999/1500-1599/1590-1599/1593/verifierD2.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleD2")
+	cmd := exec.Command("go", "build", "-o", exe, filepath.Join(dir, "1593D2.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) []int {
+	n := rng.Intn(7) + 2
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(101) - 50
+	}
+	return a
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d\n", len(arr))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1593/verifierE.go
+++ b/1000-1999/1500-1599/1590-1599/1593/verifierE.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", exe, filepath.Join(dir, "1593E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) (int, int, [][2]int) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n + 1)
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	return n, k, edges
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, edges := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+		}
+		input := sb.String()
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1593/verifierF.go
+++ b/1000-1999/1500-1599/1590-1599/1593/verifierF.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", exe, filepath.Join(dir, "1593F.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) (int, int, int, string) {
+	n := rng.Intn(7) + 2
+	a := rng.Intn(9) + 1
+	b := rng.Intn(9) + 1
+	digits := make([]byte, n)
+	for i := range digits {
+		digits[i] = byte(rng.Intn(10)) + '0'
+	}
+	return n, a, b, string(digits)
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, a, b, x := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d %d %d\n", n, a, b)
+		sb.WriteString(x)
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1593/verifierG.go
+++ b/1000-1999/1500-1599/1590-1599/1593/verifierG.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleG")
+	cmd := exec.Command("go", "build", "-o", exe, filepath.Join(dir, "1593G.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) (string, [][2]int) {
+	n := rng.Intn(10) + 2
+	chars := []byte{'(', ')', '[', ']'}
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = chars[rng.Intn(len(chars))]
+	}
+	q := rng.Intn(5) + 1
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n-1) + 1
+		r := rng.Intn(n-l) + l + 1
+		if (r-l+1)%2 == 1 {
+			if r < n {
+				r++
+			} else if l > 1 {
+				l--
+			}
+		}
+		queries[i] = [2]int{l, r}
+	}
+	return string(s), queries
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s, queries := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+		fmt.Fprintf(&sb, "%d\n", len(queries))
+		for _, q := range queries {
+			fmt.Fprintf(&sb, "%d %d\n", q[0], q[1])
+		}
+		input := sb.String()
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem 1593A
- add verifierB.go for problem 1593B
- add verifierC.go for problem 1593C
- add verifierD1.go for problem 1593D1
- add verifierD2.go for problem 1593D2
- add verifierE.go for problem 1593E
- add verifierF.go for problem 1593F
- add verifierG.go for problem 1593G

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD1.go verifierD2.go verifierE.go verifierF.go verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_68872e2f030c8324a610757ea1b19d49