### PR TITLE
Add Go verifiers for CF contest 1616

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1616/verifierA.go
+++ b/1000-1999/1600-1699/1610-1619/1616/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const numTests = 100
+const refSource = "1616A.go"
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refA_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, refSource)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return tmp, nil
+}
+
+func runBinary(path string, in []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.Bytes(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.Bytes(), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(100) + 1
+	arr := make([]int, n)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d\n", n)
+	for i := range arr {
+		arr[i] = rand.Intn(201) - 100
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprintf(&buf, "%d", arr[i])
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	comp := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < numTests; i++ {
+		input := genTest()
+		want, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(comp, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "competitor run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if bytes.TrimSpace(got) == nil || !bytes.Equal(bytes.TrimSpace(want), bytes.TrimSpace(got)) {
+			fmt.Printf("WA on test %d\ninput:\n%sexpected:\n%s\nreceived:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1616/verifierB.go
+++ b/1000-1999/1600-1699/1610-1619/1616/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const numTests = 100
+const refSource = "1616B.go"
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refB_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, refSource)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return tmp, nil
+}
+
+func runBinary(path string, in []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.Bytes(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.Bytes(), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 1
+	var s bytes.Buffer
+	for i := 0; i < n; i++ {
+		s.WriteByte(byte('a' + rand.Intn(26)))
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d\n%s\n", n, s.String())
+	return buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	comp := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < numTests; i++ {
+		input := genTest()
+		want, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(comp, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "competitor run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(bytes.TrimSpace(want), bytes.TrimSpace(got)) {
+			fmt.Printf("WA on test %d\ninput:\n%sexpected:\n%s\nreceived:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1616/verifierC.go
+++ b/1000-1999/1600-1699/1610-1619/1616/verifierC.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const numTests = 100
+const refSource = "1616C.go"
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refC_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, refSource)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return tmp, nil
+}
+
+func runBinary(path string, in []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.Bytes(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.Bytes(), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(70) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprintf(&buf, "%d", rand.Intn(201)-100)
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	comp := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < numTests; i++ {
+		input := genTest()
+		want, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(comp, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "competitor run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(bytes.TrimSpace(want), bytes.TrimSpace(got)) {
+			fmt.Printf("WA on test %d\ninput:\n%sexpected:\n%s\nreceived:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1616/verifierD.go
+++ b/1000-1999/1600-1699/1610-1619/1616/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const numTests = 100
+const refSource = "1616D.go"
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refD_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, refSource)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return tmp, nil
+}
+
+func runBinary(path string, in []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.Bytes(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.Bytes(), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(50) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprintf(&buf, "%d", rand.Intn(200001)-100000)
+	}
+	fmt.Fprintf(&buf, "\n%d\n", rand.Intn(200001)-100000)
+	return buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	comp := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < numTests; i++ {
+		input := genTest()
+		want, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(comp, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "competitor run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(bytes.TrimSpace(want), bytes.TrimSpace(got)) {
+			fmt.Printf("WA on test %d\ninput:\n%sexpected:\n%s\nreceived:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1616/verifierE.go
+++ b/1000-1999/1600-1699/1610-1619/1616/verifierE.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const numTests = 100
+const refSource = "1616E.go"
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refE_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, refSource)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return tmp, nil
+}
+
+func runBinary(path string, in []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.Bytes(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.Bytes(), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 1
+	var s, t bytes.Buffer
+	for i := 0; i < n; i++ {
+		s.WriteByte(byte('a' + rand.Intn(26)))
+		t.WriteByte(byte('a' + rand.Intn(26)))
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d\n%s\n%s\n", n, s.String(), t.String())
+	return buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	comp := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < numTests; i++ {
+		input := genTest()
+		want, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(comp, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "competitor run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(bytes.TrimSpace(want), bytes.TrimSpace(got)) {
+			fmt.Printf("WA on test %d\ninput:\n%sexpected:\n%s\nreceived:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1616/verifierF.go
+++ b/1000-1999/1600-1699/1610-1619/1616/verifierF.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const numTests = 100
+const refSource = "1616F.go"
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refF_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, refSource)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return tmp, nil
+}
+
+func runBinary(path string, in []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.Bytes(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.Bytes(), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(n*(n-1)/2 + 1)
+	edges := make([][3]int, m)
+	used := make(map[[2]int]bool)
+	for i := 0; i < m; i++ {
+		for {
+			a := rand.Intn(n) + 1
+			b := rand.Intn(n) + 1
+			if a == b {
+				continue
+			}
+			if a > b {
+				a, b = b, a
+			}
+			if !used[[2]int{a, b}] {
+				used[[2]int{a, b}] = true
+				edges[i] = [3]int{a, b, rand.Intn(4) - 1}
+				break
+			}
+		}
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&buf, "%d %d %d\n", edges[i][0], edges[i][1], edges[i][2])
+	}
+	return buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	comp := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < numTests; i++ {
+		input := genTest()
+		want, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(comp, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "competitor run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(bytes.TrimSpace(want), bytes.TrimSpace(got)) {
+			fmt.Printf("WA on test %d\ninput:\n%sexpected:\n%s\nreceived:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1616/verifierG.go
+++ b/1000-1999/1600-1699/1610-1619/1616/verifierG.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const numTests = 100
+const refSource = "1616G.go"
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refG_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, refSource)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return tmp, nil
+}
+
+func runBinary(path string, in []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.Bytes(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.Bytes(), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rand.Intn(maxEdges + 1)
+	edges := make([][2]int, m)
+	used := make(map[[2]int]bool)
+	for i := 0; i < m; i++ {
+		for {
+			a := rand.Intn(n) + 1
+			b := rand.Intn(n) + 1
+			if a >= b {
+				continue
+			}
+			if !used[[2]int{a, b}] {
+				used[[2]int{a, b}] = true
+				edges[i] = [2]int{a, b}
+				break
+			}
+		}
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&buf, "%d %d\n", edges[i][0], edges[i][1])
+	}
+	return buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	comp := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < numTests; i++ {
+		input := genTest()
+		want, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(comp, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "competitor run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(bytes.TrimSpace(want), bytes.TrimSpace(got)) {
+			fmt.Printf("WA on test %d\ninput:\n%sexpected:\n%s\nreceived:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1616/verifierH.go
+++ b/1000-1999/1600-1699/1610-1619/1616/verifierH.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const numTests = 100
+const refSource = "1616H.go"
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refH_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, refSource)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return tmp, nil
+}
+
+func runBinary(path string, in []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.Bytes(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.Bytes(), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 1
+	x := rand.Intn(1 << 30)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d\n", n, x)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprintf(&buf, "%d", rand.Intn(1<<30))
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	comp := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < numTests; i++ {
+		input := genTest()
+		want, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(comp, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "competitor run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(bytes.TrimSpace(want), bytes.TrimSpace(got)) {
+			fmt.Printf("WA on test %d\ninput:\n%sexpected:\n%s\nreceived:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier scripts for problems A–H of contest 1616
- each verifier compiles the official solution, generates 100 random tests, and compares outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_6887347a2e688324ab07ed79575eeb6a