### PR TITLE
Add verifiers for CF 1605

### DIFF
--- a/1000-1999/1600-1699/1600-1609/1605/verifierA.go
+++ b/1000-1999/1600-1699/1600-1609/1605/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseA struct {
+	a1, a2, a3 int
+}
+
+func generateTestsA() []testCaseA {
+	r := rand.New(rand.NewSource(1))
+	tests := []testCaseA{{3, 4, 5}, {2, 2, 6}, {1, 6, 5}}
+	for len(tests) < 120 {
+		tests = append(tests, testCaseA{r.Intn(1e8) + 1, r.Intn(1e8) + 1, r.Intn(1e8) + 1})
+	}
+	return tests
+}
+
+func expectedA(tc testCaseA) string {
+	sum := tc.a1 + tc.a2 + tc.a3
+	if sum%3 == 0 {
+		return "0"
+	}
+	return "1"
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsA()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d %d %d\n", tc.a1, tc.a2, tc.a3)
+		want := expectedA(tc)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1600-1699/1600-1609/1605/verifierB.go
+++ b/1000-1999/1600-1699/1600-1609/1605/verifierB.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseB struct {
+	n int
+	s string
+}
+
+func generateTestsB() []testCaseB {
+	r := rand.New(rand.NewSource(1))
+	tests := []testCaseB{{3, "010"}, {5, "11111"}, {4, "0000"}}
+	for len(tests) < 120 {
+		n := r.Intn(20) + 1
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			if r.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		tests = append(tests, testCaseB{n, sb.String()})
+	}
+	return tests
+}
+
+func expectedB(tc testCaseB) string {
+	zeros := strings.Count(tc.s, "0")
+	if zeros == 0 || zeros == tc.n {
+		return "0"
+	}
+	target := strings.Repeat("0", zeros) + strings.Repeat("1", tc.n-zeros)
+	if tc.s == target {
+		return "0"
+	}
+	indices := make([]int, 0)
+	for i := 0; i < tc.n; i++ {
+		if tc.s[i] != target[i] {
+			indices = append(indices, i+1)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(strconv.Itoa(len(indices)))
+	for _, idx := range indices {
+		sb.WriteByte(' ')
+		sb.WriteString(strconv.Itoa(idx))
+	}
+	return sb.String()
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyOutputB(tc testCaseB, out string) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	exp := expectedB(tc)
+	expLines := strings.Split(exp, "\n")
+	if len(lines) != len(expLines) {
+		return fmt.Errorf("expected %d lines got %d", len(expLines), len(lines))
+	}
+	for i := range lines {
+		if strings.TrimSpace(lines[i]) != strings.TrimSpace(expLines[i]) {
+			return fmt.Errorf("line %d mismatch: expected %q got %q", i+1, expLines[i], lines[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsB()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%s\n", tc.n, tc.s)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verifyOutputB(tc, got); err != nil {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1600-1699/1600-1609/1605/verifierC.go
+++ b/1000-1999/1600-1699/1600-1609/1605/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseC struct {
+	s string
+}
+
+func generateTestsC() []testCaseC {
+	r := rand.New(rand.NewSource(1))
+	tests := []testCaseC{{"aa"}, {"abc"}, {"abca"}}
+	letters := []byte{'a', 'b', 'c'}
+	for len(tests) < 120 {
+		n := r.Intn(20) + 1
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b[i] = letters[r.Intn(3)]
+		}
+		tests = append(tests, testCaseC{string(b)})
+	}
+	return tests
+}
+
+func solveC(s string) int {
+	if strings.Contains(s, "aa") {
+		return 2
+	}
+	if strings.Contains(s, "aba") || strings.Contains(s, "aca") {
+		return 3
+	}
+	if strings.Contains(s, "abca") || strings.Contains(s, "acba") {
+		return 4
+	}
+	if strings.Contains(s, "abbacca") || strings.Contains(s, "accabba") {
+		return 7
+	}
+	return -1
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsC()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%s\n", len(tc.s), tc.s)
+		exp := fmt.Sprintf("%d", solveC(tc.s))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:%sexpected:%s\ngot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1600-1699/1600-1609/1605/verifierD.go
+++ b/1000-1999/1600-1699/1600-1609/1605/verifierD.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseD struct {
+	n     int
+	edges [][2]int
+}
+
+func generateTestsD() []testCaseD {
+	r := rand.New(rand.NewSource(1))
+	tests := []testCaseD{}
+	for len(tests) < 120 {
+		n := r.Intn(10) + 1
+		edges := make([][2]int, 0, n-1)
+		for i := 2; i <= n; i++ {
+			u := r.Intn(i-1) + 1
+			edges = append(edges, [2]int{u, i})
+		}
+		tests = append(tests, testCaseD{n, edges})
+	}
+	return tests
+}
+
+func solveD(n int, edges [][2]int) []int {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	maxBit := bits.Len(uint(n))
+	vBits := make([][]int, maxBit)
+	for i := 1; i <= n; i++ {
+		b := bits.Len(uint(i)) - 1
+		vBits[b] = append(vBits[b], i)
+	}
+	depth := make([]int, n+1)
+	parent := make([]int, n+1)
+	parGroups := [2][]int{}
+	queue := make([]int, n)
+	qi, qj := 0, 0
+	queue[qj] = 1
+	qj++
+	parent[1] = 0
+	depth[1] = 0
+	for qi < qj {
+		x := queue[qi]
+		qi++
+		parGroups[depth[x]&1] = append(parGroups[depth[x]&1], x)
+		for _, y := range adj[x] {
+			if y == parent[x] {
+				continue
+			}
+			parent[y] = x
+			depth[y] = depth[x] + 1
+			queue[qj] = y
+			qj++
+		}
+	}
+	if len(parGroups[0]) > len(parGroups[1]) {
+		parGroups[0], parGroups[1] = parGroups[1], parGroups[0]
+	}
+	cnt0 := len(parGroups[0])
+	val := make([]int, n+1)
+	cnts := [2]int{}
+	for b := 0; b < maxBit; b++ {
+		var tmp int
+		if (cnt0>>b)&1 == 0 {
+			tmp = 1
+		} else {
+			tmp = 0
+		}
+		for _, x := range vBits[b] {
+			idx := cnts[tmp]
+			val[parGroups[tmp][idx]] = x
+			cnts[tmp]++
+		}
+	}
+	res := make([]int, n)
+	for i := 1; i <= n; i++ {
+		res[i-1] = val[i]
+	}
+	return res
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsD()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for _, e := range tc.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input := sb.String()
+		expVals := solveD(tc.n, tc.edges)
+		expStr := strings.TrimSpace(strings.Join(func(arr []int) []string {
+			s := make([]string, len(arr))
+			for i, v := range arr {
+				s[i] = fmt.Sprintf("%d", v)
+			}
+			return s
+		}(expVals), " "))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expStr {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, expStr, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1600-1699/1600-1609/1605/verifierE.go
+++ b/1000-1999/1600-1699/1600-1609/1605/verifierE.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type prefixHelper struct {
+	arr  []int64
+	pref []int64
+}
+
+func newPrefix(arr []int64) *prefixHelper {
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	pref := make([]int64, len(arr)+1)
+	for i, v := range arr {
+		pref[i+1] = pref[i] + v
+	}
+	return &prefixHelper{arr, pref}
+}
+
+func (p *prefixHelper) sumPlus(t int64) int64 {
+	if len(p.arr) == 0 {
+		return 0
+	}
+	idx := sort.Search(len(p.arr), func(i int) bool { return p.arr[i] >= -t })
+	total := p.pref[len(p.arr)]
+	left := p.pref[idx]
+	return (total - 2*left) + int64(len(p.arr)-2*idx)*t
+}
+
+func (p *prefixHelper) sumMinus(t int64) int64 {
+	if len(p.arr) == 0 {
+		return 0
+	}
+	idx := sort.Search(len(p.arr), func(i int) bool { return p.arr[i] >= t })
+	total := p.pref[len(p.arr)]
+	left := p.pref[idx]
+	return (total - 2*left) + int64(2*idx-len(p.arr))*t
+}
+
+func mobius(n int) []int {
+	mu := make([]int, n+1)
+	prime := make([]int, 0)
+	isComp := make([]bool, n+1)
+	mu[1] = 1
+	for i := 2; i <= n; i++ {
+		if !isComp[i] {
+			prime = append(prime, i)
+			mu[i] = -1
+		}
+		for _, p := range prime {
+			if i*p > n {
+				break
+			}
+			isComp[i*p] = true
+			if i%p == 0 {
+				mu[i*p] = 0
+				break
+			} else {
+				mu[i*p] = -mu[i]
+			}
+		}
+	}
+	return mu
+}
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solveE(n int, a, b []int64, queries []int64) []int64 {
+	mu := mobius(n)
+	diffBase := make([]int64, n+1)
+	for i := 2; i <= n; i++ {
+		diffBase[i] = b[i] - a[i]
+	}
+	base := make([]int64, n+1)
+	for d := 1; d <= n; d++ {
+		if mu[d] == 0 {
+			continue
+		}
+		for m := d; m <= n; m += d {
+			base[m] += int64(mu[d]) * diffBase[m/d]
+		}
+	}
+	var plusArr, minusArr []int64
+	constArrSum := int64(0)
+	for i := 1; i <= n; i++ {
+		if mu[i] == 1 {
+			plusArr = append(plusArr, base[i])
+		} else if mu[i] == -1 {
+			minusArr = append(minusArr, base[i])
+		} else {
+			constArrSum += abs64(base[i])
+		}
+	}
+	plusHelper := newPrefix(plusArr)
+	minusHelper := newPrefix(minusArr)
+	ans := make([]int64, len(queries))
+	for idx, x := range queries {
+		t := x - a[1]
+		ans[idx] = constArrSum + plusHelper.sumPlus(t) + minusHelper.sumMinus(t)
+	}
+	return ans
+}
+
+type testCaseE struct {
+	n  int
+	a  []int64
+	b  []int64
+	qs []int64
+}
+
+func generateTestsE() []testCaseE {
+	r := rand.New(rand.NewSource(1))
+	tests := []testCaseE{}
+	for len(tests) < 120 {
+		n := r.Intn(10) + 1
+		a := make([]int64, n+1)
+		b := make([]int64, n+1)
+		for i := 1; i <= n; i++ {
+			a[i] = int64(r.Intn(20))
+			b[i] = int64(r.Intn(20))
+		}
+		q := r.Intn(5) + 1
+		qs := make([]int64, q)
+		for i := 0; i < q; i++ {
+			qs[i] = int64(r.Intn(40))
+		}
+		tests = append(tests, testCaseE{n, a, b, qs})
+	}
+	return tests
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsE()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for i := 1; i <= tc.n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", tc.a[i]))
+		}
+		sb.WriteByte('\n')
+		for i := 1; i <= tc.n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", tc.b[i]))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d\n", len(tc.qs)))
+		for i, v := range tc.qs {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := solveE(tc.n, tc.a, tc.b, tc.qs)
+		gotStr, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(gotStr)
+		if len(fields) != len(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d numbers got %d\ninput:\n%s\n", i+1, len(exp), len(fields), input)
+			os.Exit(1)
+		}
+		for j, f := range fields {
+			var val int64
+			if _, err := fmt.Sscan(f, &val); err != nil || val != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%s\nexpected:%v\ngot:%v\n", i+1, input, exp, fields)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1600-1699/1600-1609/1605/verifierF.go
+++ b/1000-1999/1600-1699/1600-1609/1605/verifierF.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCaseF struct {
+	n int
+	k int
+	m int
+}
+
+func generateTestsF() []testCaseF {
+	r := rand.New(rand.NewSource(1))
+	primes := []int{100000007, 100000037, 100000039, 100000049}
+	tests := []testCaseF{}
+	for len(tests) < 120 {
+		n := r.Intn(4) + 1
+		k := r.Intn(3) + 1
+		m := primes[r.Intn(len(primes))]
+		tests = append(tests, testCaseF{n, k, m})
+	}
+	return tests
+}
+
+func nextPerm(a []int) bool {
+	i := len(a) - 2
+	for i >= 0 && a[i] >= a[i+1] {
+		i--
+	}
+	if i < 0 {
+		return false
+	}
+	j := len(a) - 1
+	for a[j] <= a[i] {
+		j--
+	}
+	a[i], a[j] = a[j], a[i]
+	for l, r := i+1, len(a)-1; l < r; l, r = l+1, r-1 {
+		a[l], a[r] = a[r], a[l]
+	}
+	return true
+}
+
+func isPalindORme(arr []int) bool {
+	n := len(arr)
+	pre := 0
+	suf := 0
+	for i := 0; i < n; i++ {
+		pre |= arr[i]
+		suf |= arr[n-1-i]
+		if pre != suf {
+			return false
+		}
+	}
+	return true
+}
+
+func isGood(arr []int) bool {
+	sort.Ints(arr)
+	tmp := make([]int, len(arr))
+	copy(tmp, arr)
+	for {
+		if isPalindORme(tmp) {
+			return true
+		}
+		if !nextPerm(tmp) {
+			break
+		}
+	}
+	return false
+}
+
+func bruteForce(n, k, m int) int {
+	limit := 1 << k
+	arr := make([]int, n)
+	count := 0
+	var dfs func(int)
+	dfs = func(pos int) {
+		if pos == n {
+			tmp := make([]int, n)
+			copy(tmp, arr)
+			if isGood(tmp) {
+				count++
+			}
+			return
+		}
+		for v := 0; v < limit; v++ {
+			arr[pos] = v
+			dfs(pos + 1)
+		}
+	}
+	dfs(0)
+	return count % m
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsF()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d %d\n", tc.n, tc.k, tc.m)
+		exp := fmt.Sprintf("%d", bruteForce(tc.n, tc.k, tc.m))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:%sexpected:%s\ngot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1605
- each verifier generates 100+ deterministic random tests
- verifiers run a candidate binary or Go file and compare against expected output
- brute-force logic included for problem F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6887317778188324bc18156255850e0a