### PR TITLE
Add Go verifiers for contest 1603

### DIFF
--- a/1000-1999/1600-1699/1600-1609/1603/verifierA.go
+++ b/1000-1999/1600-1699/1600-1609/1603/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1603A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(15) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Int63n(1_000_000_000)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCmd(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		tmp, err := os.CreateTemp("", "candidate-*")
+		if err != nil {
+			return "", err
+		}
+		tmp.Close()
+		exe := tmp.Name()
+		build := exec.Command("go", "build", "-o", exe, bin)
+		if out, err := build.CombinedOutput(); err != nil {
+			os.Remove(exe)
+			return "", fmt.Errorf("build error: %v\n%s", err, out)
+		}
+		defer os.Remove(exe)
+		cmd = exec.Command(exe)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(exe, ref, input string) error {
+	input = "1\n" + input
+	expected, err := runCmd(ref, input)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+	got, err := runCmd(exe, input)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(got, expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1603/verifierB.go
+++ b/1000-1999/1600-1699/1600-1609/1603/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1603B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	x := rng.Int63n(1_000_000_000/2)*2 + 2
+	y := rng.Int63n(1_000_000_000/2)*2 + 2
+	return fmt.Sprintf("%d %d\n", x, y)
+}
+
+func runCmd(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		tmp, err := os.CreateTemp("", "candidate-*")
+		if err != nil {
+			return "", err
+		}
+		tmp.Close()
+		exe := tmp.Name()
+		build := exec.Command("go", "build", "-o", exe, bin)
+		if out, err := build.CombinedOutput(); err != nil {
+			os.Remove(exe)
+			return "", fmt.Errorf("build error: %v\n%s", err, out)
+		}
+		defer os.Remove(exe)
+		cmd = exec.Command(exe)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(exe, ref, input string) error {
+	input = "1\n" + input
+	expected, err := runCmd(ref, input)
+	if err != nil {
+		return err
+	}
+	got, err := runCmd(exe, input)
+	if err != nil {
+		return err
+	}
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1603/verifierC.go
+++ b/1000-1999/1600-1699/1600-1609/1603/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1603C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(100)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCmd(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		tmp, err := os.CreateTemp("", "candidate-*")
+		if err != nil {
+			return "", err
+		}
+		tmp.Close()
+		exe := tmp.Name()
+		build := exec.Command("go", "build", "-o", exe, bin)
+		if out, err := build.CombinedOutput(); err != nil {
+			os.Remove(exe)
+			return "", fmt.Errorf("build error: %v\n%s", err, out)
+		}
+		defer os.Remove(exe)
+		cmd = exec.Command(exe)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(exe, ref, input string) error {
+	input = "1\n" + input
+	expected, err := runCmd(ref, input)
+	if err != nil {
+		return err
+	}
+	got, err := runCmd(exe, input)
+	if err != nil {
+		return err
+	}
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1603/verifierD.go
+++ b/1000-1999/1600-1699/1600-1609/1603/verifierD.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1603D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(n) + 1
+	return fmt.Sprintf("%d %d\n", n, k)
+}
+
+func runCmd(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		tmp, err := os.CreateTemp("", "candidate-*")
+		if err != nil {
+			return "", err
+		}
+		tmp.Close()
+		exe := tmp.Name()
+		build := exec.Command("go", "build", "-o", exe, bin)
+		if out, err := build.CombinedOutput(); err != nil {
+			os.Remove(exe)
+			return "", fmt.Errorf("build error: %v\n%s", err, out)
+		}
+		defer os.Remove(exe)
+		cmd = exec.Command(exe)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(exe, ref, input string) error {
+	input = "1\n" + input
+	expected, err := runCmd(ref, input)
+	if err != nil {
+		return err
+	}
+	got, err := runCmd(exe, input)
+	if err != nil {
+		return err
+	}
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1603/verifierE.go
+++ b/1000-1999/1600-1699/1600-1609/1603/verifierE.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1603E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+var primes = []int{1000000007, 1000000009, 1000000033, 1000000087, 1000000093, 1000000097}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	M := primes[rng.Intn(len(primes))]
+	return fmt.Sprintf("%d %d\n", n, M)
+}
+
+func runCmd(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		tmp, err := os.CreateTemp("", "candidate-*")
+		if err != nil {
+			return "", err
+		}
+		tmp.Close()
+		exe := tmp.Name()
+		build := exec.Command("go", "build", "-o", exe, bin)
+		if out, err := build.CombinedOutput(); err != nil {
+			os.Remove(exe)
+			return "", fmt.Errorf("build error: %v\n%s", err, out)
+		}
+		defer os.Remove(exe)
+		cmd = exec.Command(exe)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(exe, ref, input string) error {
+	expected, err := runCmd(ref, input)
+	if err != nil {
+		return err
+	}
+	got, err := runCmd(exe, input)
+	if err != nil {
+		return err
+	}
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1600-1609/1603/verifierF.go
+++ b/1000-1999/1600-1699/1600-1609/1603/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1603F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Int63n(1000) + 1
+	k := rng.Int63n(30)
+	var xbound int64
+	if k < 20 {
+		xbound = int64(1) << k
+	} else {
+		xbound = int64(1) << 20
+	}
+	var x int64
+	if xbound > 0 {
+		x = rng.Int63n(xbound)
+	}
+	return fmt.Sprintf("%d %d %d\n", n, k, x)
+}
+
+func runCmd(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		tmp, err := os.CreateTemp("", "candidate-*")
+		if err != nil {
+			return "", err
+		}
+		tmp.Close()
+		exe := tmp.Name()
+		build := exec.Command("go", "build", "-o", exe, bin)
+		if out, err := build.CombinedOutput(); err != nil {
+			os.Remove(exe)
+			return "", fmt.Errorf("build error: %v\n%s", err, out)
+		}
+		defer os.Remove(exe)
+		cmd = exec.Command(exe)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(exe, ref, input string) error {
+	input = "1\n" + input
+	expected, err := runCmd(ref, input)
+	if err != nil {
+		return err
+	}
+	got, err := runCmd(exe, input)
+	if err != nil {
+		return err
+	}
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new verifier programs for contest 1603
- verifiers compile the reference solutions and run 100 randomized test cases
- support binaries and `.go` submissions by compiling them to a temporary binary

## Testing
- `go build 1000-1999/1600-1699/1600-1609/1603/verifierA.go`
- `go build 1000-1999/1600-1699/1600-1609/1603/verifierB.go`
- `go build 1000-1999/1600-1699/1600-1609/1603/verifierC.go`
- `go build 1000-1999/1600-1699/1600-1609/1603/verifierD.go`
- `go build 1000-1999/1600-1699/1600-1609/1603/verifierE.go`
- `go build 1000-1999/1600-1699/1600-1609/1603/verifierF.go`
- `go build -o solA 1000-1999/1600-1699/1600-1609/1603/1603A.go`
- `go run verifierA.go ./solA`

------
https://chatgpt.com/codex/tasks/task_e_688730eb66208324a9f8af5b0ad4b4f6