### PR TITLE
Add verifiers for contest 1613

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1613/verifierA.go
+++ b/1000-1999/1600-1699/1610-1619/1613/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func digits(x int64) int {
+	d := 0
+	for x > 0 {
+		d++
+		x /= 10
+	}
+	return d
+}
+
+func pow10(k int) int64 {
+	res := int64(1)
+	for i := 0; i < k; i++ {
+		res *= 10
+	}
+	return res
+}
+
+func compare(x1, p1, x2, p2 int64) string {
+	d1 := digits(x1)
+	d2 := digits(x2)
+	len1 := d1 + int(p1)
+	len2 := d2 + int(p2)
+	if len1 > len2 {
+		return ">"
+	}
+	if len1 < len2 {
+		return "<"
+	}
+	diff := int64(d1 - d2)
+	if diff > 0 {
+		x2 *= pow10(int(diff))
+		p2 -= diff
+	} else if diff < 0 {
+		x1 *= pow10(int(-diff))
+		p1 += diff
+	}
+	if x1 > x2 {
+		return ">"
+	}
+	if x1 < x2 {
+		return "<"
+	}
+	return "="
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	x1 := rng.Int63n(1_000_000) + 1
+	p1 := rng.Int63n(1_000_000)
+	x2 := rng.Int63n(1_000_000) + 1
+	p2 := rng.Int63n(1_000_000)
+	input := fmt.Sprintf("1\n%d %d\n%d %d\n", x1, p1, x2, p2)
+	expect := compare(x1, p1, x2, p2)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1613/verifierB.go
+++ b/1000-1999/1600-1699/1610-1619/1613/verifierB.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(9) + 2 // 2..10
+	perm := rng.Perm(1000)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = perm[i] + 1
+	}
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	input := fmt.Sprintf("1\n%d\n%s\n", n, sb.String())
+	return input, a
+}
+
+func checkCase(a []int, out string) error {
+	pairs := len(a) / 2
+	scan := bufio.NewScanner(strings.NewReader(out))
+	scan.Split(bufio.ScanWords)
+	arrSet := make(map[int]bool)
+	for _, v := range a {
+		arrSet[v] = true
+	}
+	used := make(map[string]bool)
+	for i := 0; i < pairs; i++ {
+		if !scan.Scan() {
+			return fmt.Errorf("not enough numbers")
+		}
+		x, err := strconv.Atoi(scan.Text())
+		if err != nil {
+			return fmt.Errorf("invalid int")
+		}
+		if !scan.Scan() {
+			return fmt.Errorf("not enough numbers")
+		}
+		y, err := strconv.Atoi(scan.Text())
+		if err != nil {
+			return fmt.Errorf("invalid int")
+		}
+		if x == y {
+			return fmt.Errorf("x == y")
+		}
+		if !arrSet[x] || !arrSet[y] {
+			return fmt.Errorf("numbers not in array")
+		}
+		mod := x % y
+		if arrSet[mod] {
+			return fmt.Errorf("x mod y present")
+		}
+		key := fmt.Sprintf("%d,%d", x, y)
+		if used[key] {
+			return fmt.Errorf("duplicate pair")
+		}
+		used[key] = true
+	}
+	if scan.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, arr := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if err := checkCase(arr, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1613/verifierC.go
+++ b/1000-1999/1600-1699/1610-1619/1613/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func enough(k int64, a []int64, h int64) bool {
+	damage := int64(0)
+	n := len(a)
+	for i := 0; i < n-1; i++ {
+		gap := a[i+1] - a[i]
+		if gap >= k {
+			damage += k
+		} else {
+			damage += gap
+		}
+		if damage >= h {
+			return true
+		}
+	}
+	damage += k
+	return damage >= h
+}
+
+func solveCase(a []int64, h int64) int64 {
+	l, r := int64(1), h
+	for l < r {
+		m := (l + r) / 2
+		if enough(m, a, h) {
+			r = m
+		} else {
+			l = m + 1
+		}
+	}
+	return l
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	a := make([]int64, n)
+	val := int64(0)
+	for i := 0; i < n; i++ {
+		val += int64(rng.Intn(10) + 1)
+		a[i] = val
+	}
+	h := int64(rng.Intn(1000) + 1)
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	input := fmt.Sprintf("1\n%d %d\n%s\n", n, h, sb.String())
+	expect := fmt.Sprintf("%d", solveCase(a, h))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1613/verifierD.go
+++ b/1000-1999/1600-1699/1610-1619/1613/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(a []int) int64 {
+	n := len(a)
+	dp0 := make([]int64, n+5)
+	dp1 := make([]int64, n+5)
+	dp0[0] = 1
+	for _, x := range a {
+		dp0[x+1] = (dp0[x+1] * 2) % mod
+		dp1[x+1] = (dp1[x+1] * 2) % mod
+		tmp := dp0[x]
+		dp0[x+1] = (dp0[x+1] + tmp) % mod
+		if x >= 1 {
+			tmp0 := dp0[x-1]
+			tmp1 := dp1[x-1]
+			dp1[x-1] = (tmp1*2 + tmp0) % mod
+		}
+	}
+	var ans int64
+	for i := 0; i < len(dp0); i++ {
+		ans += dp0[i] + dp1[i]
+	}
+	ans = (ans - 1) % mod
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(n + 1)
+	}
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	input := fmt.Sprintf("1\n%d\n%s\n", n, sb.String())
+	expect := fmt.Sprintf("%d", solve(a))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1613/verifierE.go
+++ b/1000-1999/1600-1699/1610-1619/1613/verifierE.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(grid [][]byte, n, m int) string {
+	var sx, sy int
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 'L' {
+				sx, sy = i, j
+			}
+		}
+	}
+	deg := make([][]int, n)
+	for i := 0; i < n; i++ {
+		deg[i] = make([]int, m)
+	}
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '#' {
+				continue
+			}
+			cnt := 0
+			for _, d := range dirs {
+				ni, nj := i+d[0], j+d[1]
+				if ni >= 0 && ni < n && nj >= 0 && nj < m && grid[ni][nj] != '#' {
+					cnt++
+				}
+			}
+			deg[i][j] = cnt
+		}
+	}
+	q := []point{{sx, sy}}
+	for head := 0; head < len(q); head++ {
+		p := q[head]
+		for _, d := range dirs {
+			ni, nj := p.x+d[0], p.y+d[1]
+			if ni < 0 || ni >= n || nj < 0 || nj >= m {
+				continue
+			}
+			if grid[ni][nj] != '.' {
+				continue
+			}
+			deg[ni][nj]--
+			if deg[ni][nj] <= 1 {
+				grid[ni][nj] = '+'
+				q = append(q, point{ni, nj})
+			}
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	for n*m > 16 { // ensure small
+		n = rng.Intn(4) + 1
+		m = rng.Intn(4) + 1
+	}
+	grid := make([][]byte, n)
+	labPlaced := false
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if !labPlaced && rng.Intn(n*m) == 0 {
+				row[j] = 'L'
+				labPlaced = true
+			} else {
+				if rng.Intn(4) == 0 {
+					row[j] = '#'
+				} else {
+					row[j] = '.'
+				}
+			}
+		}
+		grid[i] = row
+	}
+	if !labPlaced {
+		grid[0][0] = 'L'
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	expect := solveCase(copyGrid(grid), n, m)
+	return sb.String(), expect
+}
+
+func copyGrid(g [][]byte) [][]byte {
+	n := len(g)
+	res := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		res[i] = append([]byte(nil), g[i]...)
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1613/verifierF.go
+++ b/1000-1999/1600-1699/1610-1619/1613/verifierF.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1613F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	if n < 2 {
+		n = 2
+	}
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	input := sb.String()
+	return input, input
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		_, oracleIn := generateCase(rng)
+		exp, err := run(oracle, oracleIn)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, oracleIn)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, oracleIn)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, oracleIn)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for all problems of contest 1613
- each verifier generates 100 random cases
- verifiers call a candidate binary and check against expected results

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688733a88ce88324b493ec839fb44c0f