### PR TITLE
Add solution verifiers for CF contest 1607

### DIFF
--- a/1000-1999/1600-1699/1600-1609/1607/verifierA.go
+++ b/1000-1999/1600-1699/1600-1609/1607/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randLayout() string {
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	rand.Shuffle(len(letters), func(i, j int) { letters[i], letters[j] = letters[j], letters[i] })
+	return string(letters)
+}
+
+func randWord() string {
+	n := rand.Intn(50) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rand.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin := "./refA.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1607A.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(1)
+	type tc struct{ layout, word string }
+	cases := []tc{
+		{"abcdefghijklmnopqrstuvwxyz", "a"},
+		{"abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"},
+		{"zyxwvutsrqponmlkjihgfedcba", strings.Repeat("a", 50)},
+	}
+	for len(cases) < 100 {
+		cases = append(cases, tc{randLayout(), randWord()})
+	}
+
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%s\n%s\n", c.layout, c.word)
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp = strings.TrimSpace(exp)
+		got = strings.TrimSpace(got)
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1607/verifierB.go
+++ b/1000-1999/1600-1699/1600-1609/1607/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solve(x, n int64) int64 {
+	r := n % 4
+	if x%2 == 0 {
+		switch r {
+		case 0:
+			return x
+		case 1:
+			return x - n
+		case 2:
+			return x + 1
+		default:
+			return x + n + 1
+		}
+	} else {
+		switch r {
+		case 0:
+			return x
+		case 1:
+			return x + n
+		case 2:
+			return x - 1
+		default:
+			return x - n - 1
+		}
+	}
+}
+
+func randCase() (int64, int64) {
+	x := rand.Int63n(2_000_000_001) - 1_000_000_000
+	n := rand.Int63n(1_000_000_000_000_000 + 1)
+	return x, n
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin := "./refB.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1607B.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(2)
+	type tc struct{ x, n int64 }
+	cases := []tc{
+		{0, 0},
+		{0, 1},
+		{-1_000_000_000_000_00, 1_000_000_000_000_00},
+	}
+	for len(cases) < 100 {
+		x, n := randCase()
+		cases = append(cases, tc{x, n})
+	}
+
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d %d\n", c.x, c.n)
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp = strings.TrimSpace(exp)
+		got = strings.TrimSpace(got)
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1607/verifierC.go
+++ b/1000-1999/1600-1699/1600-1609/1607/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func runCmd(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solve(arr []int64) int64 {
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	ans := arr[0]
+	for i := 1; i < len(arr); i++ {
+		diff := arr[i] - arr[i-1]
+		if diff > ans {
+			ans = diff
+		}
+	}
+	return ans
+}
+
+func randCase() []int64 {
+	n := rand.Intn(50) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = rand.Int63n(2_000_000_001) - 1_000_000_000
+	}
+	return arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	rand.Seed(3)
+	cases := [][]int64{
+		{10},
+		{-5, -5},
+		{-1, 0, 1},
+	}
+	for len(cases) < 100 {
+		cases = append(cases, randCase())
+	}
+
+	for i, arr := range cases {
+		input := fmt.Sprintf("1\n%d\n", len(arr))
+		for j, v := range arr {
+			if j+1 == len(arr) {
+				input += fmt.Sprintf("%d\n", v)
+			} else {
+				input += fmt.Sprintf("%d ", v)
+			}
+		}
+		expected := solve(append([]int64(nil), arr...))
+		gotStr, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		gotStr = strings.TrimSpace(gotStr)
+		if gotStr != fmt.Sprint(expected) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %d\ngot: %s\n", i+1, input, expected, gotStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1607/verifierD.go
+++ b/1000-1999/1600-1699/1600-1609/1607/verifierD.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func runCmd(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solve(a []int, s string) string {
+	blues := make([]int, 0, len(a))
+	reds := make([]int, 0, len(a))
+	for i, v := range a {
+		if s[i] == 'B' {
+			blues = append(blues, v)
+		} else {
+			reds = append(reds, v)
+		}
+	}
+	sort.Ints(blues)
+	sort.Sort(sort.Reverse(sort.IntSlice(reds)))
+	pos := 1
+	for _, v := range blues {
+		if v < pos {
+			return "NO"
+		}
+		pos++
+	}
+	pos = len(a)
+	for _, v := range reds {
+		if v > pos {
+			return "NO"
+		}
+		pos--
+	}
+	return "YES"
+}
+
+func randCase() ([]int, string) {
+	n := rand.Intn(20) + 1
+	a := make([]int, n)
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(10) + 1
+		if rand.Intn(2) == 0 {
+			sb.WriteByte('B')
+		} else {
+			sb.WriteByte('R')
+		}
+	}
+	return a, sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	rand.Seed(4)
+	casesA := [][]int{{1}, {2}, {3, 1, 2}}
+	casesS := []string{"B", "R", "BRB"}
+	for len(casesA) < 100 {
+		a, s := randCase()
+		casesA = append(casesA, a)
+		casesS = append(casesS, s)
+	}
+
+	for i := range casesA {
+		a := casesA[i]
+		s := casesS[i]
+		input := fmt.Sprintf("1\n%d\n", len(a))
+		for j, v := range a {
+			if j+1 == len(a) {
+				input += fmt.Sprintf("%d\n", v)
+			} else {
+				input += fmt.Sprintf("%d ", v)
+			}
+		}
+		input += fmt.Sprintf("%s\n", s)
+		expected := solve(append([]int(nil), a...), s)
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1607/verifierE.go
+++ b/1000-1999/1600-1699/1600-1609/1607/verifierE.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solve(n, m int, s string) (int, int) {
+	minX, maxX := 0, 0
+	minY, maxY := 0, 0
+	x, y := 0, 0
+	startRow, startCol := 1, 1
+	for _, c := range s {
+		nx, ny := x, y
+		switch c {
+		case 'L':
+			ny--
+		case 'R':
+			ny++
+		case 'U':
+			nx--
+		case 'D':
+			nx++
+		}
+		newMinX := min(minX, nx)
+		newMaxX := max(maxX, nx)
+		newMinY := min(minY, ny)
+		newMaxY := max(maxY, ny)
+		if newMaxX-newMinX+1 > n || newMaxY-newMinY+1 > m {
+			break
+		}
+		x, y = nx, ny
+		minX, maxX = newMinX, newMaxX
+		minY, maxY = newMinY, newMaxY
+		startRow = 1 - minX
+		startCol = 1 - minY
+	}
+	return startRow, startCol
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func randCase() (int, int, string) {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(10) + 1
+	length := rand.Intn(20) + 1
+	b := make([]byte, length)
+	dirs := "LRUD"
+	for i := range b {
+		b[i] = dirs[rand.Intn(4)]
+	}
+	return n, m, string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	rand.Seed(5)
+	ns := []int{1, 2, 3}
+	ms := []int{1, 2, 3}
+	ss := []string{"L", "RRUU", "UDLR"}
+	cases := make([]struct {
+		n, m int
+		s    string
+	}, 0, 100)
+	for i := 0; i < len(ns); i++ {
+		cases = append(cases, struct {
+			n, m int
+			s    string
+		}{ns[i], ms[i], ss[i]})
+	}
+	for len(cases) < 100 {
+		n, m, s := randCase()
+		cases = append(cases, struct {
+			n, m int
+			s    string
+		}{n, m, s})
+	}
+
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d %d\n%s\n", c.n, c.m, c.s)
+		expR, expC := solve(c.n, c.m, c.s)
+		exp := fmt.Sprintf("%d %d", expR, expC)
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1607/verifierF.go
+++ b/1000-1999/1600-1699/1600-1609/1607/verifierF.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randBoard() (int, int, []string) {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(5) + 1
+	board := make([]string, n)
+	dirs := "LRUD"
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			b[j] = dirs[rand.Intn(4)]
+		}
+		board[i] = string(b)
+	}
+	return n, m, board
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin := "./refF.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1607F.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(6)
+	type tc struct {
+		n, m  int
+		board []string
+	}
+	cases := []tc{
+		{1, 1, []string{"U"}},
+	}
+	for len(cases) < 100 {
+		n, m, b := randBoard()
+		cases = append(cases, tc{n, m, b})
+	}
+
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d %d\n", c.n, c.m)
+		for _, row := range c.board {
+			input += row + "\n"
+		}
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp = strings.TrimSpace(exp)
+		got = strings.TrimSpace(got)
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1607/verifierG.go
+++ b/1000-1999/1600-1699/1600-1609/1607/verifierG.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randCase() (int, int64, []int64, []int64) {
+	n := rand.Intn(5) + 1
+	m := int64(rand.Intn(10))
+	a := make([]int64, n)
+	b := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rand.Intn(10))
+		b[i] = int64(rand.Intn(10))
+		if a[i]+b[i] < m {
+			a[i] += m - (a[i] + b[i])
+		}
+	}
+	return n, m, a, b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin := "./refG.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1607G.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(7)
+	type tc struct {
+		n    int
+		m    int64
+		a, b []int64
+	}
+	cases := []tc{{1, 0, []int64{0}, []int64{0}}}
+	for len(cases) < 100 {
+		n, m, a, b := randCase()
+		cases = append(cases, tc{n, m, a, b})
+	}
+
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d %d\n", c.n, c.m)
+		for j := 0; j < c.n; j++ {
+			input += fmt.Sprintf("%d %d\n", c.a[j], c.b[j])
+		}
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp = strings.TrimSpace(exp)
+		got = strings.TrimSpace(got)
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1607/verifierH.go
+++ b/1000-1999/1600-1699/1600-1609/1607/verifierH.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randCase() (int, []int, []int, []int) {
+	n := rand.Intn(5) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	m := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(10)
+		b[i] = rand.Intn(10)
+		limit := a[i] + b[i]
+		m[i] = rand.Intn(limit + 1)
+	}
+	return n, a, b, m
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin := "./refH.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "1607H.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(8)
+	type tc struct {
+		n       int
+		a, b, m []int
+	}
+	cases := []tc{{1, []int{0}, []int{0}, []int{0}}}
+	for len(cases) < 100 {
+		n, a, b, m := randCase()
+		cases = append(cases, tc{n, a, b, m})
+	}
+
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d\n", c.n)
+		for j := 0; j < c.n; j++ {
+			input += fmt.Sprintf("%d %d %d\n", c.a[j], c.b[j], c.m[j])
+		}
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp = strings.TrimSpace(exp)
+		got = strings.TrimSpace(got)
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–H of contest 1607
- each verifier generates at least 100 test cases and can run against any binary

## Testing
- `go build verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_6887320391588324956784e05f98af4d