### PR TITLE
Add solution verifiers for Codeforces 1598

### DIFF
--- a/1000-1999/1500-1599/1590-1599/1598/verifierA.go
+++ b/1000-1999/1500-1599/1590-1599/1598/verifierA.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func expectedA(n int, row1, row2 string) string {
+	grid := []string{row1, row2}
+	dirs := [8][2]int{{-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1}}
+	vis := make([][]bool, 2)
+	for i := range vis {
+		vis[i] = make([]bool, n)
+	}
+	type node struct{ r, c int }
+	q := []node{{0, 0}}
+	vis[0][0] = true
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		if cur.r == 1 && cur.c == n-1 {
+			return "YES"
+		}
+		for _, d := range dirs {
+			nr, nc := cur.r+d[0], cur.c+d[1]
+			if nr < 0 || nr >= 2 || nc < 0 || nc >= n {
+				continue
+			}
+			if grid[nr][nc] == '1' || vis[nr][nc] {
+				continue
+			}
+			vis[nr][nc] = true
+			q = append(q, node{nr, nc})
+		}
+	}
+	if vis[1][n-1] {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(98) + 3 // 3..100
+		row1 := make([]byte, n)
+		row2 := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if j == 0 {
+				row1[j] = '0'
+			} else {
+				if rng.Intn(2) == 0 {
+					row1[j] = '0'
+				} else {
+					row1[j] = '1'
+				}
+			}
+			if j == n-1 {
+				row2[j] = '0'
+			} else {
+				if rng.Intn(2) == 0 {
+					row2[j] = '0'
+				} else {
+					row2[j] = '1'
+				}
+			}
+		}
+		input := fmt.Sprintf("1\n%d\n%s\n%s\n", n, string(row1), string(row2))
+		exp := expectedA(n, string(row1), string(row2))
+		cases[i] = testCase{input: input, expected: exp}
+	}
+	return cases
+}
+
+func run(bin, stringInput string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(stringInput)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if out != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1598/verifierB.go
+++ b/1000-1999/1500-1599/1590-1599/1598/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func expectedB(n int, mat [][]int) string {
+	for d1 := 0; d1 < 5; d1++ {
+		for d2 := d1 + 1; d2 < 5; d2++ {
+			aOnly, bOnly := 0, 0
+			valid := true
+			for i := 0; i < n; i++ {
+				a := mat[i][d1]
+				b := mat[i][d2]
+				if a == 0 && b == 0 {
+					valid = false
+					break
+				}
+				if a == 1 && b == 0 {
+					aOnly++
+				}
+				if a == 0 && b == 1 {
+					bOnly++
+				}
+			}
+			if valid && aOnly <= n/2 && bOnly <= n/2 {
+				return "YES"
+			}
+		}
+	}
+	return "NO"
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10)*2 + 2 // even 2..20
+		mat := make([][]int, n)
+		for j := 0; j < n; j++ {
+			mat[j] = make([]int, 5)
+			ok := false
+			for k := 0; k < 5; k++ {
+				val := rng.Intn(2)
+				if val == 1 {
+					ok = true
+				}
+				mat[j][k] = val
+			}
+			if !ok {
+				mat[j][rng.Intn(5)] = 1
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			for k := 0; k < 5; k++ {
+				if k > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprint(mat[j][k]))
+			}
+			sb.WriteByte('\n')
+		}
+		exp := expectedB(n, mat)
+		cases[i] = testCase{input: sb.String(), expected: exp}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if out != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1598/verifierC.go
+++ b/1000-1999/1500-1599/1590-1599/1598/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func expectedC(arr []int64) int64 {
+	n := int64(len(arr))
+	var sum int64
+	for _, v := range arr {
+		sum += v
+	}
+	sum2 := sum * 2
+	if sum2%n != 0 {
+		return 0
+	}
+	target := sum2 / n
+	count := make(map[int64]int64)
+	var ans int64
+	for _, v := range arr {
+		ans += count[target-v]
+		count[v]++
+	}
+	return ans
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int64, n)
+		for j := 0; j < n; j++ {
+			arr[j] = int64(rng.Intn(21) - 10)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		exp := expectedC(arr)
+		cases[i] = testCase{input: sb.String(), expected: exp}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var got int64
+		fmt.Sscan(out, &got)
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1598/verifierD.go
+++ b/1000-1999/1500-1599/1590-1599/1598/verifierD.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func expectedD(a, b []int) int64 {
+	n := len(a)
+	cntA := make(map[int]int)
+	cntB := make(map[int]int)
+	for i := 0; i < n; i++ {
+		cntA[a[i]]++
+		cntB[b[i]]++
+	}
+	total := int64(n) * (int64(n) - 1) * (int64(n) - 2) / 6
+	var bad int64
+	for i := 0; i < n; i++ {
+		bad += int64(cntA[a[i]]-1) * int64(cntB[b[i]]-1)
+	}
+	return total - bad
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 3
+		arrA := make([]int, n)
+		arrB := make([]int, n)
+		for j := 0; j < n; j++ {
+			arrA[j] = rng.Intn(5)
+			arrB[j] = rng.Intn(5)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", arrA[j], arrB[j]))
+		}
+		exp := expectedD(arrA, arrB)
+		cases[i] = testCase{input: sb.String(), expected: exp}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var got int64
+		fmt.Sscan(out, &got)
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1598/verifierE.go
+++ b/1000-1999/1500-1599/1590-1599/1598/verifierE.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct{ x, y int }
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveE(n, m int, ops []query) string {
+	grid := make([][]bool, n+2)
+	rlen := make([][]int, n+2)
+	dlen := make([][]int, n+2)
+	for i := 0; i <= n+1; i++ {
+		grid[i] = make([]bool, m+2)
+		rlen[i] = make([]int, m+2)
+		dlen[i] = make([]int, m+2)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			grid[i][j] = true
+		}
+	}
+	var total int64
+	for i := n; i >= 1; i-- {
+		for j := m; j >= 1; j-- {
+			r := 1
+			if j < m {
+				r += dlen[i][j+1]
+			}
+			d := 1
+			if i < n {
+				d += rlen[i+1][j]
+			}
+			rlen[i][j] = r
+			dlen[i][j] = d
+			total += int64(r + d - 1)
+		}
+	}
+	var out strings.Builder
+	for _, op := range ops {
+		x, y := op.x, op.y
+		prev := grid[x][y]
+		grid[x][y] = !grid[x][y]
+		queue := []query{{x, y}}
+		recompute := func(i, j int, prev bool) {
+			oldR := rlen[i][j]
+			oldD := dlen[i][j]
+			var oldC int64
+			if prev {
+				oldC = int64(oldR + oldD - 1)
+			}
+			var newR, newD int
+			if grid[i][j] {
+				newR = 1
+				if j < m && grid[i][j+1] {
+					newR += dlen[i][j+1]
+				}
+				newD = 1
+				if i < n && grid[i+1][j] {
+					newD += rlen[i+1][j]
+				}
+			}
+			rlen[i][j] = newR
+			dlen[i][j] = newD
+			var newC int64
+			if grid[i][j] {
+				newC = int64(newR + newD - 1)
+			}
+			if oldC != newC {
+				total += newC - oldC
+			}
+		}
+		for len(queue) > 0 {
+			p := queue[0]
+			queue = queue[1:]
+			pr := grid[p.x][p.y]
+			if p.x == x && p.y == y {
+				pr = prev
+			}
+			oldR := rlen[p.x][p.y]
+			oldD := dlen[p.x][p.y]
+			recompute(p.x, p.y, pr)
+			if rlen[p.x][p.y] != oldR || dlen[p.x][p.y] != oldD {
+				if p.x > 1 {
+					queue = append(queue, query{p.x - 1, p.y})
+				}
+				if p.y > 1 {
+					queue = append(queue, query{p.x, p.y - 1})
+				}
+			}
+		}
+		out.WriteString(fmt.Sprintln(total))
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		q := rng.Intn(5) + 1
+		ops := make([]query, q)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+		for j := 0; j < q; j++ {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(m) + 1
+			ops[j] = query{x, y}
+			sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		}
+		exp := solveE(n, m, ops)
+		cases[i] = testCase{input: sb.String(), expected: exp}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1598/verifierF.go
+++ b/1000-1999/1500-1599/1590-1599/1598/verifierF.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func solveF(strs []string) int {
+	n := len(strs)
+	net := make([]int, n)
+	minPref := make([]int, n)
+	freq := make([]map[int]int, n)
+	for i := 0; i < n; i++ {
+		sum := 0
+		minv := 0
+		freq[i] = make(map[int]int)
+		for _, ch := range strs[i] {
+			if ch == '(' {
+				sum++
+			} else {
+				sum--
+			}
+			if sum < minv {
+				minv = sum
+			}
+			if sum == minv {
+				freq[i][sum]++
+			}
+		}
+		net[i] = sum
+		minPref[i] = minv
+	}
+	size := 1 << n
+	bal := make([]int, size)
+	for mask := 1; mask < size; mask++ {
+		lb := mask & -mask
+		idx := 0
+		for (lb>>idx)&1 == 0 {
+			idx++
+		}
+		bal[mask] = bal[mask^lb] + net[idx]
+	}
+	const negInf = -1 << 60
+	dp := make([]int, size)
+	for i := range dp {
+		dp[i] = negInf
+	}
+	dp[0] = 0
+	ans := 0
+	for mask := 0; mask < size; mask++ {
+		if dp[mask] < 0 {
+			continue
+		}
+		cur := bal[mask]
+		if dp[mask] > ans {
+			ans = dp[mask]
+		}
+		for i := 0; i < n; i++ {
+			if mask>>i&1 == 0 {
+				add := freq[i][-cur]
+				if cur+minPref[i] >= 0 {
+					nmask := mask | (1 << i)
+					if dp[nmask] < dp[mask]+add {
+						dp[nmask] = dp[mask] + add
+					}
+				} else {
+					if dp[mask]+add > ans {
+						ans = dp[mask] + add
+					}
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	letters := []rune{'(', ')'}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(3) + 1 // 1..3
+		strs := make([]string, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			l := rng.Intn(5) + 1
+			b := make([]rune, l)
+			for k := 0; k < l; k++ {
+				b[k] = letters[rng.Intn(2)]
+			}
+			s := string(b)
+			strs[j] = s
+			sb.WriteString(fmt.Sprintf("%s\n", s))
+		}
+		exp := solveF(strs)
+		cases[i] = testCase{input: sb.String(), expected: exp}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscan(out, &got)
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1500-1599/1590-1599/1598/verifierG.go
+++ b/1000-1999/1500-1599/1590-1599/1598/verifierG.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const md = 2006091501
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func exkmp(S, T string) []int {
+	n, m := len(S), len(T)
+	nxt := make([]int, m)
+	nxt[0] = m
+	l, r := 0, 0
+	for i := 1; i < m; i++ {
+		if i <= r {
+			nxt[i] = min(r-i+1, nxt[i-l])
+		}
+		for i+nxt[i] < m && T[nxt[i]] == T[i+nxt[i]] {
+			nxt[i]++
+		}
+		if i+nxt[i]-1 > r {
+			l = i
+			r = i + nxt[i] - 1
+		}
+	}
+	le := make([]int, n)
+	l, r = 0, 0
+	for i := 0; i < n; i++ {
+		if i <= r {
+			le[i] = min(r-i+1, nxt[i-l])
+		}
+		for i+le[i] < n && le[i] < m && S[i+le[i]] == T[le[i]] {
+			le[i]++
+		}
+		if i+le[i]-1 > r {
+			l = i
+			r = i + le[i] - 1
+		}
+	}
+	return le
+}
+
+func solveG(S, T string) string {
+	n, m := len(S), len(T)
+	le := exkmp(S, T)
+	ha := make([]int64, n+1)
+	mi := make([]int64, n+1)
+	mi[0] = 1
+	var ht int64
+	for i := 0; i < m; i++ {
+		ht = (ht*10 + int64(T[i]-'0')) % md
+	}
+	for i := 0; i < n; i++ {
+		mi[i+1] = (mi[i] * 10) % md
+		ha[i+1] = (ha[i]*10 + int64(S[i]-'0')) % md
+	}
+	var ans string
+	check := func(a, b, c int) {
+		if a < 0 || c >= n || ans != "" {
+			return
+		}
+		h1 := (ha[b+1] - ha[a]*mi[b-a+1]%md + md) % md
+		h2 := (ha[c+1] - ha[b+1]*mi[c-b]%md + md) % md
+		if (h1+h2)%md != ht {
+			return
+		}
+		ans = fmt.Sprintf("%d %d\n%d %d", a+1, b+1, b+2, c+1)
+	}
+	for l := 0; l+m <= n; l++ {
+		r := l + m - 1
+		c := le[l]
+		if c == m || S[l+c] > T[c] {
+			continue
+		}
+		z := m - c
+		check(l, r, r+z)
+		check(l-z, l-1, r)
+		z--
+		if z > 0 {
+			check(l, r, r+z)
+			check(l-z, l-1, r)
+		}
+		if ans != "" {
+			return ans
+		}
+	}
+	if ans == "" && m > 1 {
+		for l := 0; l+2*(m-1) <= n; l++ {
+			check(l, l+m-2, l+2*m-3)
+			if ans != "" {
+				return ans
+			}
+		}
+	}
+	return ans
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	digits := []rune("0123456789")
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 3
+		m := rng.Intn(2) + 2
+		sbS := make([]rune, n)
+		sbT := make([]rune, m)
+		for j := 0; j < n; j++ {
+			sbS[j] = digits[rng.Intn(10)]
+		}
+		for j := 0; j < m; j++ {
+			sbT[j] = digits[rng.Intn(10)]
+		}
+		S := string(sbS)
+		T := string(sbT)
+		input := fmt.Sprintf("%s\n%s\n", S, T)
+		exp := solveG(S, T)
+		cases[i] = testCase{input: input, expected: exp}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if out != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G in contest 1598
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go run verifierA.go ./1598A`
- `go run verifierB.go ./1598B`
- `go run verifierC.go ./1598C`
- `go run verifierD.go ./1598D`
- `go run verifierE.go ./1598E`
- `go run verifierF.go ./1598F`
- `go run verifierG.go ./1598G`


------
https://chatgpt.com/codex/tasks/task_e_68872f8d3c4c8324817078b0ecbf7cf3