### PR TITLE
Add Go verifiers for contest 1610

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1610/verifierA.go
+++ b/1000-1999/1600-1699/1610-1619/1610/verifierA.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(cmdPath string, input string) (string, error) {
+	cmd := exec.Command(cmdPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	cmd := exec.Command("go", "run", "1610A.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(1000) + 1
+		m := rand.Intn(1000) + 1
+		input := fmt.Sprintf("1\n%d %d\n", n, m)
+		expected, err := runRef(input)
+		if err != nil {
+			fmt.Println("failed to run reference:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed: expected %s got %s (input %d %d)\n", t, expected, got, n, m)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1610-1619/1610/verifierB.go
+++ b/1000-1999/1600-1699/1610-1619/1610/verifierB.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	cmd := exec.Command("go", "run", "1610B.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(20) + 1
+		input := fmt.Sprintf("1\n%d\n", n)
+		for i := 0; i < n; i++ {
+			input += fmt.Sprintf("%d ", rand.Intn(10))
+		}
+		input += "\n"
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed: expected %s got %s\ninput:%s\n", t, exp, got, strings.ReplaceAll(input, "\n", " "))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1610-1619/1610/verifierC.go
+++ b/1000-1999/1600-1699/1610-1619/1610/verifierC.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(in string) (string, error) {
+	cmd := exec.Command("go", "run", "1610C.go")
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(10) + 1
+		input := fmt.Sprintf("1\n%d\n", n)
+		for i := 0; i < n; i++ {
+			a := rand.Intn(10)
+			b := rand.Intn(10)
+			input += fmt.Sprintf("%d %d\n", a, b)
+		}
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed: expected %s got %s\n", t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1610-1619/1610/verifierD.go
+++ b/1000-1999/1600-1699/1610-1619/1610/verifierD.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(in string) (string, error) {
+	cmd := exec.Command("go", "run", "1610D.go")
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(10) + 1
+		input := fmt.Sprintf("%d\n", n)
+		for i := 0; i < n; i++ {
+			input += fmt.Sprintf("%d ", rand.Int63n(1e6))
+		}
+		input += "\n"
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed expected %s got %s\n", t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1610-1619/1610/verifierE.go
+++ b/1000-1999/1600-1699/1610-1619/1610/verifierE.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(in string) (string, error) {
+	cmd := exec.Command("go", "run", "1610E.go")
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(10) + 1
+		input := fmt.Sprintf("1\n%d\n", n)
+		for i := 0; i < n; i++ {
+			input += fmt.Sprintf("%d ", rand.Intn(1000))
+		}
+		input += "\n"
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed expected %s got %s\n", t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1610-1619/1610/verifierF.go
+++ b/1000-1999/1600-1699/1610-1619/1610/verifierF.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(in string) (string, error) {
+	cmd := exec.Command("go", "run", "1610F.go")
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(5) + 1
+		input := fmt.Sprintf("%d %d\n", n, m)
+		for i := 0; i < m; i++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			w := rand.Intn(3)
+			input += fmt.Sprintf("%d %d %d\n", u, v, w)
+		}
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed expected %s got %s\n", t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1610-1619/1610/verifierG.go
+++ b/1000-1999/1600-1699/1610-1619/1610/verifierG.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	cmd := exec.Command("go", "run", "1610G.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randStr() string {
+	n := rand.Intn(20) + 1
+	b := make([]byte, n)
+	b[0] = ')'
+	for i := 1; i < n; i++ {
+		if rand.Intn(2) == 0 {
+			b[i] = '('
+		} else {
+			b[i] = ')'
+		}
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		s := randStr()
+		input := s + "\n"
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed expected %s got %s\ninput:%s\n", t, exp, got, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1610-1619/1610/verifierH.go
+++ b/1000-1999/1600-1699/1610-1619/1610/verifierH.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	cmd := exec.Command("go", "run", "1610H.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTree(n int) []int {
+	parents := make([]int, n-1)
+	for i := 2; i <= n; i++ {
+		parents[i-2] = rand.Intn(i-1) + 1
+	}
+	return parents
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(5) + 2
+		m := rand.Intn(5) + 1
+		parents := genTree(n)
+		input := fmt.Sprintf("%d %d\n", n, m)
+		for _, p := range parents {
+			input += fmt.Sprintf("%d ", p)
+		}
+		input += "\n"
+		for i := 0; i < m; i++ {
+			x := rand.Intn(n) + 1
+			y := rand.Intn(n) + 1
+			input += fmt.Sprintf("%d %d\n", x, y)
+		}
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed expected %s got %s\n", t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1610-1619/1610/verifierI.go
+++ b/1000-1999/1600-1699/1610-1619/1610/verifierI.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	cmd := exec.Command("go", "run", "1610I.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(10) + 1
+		input := fmt.Sprintf("%d\n", n)
+		for i := 0; i < n-1; i++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			input += fmt.Sprintf("%d %d\n", u, v)
+		}
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed expected %s got %s\n", t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A-I of contest 1610
- each verifier generates at least 100 random test cases and checks a given binary against the reference solution

## Testing
- `go run verifierA.go ./1610A_bin`
- `go run verifierB.go ./1610B_bin`


------
https://chatgpt.com/codex/tasks/task_e_688732d5bba4832496b167de0834c25b