### PR TITLE
Add Go verifiers for contest 1617

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1617/verifierA.go
+++ b/1000-1999/1600-1699/1610-1619/1617/verifierA.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errb.String(), err
+	}
+	return out.String(), nil
+}
+
+func solve(s, perm string) string {
+	cnt := make([]int, 26)
+	for i := 0; i < len(s); i++ {
+		cnt[s[i]-'a']++
+	}
+	var sb strings.Builder
+	if perm == "abc" && cnt[0] > 0 && cnt[1] > 0 && cnt[2] > 0 {
+		for i := 0; i < cnt[0]; i++ {
+			sb.WriteByte('a')
+		}
+		for i := 0; i < cnt[2]; i++ {
+			sb.WriteByte('c')
+		}
+		for i := 0; i < cnt[1]; i++ {
+			sb.WriteByte('b')
+		}
+		for ch := byte('d'); ch <= 'z'; ch++ {
+			for i := 0; i < cnt[ch-'a']; i++ {
+				sb.WriteByte(ch)
+			}
+		}
+	} else {
+		for ch := byte('a'); ch <= 'z'; ch++ {
+			for i := 0; i < cnt[ch-'a']; i++ {
+				sb.WriteByte(ch)
+			}
+		}
+	}
+	return sb.String()
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + rng.Intn(26)))
+	}
+	letters := []byte{'a', 'b', 'c'}
+	rng.Shuffle(3, func(i, j int) { letters[i], letters[j] = letters[j], letters[i] })
+	return sb.String(), string(letters)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const tests = 100
+	var input bytes.Buffer
+	input.WriteString(fmt.Sprintf("%d\n", tests))
+	expected := make([]string, tests)
+	for i := 0; i < tests; i++ {
+		s, perm := genTest(rng)
+		expected[i] = solve(s, perm)
+		input.WriteString(s)
+		input.WriteByte('\n')
+		input.WriteString(perm)
+		input.WriteByte('\n')
+	}
+	out, err := run(bin, input.String())
+	if err != nil {
+		fmt.Printf("runtime error: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != tests {
+		fmt.Printf("expected %d lines of output got %d\n", tests, len(lines))
+		os.Exit(1)
+	}
+	for i := 0; i < tests; i++ {
+		if strings.TrimSpace(lines[i]) != expected[i] {
+			fmt.Printf("test %d failed\nexpected:%s got:%s\n", i+1, expected[i], strings.TrimSpace(lines[i]))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1617/verifierB.go
+++ b/1000-1999/1600-1699/1610-1619/1617/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errb.String(), err
+	}
+	return out.String(), nil
+}
+
+func solve(n int) string {
+	if n%2 == 0 {
+		return fmt.Sprintf("%d %d 1", n/2-1, n/2)
+	}
+	if (n-1)%4 == 0 {
+		k := (n - 1) / 2
+		return fmt.Sprintf("%d %d 1", k-1, k+1)
+	}
+	k := (n - 1) / 2
+	return fmt.Sprintf("%d %d 1", k-2, k+2)
+}
+
+func genTest(rng *rand.Rand) int {
+	return rng.Intn(1_000_000_000-10) + 10
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const tests = 100
+	var input bytes.Buffer
+	input.WriteString(fmt.Sprintf("%d\n", tests))
+	expected := make([]string, tests)
+	nums := make([]int, tests)
+	for i := 0; i < tests; i++ {
+		n := genTest(rng)
+		nums[i] = n
+		expected[i] = solve(n)
+		input.WriteString(fmt.Sprintf("%d\n", n))
+	}
+	out, err := run(bin, input.String())
+	if err != nil {
+		fmt.Printf("runtime error: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != tests {
+		fmt.Printf("expected %d lines of output got %d\n", tests, len(lines))
+		os.Exit(1)
+	}
+	for i := 0; i < tests; i++ {
+		if strings.TrimSpace(lines[i]) != expected[i] {
+			fmt.Printf("test %d failed (n=%d) expected:%s got:%s\n", i+1, nums[i], expected[i], strings.TrimSpace(lines[i]))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1617/verifierC.go
+++ b/1000-1999/1600-1699/1610-1619/1617/verifierC.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errb.String(), err
+	}
+	return out.String(), nil
+}
+
+func solveCase(a []int) int {
+	n := len(a)
+	used := make([]bool, n+1)
+	extras := make([]int, 0)
+	for _, v := range a {
+		if v >= 1 && v <= n && !used[v] {
+			used[v] = true
+		} else {
+			extras = append(extras, v)
+		}
+	}
+	sort.Ints(extras)
+	missing := make([]int, 0)
+	for i := 1; i <= n; i++ {
+		if !used[i] {
+			missing = append(missing, i)
+		}
+	}
+	if len(extras) != len(missing) {
+		return -1
+	}
+	for i, m := range missing {
+		if extras[i] <= 2*m {
+			return -1
+		}
+	}
+	return len(extras)
+}
+
+func genTest(rng *rand.Rand) []int {
+	n := rng.Intn(10) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(30) + 1
+	}
+	return a
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const tests = 100
+	var input bytes.Buffer
+	input.WriteString(fmt.Sprintf("%d\n", tests))
+	expected := make([]int, tests)
+	for i := 0; i < tests; i++ {
+		arr := genTest(rng)
+		expected[i] = solveCase(append([]int(nil), arr...))
+		input.WriteString(fmt.Sprintf("%d\n", len(arr)))
+		for j, v := range arr {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", v))
+		}
+		input.WriteByte('\n')
+	}
+	out, err := run(bin, input.String())
+	if err != nil {
+		fmt.Printf("runtime error: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != tests {
+		fmt.Printf("expected %d lines of output got %d\n", tests, len(lines))
+		os.Exit(1)
+	}
+	for i := 0; i < tests; i++ {
+		got := strings.TrimSpace(lines[i])
+		if got != fmt.Sprintf("%d", expected[i]) {
+			fmt.Printf("test %d failed expected:%d got:%s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1617/verifierD1.go
+++ b/1000-1999/1600-1699/1610-1619/1617/verifierD1.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem D1 is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1600-1699/1610-1619/1617/verifierD2.go
+++ b/1000-1999/1600-1699/1610-1619/1617/verifierD2.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem D2 is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1600-1699/1610-1619/1617/verifierE.go
+++ b/1000-1999/1600-1699/1610-1619/1617/verifierE.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errb.String(), err
+	}
+	return out.String(), nil
+}
+
+func getInv(v int) int {
+	lg := 0
+	for (1 << (lg + 1)) <= v {
+		lg++
+	}
+	inv := (1 << (lg + 1)) - v
+	if inv == v {
+		return 0
+	}
+	return inv
+}
+
+func distance(p1, p2 []int) int {
+	pf := 0
+	m := len(p1)
+	if len(p2) < m {
+		m = len(p2)
+	}
+	for pf < m && p1[pf] == p2[pf] {
+		pf++
+	}
+	return len(p1) + len(p2) - 2*pf
+}
+
+func solveCase(a []int) (int, int, int) {
+	n := len(a)
+	paths := make([][]int, n)
+	for i := 0; i < n; i++ {
+		path := []int{a[i]}
+		for path[len(path)-1] != 0 {
+			path = append(path, getInv(path[len(path)-1]))
+		}
+		for l, r := 0, len(path)-1; l < r; l, r = l+1, r-1 {
+			path[l], path[r] = path[r], path[l]
+		}
+		paths[i] = path
+	}
+	from := 0
+	best := -1
+	far := -1
+	for i := 0; i < n; i++ {
+		if i == from {
+			continue
+		}
+		d := distance(paths[from], paths[i])
+		if d > best {
+			best = d
+			far = i
+		}
+	}
+	from = far
+	best = -1
+	far2 := -1
+	for i := 0; i < n; i++ {
+		if i == from {
+			continue
+		}
+		d := distance(paths[from], paths[i])
+		if d > best {
+			best = d
+			far2 = i
+		}
+	}
+	return from + 1, far2 + 1, best
+}
+
+func genTest(rng *rand.Rand) []int {
+	n := rng.Intn(9) + 2
+	used := make(map[int]bool)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		for {
+			v := rng.Intn(1000)
+			if !used[v] {
+				used[v] = true
+				arr[i] = v
+				break
+			}
+		}
+	}
+	return arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		arr := genTest(rng)
+		u, v, d := solveCase(arr)
+		var input bytes.Buffer
+		input.WriteString(fmt.Sprintf("%d\n", len(arr)))
+		for i, x := range arr {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", x))
+		}
+		input.WriteByte('\n')
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n%s", t+1, err, out)
+			os.Exit(1)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		if len(fields) != 3 {
+			fmt.Printf("test %d expected three numbers got %d\n", t+1, len(fields))
+			os.Exit(1)
+		}
+		var gotU, gotV, gotD int
+		if _, err := fmt.Sscan(fields[0], &gotU); err != nil {
+			fmt.Printf("test %d bad output: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if _, err := fmt.Sscan(fields[1], &gotV); err != nil {
+			fmt.Printf("test %d bad output: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if _, err := fmt.Sscan(fields[2], &gotD); err != nil {
+			fmt.Printf("test %d bad output: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if gotU != u || gotV != v || gotD != d {
+			fmt.Printf("test %d failed expected:%d %d %d got:%d %d %d\n", t+1, u, v, d, gotU, gotV, gotD)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD1.go and verifierD2.go placeholders
- add verifierE.go for problem E

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_688734c01f8083248530ccb681520b51