### PR TITLE
Add solution verifiers for contest 1615

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1615/verifierA.go
+++ b/1000-1999/1600-1699/1610-1619/1615/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1615A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(0)
+	tests := make([]Test, 0, 20)
+	for i := 0; i < 19; i++ {
+		n := rand.Intn(9) + 1 // 1..9
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n) + "\n")
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(rand.Intn(10)))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	tests = append(tests, Test{"1\n1\n0\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		want, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1615/verifierB.go
+++ b/1000-1999/1600-1699/1610-1619/1615/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1615B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(1)
+	tests := make([]Test, 0, 20)
+	for i := 0; i < 19; i++ {
+		l := rand.Intn(100)
+		r := l + rand.Intn(100)
+		input := fmt.Sprintf("1\n%d %d\n", l, r)
+		tests = append(tests, Test{input})
+	}
+	tests = append(tests, Test{"1\n0 0\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		want, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1615/verifierC.go
+++ b/1000-1999/1600-1699/1610-1619/1615/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1615C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(2)
+	tests := make([]Test, 0, 20)
+	for i := 0; i < 19; i++ {
+		n := rand.Intn(8) + 1
+		var a, b strings.Builder
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				a.WriteByte('0')
+			} else {
+				a.WriteByte('1')
+			}
+			if rand.Intn(2) == 0 {
+				b.WriteByte('0')
+			} else {
+				b.WriteByte('1')
+			}
+		}
+		input := fmt.Sprintf("1\n%d\n%s\n%s\n", n, a.String(), b.String())
+		tests = append(tests, Test{input})
+	}
+	tests = append(tests, Test{"1\n1\n0\n1\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		want, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1615/verifierD.go
+++ b/1000-1999/1600-1699/1610-1619/1615/verifierD.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1615D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(3)
+	tests := make([]Test, 0, 20)
+	for t := 0; t < 19; t++ {
+		n := rand.Intn(4) + 2 // 2..5
+		q := rand.Intn(3)
+		edges := make([][3]int, n-1)
+		for i := 1; i < n; i++ {
+			u := rand.Intn(i) + 1
+			v := i + 1
+			w := rand.Intn(6) - 1 // maybe -1..4
+			if w < 0 {
+				w = -1
+			}
+			edges[i-1] = [3]int{u, v, w}
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i := 0; i < n-1; i++ {
+			e := edges[i]
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+		}
+		for i := 0; i < q; i++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			for v == u {
+				v = rand.Intn(n) + 1
+			}
+			w := rand.Intn(2)
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", u, v, w))
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	// minimal case
+	tests = append(tests, Test{"1\n2 0\n1 2 -1\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		want, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1615/verifierE.go
+++ b/1000-1999/1600-1699/1610-1619/1615/verifierE.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1615E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(4)
+	tests := make([]Test, 0, 20)
+	for t := 0; t < 19; t++ {
+		n := rand.Intn(6) + 1
+		k := rand.Intn(n) + 1
+		edges := make([][2]int, n-1)
+		for i := 1; i < n; i++ {
+			u := rand.Intn(i) + 1
+			v := i + 1
+			edges[i-1] = [2]int{u, v}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n-1; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", edges[i][0], edges[i][1]))
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	tests = append(tests, Test{"1 1\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		want, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1615/verifierF.go
+++ b/1000-1999/1600-1699/1610-1619/1615/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1615F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(5)
+	tests := make([]Test, 0, 20)
+	for t := 0; t < 19; t++ {
+		n := rand.Intn(5) + 1
+		var s, tt strings.Builder
+		for i := 0; i < n; i++ {
+			ch := rand.Intn(3)
+			if ch == 0 {
+				s.WriteByte('0')
+			} else if ch == 1 {
+				s.WriteByte('1')
+			} else {
+				s.WriteByte('?')
+			}
+			ch = rand.Intn(3)
+			if ch == 0 {
+				tt.WriteByte('0')
+			} else if ch == 1 {
+				tt.WriteByte('1')
+			} else {
+				tt.WriteByte('?')
+			}
+		}
+		input := fmt.Sprintf("1\n%d\n%s\n%s\n", n, s.String(), tt.String())
+		tests = append(tests, Test{input})
+	}
+	tests = append(tests, Test{"1\n1\n?\n1\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		want, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1615/verifierG.go
+++ b/1000-1999/1600-1699/1610-1619/1615/verifierG.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1615G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(6)
+	tests := make([]Test, 0, 20)
+	for t := 0; t < 19; t++ {
+		n := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d ", rand.Intn(4)))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	tests = append(tests, Test{"1\n0\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		want, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1615/verifierH.go
+++ b/1000-1999/1600-1699/1610-1619/1615/verifierH.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "./refH.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1615H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(7)
+	tests := make([]Test, 0, 20)
+	for t := 0; t < 19; t++ {
+		n := rand.Intn(4) + 1
+		m := rand.Intn(n*n + 1)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d ", rand.Intn(5)))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			for v == u {
+				v = rand.Intn(n) + 1
+			}
+			sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	tests = append(tests, Test{"1 0\n0\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		want, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` through `verifierH.go` in `1615` directory
- each verifier builds the reference solution, generates 20 random tests and compares output to any provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_68873434a718832486264f6883b440a7