### PR TITLE
Add Go verifiers for CF contest 1612

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1612/verifierA.go
+++ b/1000-1999/1600-1699/1610-1619/1612/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func check(x, y int, output string) error {
+	parts := strings.Fields(output)
+	if len(parts) != 2 {
+		return fmt.Errorf("expected two integers, got %q", output)
+	}
+	a, err1 := strconv.Atoi(parts[0])
+	b, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("failed to parse integers from %q", output)
+	}
+	if (x+y)%2 == 1 {
+		if a != -1 || b != -1 {
+			return fmt.Errorf("expected -1 -1 for x=%d y=%d, got %d %d", x, y, a, b)
+		}
+		return nil
+	}
+	if a == -1 && b == -1 {
+		return fmt.Errorf("solution exists for x=%d y=%d but got -1 -1", x, y)
+	}
+	if a < 0 || b < 0 || a > x || b > y {
+		return fmt.Errorf("invalid coordinates %d %d for x=%d y=%d", a, b, x, y)
+	}
+	if a+b != (x+y)/2 {
+		return fmt.Errorf("a+b mismatch for x=%d y=%d: got %d+%d", x, y, a, b)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for x := 0; x <= 50; x++ {
+		for y := 0; y <= 50; y++ {
+			input := fmt.Sprintf("1\n%d %d\n", x, y)
+			out, err := run(bin, input)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case x=%d y=%d failed: %v\n", x, y, err)
+				os.Exit(1)
+			}
+			if err := check(x, y, out); err != nil {
+				fmt.Fprintf(os.Stderr, "case x=%d y=%d failed: %v\n", x, y, err)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1612/verifierB.go
+++ b/1000-1999/1600-1699/1610-1619/1612/verifierB.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func possible(n, a, b int) bool {
+	half := n / 2
+	return a <= half+1 && b >= half && a != b
+}
+
+func check(n, a, b int, output string) error {
+	output = strings.TrimSpace(output)
+	if output == "-1" {
+		if possible(n, a, b) {
+			return fmt.Errorf("expected valid permutation but got -1")
+		}
+		return nil
+	}
+	if !possible(n, a, b) {
+		return fmt.Errorf("expected -1 but got %q", output)
+	}
+	parts := strings.Fields(output)
+	if len(parts) != n {
+		return fmt.Errorf("expected %d integers, got %d", n, len(parts))
+	}
+	seen := make([]bool, n+1)
+	vals := make([]int, n)
+	for i, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", p)
+		}
+		if v < 1 || v > n || seen[v] {
+			return fmt.Errorf("invalid permutation value %d", v)
+		}
+		seen[v] = true
+		vals[i] = v
+	}
+	half := n / 2
+	minLeft := vals[0]
+	for i := 1; i < half; i++ {
+		if vals[i] < minLeft {
+			minLeft = vals[i]
+		}
+	}
+	maxRight := vals[half]
+	for i := half + 1; i < n; i++ {
+		if vals[i] > maxRight {
+			maxRight = vals[i]
+		}
+	}
+	if minLeft != a || maxRight != b {
+		return fmt.Errorf("constraints not satisfied")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50)*2 + 2 // even from 2..100
+		a := rand.Intn(n) + 1
+		b := rand.Intn(n-1) + 1
+		if b >= a {
+			b++
+			if b > n {
+				b = 1
+			}
+		}
+		input := fmt.Sprintf("1\n%d %d %d\n", n, a, b)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(n, a, b, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d a=%d b=%d\n", i+1, err, n, a, b)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1612/verifierC.go
+++ b/1000-1999/1600-1699/1610-1619/1612/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func sumFirst(n, k int64) int64 {
+	if n <= k {
+		return n * (n + 1) / 2
+	}
+	m := n - k
+	p := k - m - 1
+	return k*k - p*(p+1)/2
+}
+
+func expected(k, x int64) int64 {
+	if x >= k*k {
+		return 2*k - 1
+	}
+	low, high := int64(1), 2*k-1
+	for low < high {
+		mid := (low + high) / 2
+		if sumFirst(mid, k) >= x {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	return low
+}
+
+func check(k, x int64, output string) error {
+	val, err := strconv.ParseInt(strings.TrimSpace(output), 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid integer output %q", output)
+	}
+	want := expected(k, x)
+	if val != want {
+		return fmt.Errorf("expected %d got %d", want, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		k := rand.Int63n(100000) + 1
+		maxX := k * k
+		x := rand.Int63n(maxX) + 1
+		input := fmt.Sprintf("1\n%d %d\n", k, x)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(k, x, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: k=%d x=%d\n", i+1, err, k, x)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1612/verifierD.go
+++ b/1000-1999/1600-1699/1610-1619/1612/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func isMagic(a, b, x int64) bool {
+	g := gcd(a, b)
+	if x%g != 0 {
+		return false
+	}
+	a /= g
+	b /= g
+	x /= g
+	for a != 0 && b != 0 && max64(a, b) >= x {
+		if a == x || b == x {
+			return true
+		}
+		if a < b {
+			a, b = b, a
+		}
+		if (a-x)%b == 0 {
+			return true
+		}
+		a %= b
+	}
+	return a == x || b == x
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func check(a, b, x int64, output string) error {
+	got := strings.TrimSpace(output)
+	want := "NO"
+	if isMagic(a, b, x) {
+		want = "YES"
+	}
+	if got != want {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		a := rand.Int63n(1000000) + 1
+		b := rand.Int63n(1000000) + 1
+		x := rand.Int63n(1000000) + 1
+		input := fmt.Sprintf("1\n%d %d %d\n", a, b, x)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(a, b, x, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: a=%d b=%d x=%d\n", i+1, err, a, b, x)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1612/verifierE.go
+++ b/1000-1999/1600-1699/1610-1619/1612/verifierE.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type entry struct {
+	sum int
+	id  int
+}
+
+func bestAvg(n int, pairs [][2]int) (float64, map[int]int) {
+	teamVals := make(map[int][]int)
+	teams := make([]int, 0)
+	for _, p := range pairs {
+		m := p[0]
+		k := p[1]
+		if _, ok := teamVals[m]; !ok {
+			teams = append(teams, m)
+		}
+		teamVals[m] = append(teamVals[m], k)
+	}
+	best := 0.0
+	sums := make(map[int]int)
+	for t := 1; t <= 20; t++ {
+		entries := make([]entry, 0, len(teams))
+		for _, id := range teams {
+			vals := teamVals[id]
+			s := 0
+			for _, v := range vals {
+				if v >= t {
+					s += t
+				} else {
+					s += v
+				}
+			}
+			if s > 0 {
+				entries = append(entries, entry{s, id})
+			}
+		}
+		if len(entries) < t {
+			continue
+		}
+		sort.Slice(entries, func(i, j int) bool { return entries[i].sum > entries[j].sum })
+		total := 0
+		ids := make([]int, t)
+		for i := 0; i < t; i++ {
+			total += entries[i].sum
+			ids[i] = entries[i].id
+		}
+		avg := float64(total) / float64(t)
+		if avg > best {
+			best = avg
+			sums = make(map[int]int)
+			for i := 0; i < t; i++ {
+				sums[ids[i]] = 1
+			}
+		}
+	}
+	return best, sums
+}
+
+func computeAvg(t int, selected []int, pairs [][2]int) float64 {
+	idSet := make(map[int]bool)
+	for _, id := range selected {
+		idSet[id] = true
+	}
+	total := 0
+	for _, p := range pairs {
+		if !idSet[p[0]] {
+			continue
+		}
+		if t <= p[1] {
+			total += t
+		} else {
+			total += p[1]
+		}
+	}
+	return float64(total) / float64(t)
+}
+
+func parseOutput(output string) (int, []int, error) {
+	parts := strings.Fields(output)
+	if len(parts) == 0 {
+		return 0, nil, fmt.Errorf("empty output")
+	}
+	t, err := strconv.Atoi(parts[0])
+	if err != nil || t < 0 {
+		return 0, nil, fmt.Errorf("invalid t")
+	}
+	if len(parts)-1 != t {
+		return 0, nil, fmt.Errorf("expected %d ids, got %d", t, len(parts)-1)
+	}
+	ids := make([]int, t)
+	for i := 0; i < t; i++ {
+		v, err := strconv.Atoi(parts[i+1])
+		if err != nil {
+			return 0, nil, fmt.Errorf("invalid id %q", parts[i+1])
+		}
+		ids[i] = v
+	}
+	return t, ids, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 2
+		pairs := make([][2]int, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			m := rand.Intn(8) + 1
+			k := rand.Intn(5) + 1
+			pairs[j] = [2]int{m, k}
+			fmt.Fprintf(&sb, "%d %d\n", m, k)
+		}
+		input := sb.String()
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		tOut, ids, err := parseOutput(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\noutput:%s\n", i+1, err, out)
+			os.Exit(1)
+		}
+		best, _ := bestAvg(n, pairs)
+		avg := computeAvg(tOut, ids, pairs)
+		if absFloat(best-avg) > 1e-6 {
+			fmt.Fprintf(os.Stderr, "case %d failed: suboptimal average\n", i+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func absFloat(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/1000-1999/1600-1699/1610-1619/1612/verifierF.go
+++ b/1000-1999/1600-1699/1610-1619/1612/verifierF.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ a, b int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func bfs(n, m int, good map[pair]bool) int {
+	type state struct{ a, b int }
+	dist := make([][]int, n+1)
+	for i := range dist {
+		dist[i] = make([]int, m+1)
+		for j := range dist[i] {
+			dist[i][j] = -1
+		}
+	}
+	q := list.New()
+	q.PushBack(state{1, 1})
+	dist[1][1] = 0
+	for q.Len() > 0 {
+		e := q.Front()
+		q.Remove(e)
+		s := e.Value.(state)
+		d := dist[s.a][s.b]
+		if s.a == n && s.b == m {
+			return d
+		}
+		best := 0
+		for i := 1; i <= s.a; i++ {
+			for j := 1; j <= s.b; j++ {
+				p := i + j
+				if good[pair{i, j}] {
+					p++
+				}
+				if p > best {
+					best = p
+				}
+			}
+		}
+		if s.a < n && best >= s.a+1 && dist[s.a+1][s.b] == -1 {
+			dist[s.a+1][s.b] = d + 1
+			q.PushBack(state{s.a + 1, s.b})
+		}
+		if s.b < m && best >= s.b+1 && dist[s.a][s.b+1] == -1 {
+			dist[s.a][s.b+1] = d + 1
+			q.PushBack(state{s.a, s.b + 1})
+		}
+	}
+	return -1
+}
+
+func parse(output string) (int, error) {
+	output = strings.TrimSpace(output)
+	var val int
+	_, err := fmt.Sscanf(output, "%d", &val)
+	return val, err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 2
+		m := rand.Intn(5) + 2
+		q := rand.Intn(n*m + 1)
+		good := make(map[pair]bool)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n%d\n", n, m, q)
+		for i := 0; i < q; i++ {
+			a := rand.Intn(n) + 1
+			b := rand.Intn(m) + 1
+			good[pair{a, b}] = true
+			fmt.Fprintf(&sb, "%d %d\n", a, b)
+		}
+		input := sb.String()
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := parse(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed to parse output: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		want := bfs(n, m, good)
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\n", t+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1612/verifierG.go
+++ b/1000-1999/1600-1699/1610-1619/1612/verifierG.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1_000_000_007
+const INV2 int64 = (MOD + 1) / 2
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(c []int) (int64, int64) {
+	m := len(c)
+	maxC := 0
+	for _, v := range c {
+		if v > maxC {
+			maxC = v
+		}
+	}
+	arrOdd := make([]int64, maxC)
+	arrEven := make([]int64, maxC)
+	for _, v := range c {
+		if v%2 == 1 {
+			arrOdd[v-1]++
+		} else {
+			arrEven[v-1]++
+		}
+	}
+	prefOdd := make([]int64, maxC+1)
+	prefEven := make([]int64, maxC+1)
+	for t := maxC - 1; t >= 0; t-- {
+		prefOdd[t] = prefOdd[t+1] + arrOdd[t]
+		prefEven[t] = prefEven[t+1] + arrEven[t]
+	}
+	fact := make([]int64, m+1)
+	fact[0] = 1
+	for i := 1; i <= m; i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	pos := int64(1)
+	ans := int64(0)
+	ways := int64(1)
+	for x := -maxC + 1; x <= maxC-1; x++ {
+		t := x
+		if t < 0 {
+			t = -t
+		}
+		if t >= maxC {
+			continue
+		}
+		var cnt int64
+		if t%2 == 0 {
+			cnt = prefOdd[t]
+		} else {
+			cnt = prefEven[t]
+		}
+		if cnt == 0 {
+			continue
+		}
+		cntMod := cnt % MOD
+		posMod := pos % MOD
+		sumPosMod := (cntMod * posMod) % MOD
+		sumPosMod = (sumPosMod + cntMod*((cnt-1)%MOD)%MOD*INV2%MOD) % MOD
+		xMod := int64(x % int(MOD))
+		if xMod < 0 {
+			xMod += MOD
+		}
+		ans = (ans + xMod*sumPosMod%MOD) % MOD
+		ways = ways * fact[int(cnt)] % MOD
+		pos += cnt
+	}
+	return ans, ways
+}
+
+func parseOutput(output string) (int64, int64, error) {
+	parts := strings.Fields(output)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("expected two integers")
+	}
+	a, err1 := strconv.ParseInt(parts[0], 10, 64)
+	b, err2 := strconv.ParseInt(parts[1], 10, 64)
+	if err1 != nil || err2 != nil {
+		return 0, 0, fmt.Errorf("invalid integers")
+	}
+	a %= MOD
+	b %= MOD
+	if a < 0 {
+		a += MOD
+	}
+	if b < 0 {
+		b += MOD
+	}
+	return a, b, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		m := rand.Intn(5) + 1
+		c := make([]int, m)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", m)
+		for i := 0; i < m; i++ {
+			c[i] = rand.Intn(5) + 1
+			fmt.Fprintf(&sb, "%d ", c[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		gotAns, gotWays, err := parseOutput(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d invalid output: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		ans, ways := solve(c)
+		if gotAns != ans%MOD || gotWays != ways%MOD {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d %d got %d %d\n", t+1, ans%MOD, ways%MOD, gotAns, gotWays)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A-G of contest 1612
- each verifier generates at least 100 test cases and checks a binary's output

## Testing
- `go build verifierA.go`
- `go build verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_68873361f73083248dac37450d9378f2