### PR TITLE
Add Go verifiers for Codeforces Round 1619

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1619/verifierA.go
+++ b/1000-1999/1600-1699/1610-1619/1619/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func isSquare(s string) bool {
+	if len(s)%2 != 0 {
+		return false
+	}
+	half := len(s) / 2
+	return s[:half] == s[half:]
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		l := rng.Intn(100) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rng.Intn(26))
+		}
+		s := string(b)
+		fmt.Fprintln(&sb, s)
+		if isSquare(s) {
+			out.WriteString("YES\n")
+		} else {
+			out.WriteString("NO\n")
+		}
+	}
+	return sb.String(), strings.TrimSpace(out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1619/verifierB.go
+++ b/1000-1999/1600-1699/1610-1619/1619/verifierB.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func intSqrt(n int64) int64 {
+	x := int64(math.Sqrt(float64(n)))
+	for (x+1)*(x+1) <= n {
+		x++
+	}
+	for x*x > n {
+		x--
+	}
+	return x
+}
+
+func intCbrt(n int64) int64 {
+	x := int64(math.Cbrt(float64(n)))
+	for (x+1)*(x+1)*(x+1) <= n {
+		x++
+	}
+	for x*x*x > n {
+		x--
+	}
+	return x
+}
+
+func intSixthRoot(n int64) int64 {
+	x := int64(math.Pow(float64(n), 1.0/6.0))
+	pow6 := func(v int64) int64 {
+		res := int64(1)
+		for i := 0; i < 6; i++ {
+			res *= v
+		}
+		return res
+	}
+	for pow6(x+1) <= n {
+		x++
+	}
+	for pow6(x) > n {
+		x--
+	}
+	return x
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		sq := intSqrt(n)
+		cb := intCbrt(n)
+		sixth := intSixthRoot(n)
+		fmt.Fprintf(&out, "%d\n", sq+cb-sixth)
+	}
+	return sb.String(), strings.TrimSpace(out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1619/verifierC.go
+++ b/1000-1999/1600-1699/1610-1619/1619/verifierC.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func solveCase(aStr, sStr string) string {
+	i := len(aStr) - 1
+	j := len(sStr) - 1
+	ans := make([]byte, 0, len(sStr))
+	for i >= 0 {
+		if j < 0 {
+			return "-1"
+		}
+		aDigit := aStr[i] - '0'
+		sDigit := sStr[j] - '0'
+		if sDigit >= aDigit {
+			ans = append(ans, '0'+(sDigit-aDigit))
+			j--
+		} else {
+			if j == 0 {
+				return "-1"
+			}
+			twoDigit := (sStr[j-1]-'0')*10 + sDigit
+			diff := twoDigit - aDigit
+			if diff < 0 || diff > 9 {
+				return "-1"
+			}
+			ans = append(ans, '0'+diff)
+			j -= 2
+		}
+		i--
+	}
+	for j >= 0 {
+		ans = append(ans, sStr[j])
+		j--
+	}
+	for len(ans) > 1 && ans[len(ans)-1] == '0' {
+		ans = ans[:len(ans)-1]
+	}
+	for l, r := 0, len(ans)-1; l < r; l, r = l+1, r-1 {
+		ans[l], ans[r] = ans[r], ans[l]
+	}
+	return string(ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		a := rng.Int63n(1_000_000_000_000_000_000) + 1
+		s := a + rng.Int63n(1_000_000_000_000_000_000-a) + 1
+		fmt.Fprintf(&sb, "%d %d\n", a, s)
+		fmt.Fprintf(&out, "%s\n", solveCase(fmt.Sprint(a), fmt.Sprint(s)))
+	}
+	return sb.String(), strings.TrimSpace(out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1619/verifierD.go
+++ b/1000-1999/1600-1699/1610-1619/1619/verifierD.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func check(matrix [][]int, m, n int, x int) bool {
+	friendOk := make([]bool, n)
+	hasDouble := false
+	for i := 0; i < m; i++ {
+		cnt := 0
+		row := matrix[i]
+		for j := 0; j < n; j++ {
+			if row[j] >= x {
+				if !friendOk[j] {
+					friendOk[j] = true
+				}
+				cnt++
+			}
+		}
+		if cnt >= 2 {
+			hasDouble = true
+		}
+	}
+	if !hasDouble {
+		return false
+	}
+	for j := 0; j < n; j++ {
+		if !friendOk[j] {
+			return false
+		}
+	}
+	return true
+}
+
+func solveCase(matrix [][]int, m, n int) int {
+	low := 1
+	high := 1000000000
+	for low < high {
+		mid := (low + high + 1) / 2
+		if check(matrix, m, n, mid) {
+			low = mid
+		} else {
+			high = mid - 1
+		}
+	}
+	return low
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	m := rng.Intn(5) + 2
+	n := rng.Intn(5) + 2
+	matrix := make([][]int, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", m, n)
+	for i := 0; i < m; i++ {
+		matrix[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			val := rng.Intn(1000000000) + 1
+			matrix[i][j] = val
+			fmt.Fprintf(&sb, "%d ", val)
+		}
+		sb.WriteByte('\n')
+	}
+	ans := solveCase(matrix, m, n)
+	return sb.String(), fmt.Sprint(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1619/verifierE.go
+++ b/1000-1999/1600-1699/1610-1619/1619/verifierE.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+type MaxHeap []int
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func solveCase(arr []int) []int {
+	n := len(arr)
+	freq := make([]int, n+1)
+	for _, v := range arr {
+		if v <= n {
+			freq[v]++
+		}
+	}
+	fill := make([]int, n)
+	for i := range fill {
+		fill[i] = -1
+	}
+	h := &MaxHeap{}
+	heap.Init(h)
+	cost := 0
+	for i := 0; i < n; i++ {
+		for c := 0; c < freq[i]; c++ {
+			heap.Push(h, i)
+		}
+		if h.Len() == 0 {
+			break
+		}
+		val := heap.Pop(h).(int)
+		cost += i - val
+		fill[i] = cost
+	}
+	ans := make([]int, n+1)
+	ans[0] = freq[0]
+	impossible := false
+	for i := 1; i <= n; i++ {
+		if impossible || fill[i-1] == -1 {
+			ans[i] = -1
+			impossible = true
+		} else {
+			ans[i] = fill[i-1] + freq[i]
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n + 1)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	res := solveCase(arr)
+	var out strings.Builder
+	for i := 0; i <= n; i++ {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprintf(&out, "%d", res[i])
+	}
+	return sb.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1619/verifierF.go
+++ b/1000-1999/1600-1699/1610-1619/1619/verifierF.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func solveCase(n, m, k int64) string {
+	var sb strings.Builder
+	stBig := int64(1)
+	for i := int64(0); i < k; i++ {
+		temp := m
+		big := n % m
+		stSmall := stBig
+		for j := int64(0); j < temp; j++ {
+			if big > 0 {
+				size := (n + m - 1) / m
+				fmt.Fprintf(&sb, "%d ", size)
+				eles := size
+				for eles > 0 {
+					fmt.Fprintf(&sb, "%d ", stBig)
+					stBig++
+					if stBig > n {
+						stBig = 1
+					}
+					stSmall = stBig
+					eles--
+				}
+				sb.WriteByte('\n')
+				big--
+			} else {
+				size := n / m
+				fmt.Fprintf(&sb, "%d ", size)
+				eles := size
+				for eles > 0 {
+					fmt.Fprintf(&sb, "%d ", stSmall)
+					stSmall++
+					if stSmall > n {
+						stSmall = 1
+					}
+					eles--
+				}
+				sb.WriteByte('\n')
+			}
+		}
+	}
+	sb.WriteByte('\n')
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(20) + 2)
+	m := int64(rng.Intn(int(n/2)) + 1)
+	if m == 0 {
+		m = 1
+	}
+	if n < 2*m {
+		n = 2 * m
+	}
+	k := int64(rng.Intn(5) + 1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d\n", n, m, k)
+	return sb.String(), solveCase(n, m, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1619/verifierG.go
+++ b/1000-1999/1600-1699/1610-1619/1619/verifierG.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+type dsu struct {
+	parent []int
+	rank   []byte
+}
+
+func newDSU(n int) *dsu {
+	d := &dsu{parent: make([]int, n), rank: make([]byte, n)}
+	for i := range d.parent {
+		d.parent[i] = i
+	}
+	return d
+}
+
+func (d *dsu) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *dsu) union(a, b int) {
+	a = d.find(a)
+	b = d.find(b)
+	if a == b {
+		return
+	}
+	if d.rank[a] < d.rank[b] {
+		a, b = b, a
+	}
+	d.parent[b] = a
+	if d.rank[a] == d.rank[b] {
+		d.rank[a]++
+	}
+}
+
+type mine struct {
+	x, y int
+	t    int
+}
+
+func solveCase(mines []mine, k int) int {
+	n := len(mines)
+	d := newDSU(n)
+	type pair struct{ val, idx int }
+	mpX := make(map[int][]pair)
+	for i, m := range mines {
+		mpX[m.x] = append(mpX[m.x], pair{m.y, i})
+	}
+	for _, arr := range mpX {
+		sort.Slice(arr, func(i, j int) bool { return arr[i].val < arr[j].val })
+		for j := 1; j < len(arr); j++ {
+			if arr[j].val-arr[j-1].val <= k {
+				d.union(arr[j].idx, arr[j-1].idx)
+			}
+		}
+	}
+	mpY := make(map[int][]pair)
+	for i, m := range mines {
+		mpY[m.y] = append(mpY[m.y], pair{m.x, i})
+	}
+	for _, arr := range mpY {
+		sort.Slice(arr, func(i, j int) bool { return arr[i].val < arr[j].val })
+		for j := 1; j < len(arr); j++ {
+			if arr[j].val-arr[j-1].val <= k {
+				d.union(arr[j].idx, arr[j-1].idx)
+			}
+		}
+	}
+	compMin := make(map[int]int)
+	maxTime := 0
+	for i, m := range mines {
+		root := d.find(i)
+		if val, ok := compMin[root]; !ok || m.t < val {
+			compMin[root] = m.t
+		}
+		if m.t > maxTime {
+			maxTime = m.t
+		}
+	}
+	times := make([]int, 0, len(compMin))
+	for _, t := range compMin {
+		times = append(times, t)
+	}
+	sort.Ints(times)
+	hi := maxTime
+	if hi < len(times) {
+		hi = len(times)
+	}
+	l, r := -1, hi
+	for r-l > 1 {
+		mid := (l + r) / 2
+		idx := sort.Search(len(times), func(i int) bool { return times[i] > mid })
+		cnt := len(times) - idx
+		if cnt <= mid+1 {
+			r = mid
+		} else {
+			l = mid
+		}
+	}
+	return r
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(5)
+	mines := make([]mine, n)
+	for i := 0; i < n; i++ {
+		mines[i] = mine{
+			x: rng.Intn(21) - 10,
+			y: rng.Intn(21) - 10,
+			t: rng.Intn(20),
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, k)
+	for _, m := range mines {
+		fmt.Fprintf(&sb, "%d %d %d\n", m.x, m.y, m.t)
+	}
+	return sb.String(), fmt.Sprint(solveCase(mines, k))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1610-1619/1619/verifierH.go
+++ b/1000-1999/1600-1699/1610-1619/1619/verifierH.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func rebuild(p []int, jump, cnt, block []int, b, B, n int) {
+	l := b*B + 1
+	r := (b + 1) * B
+	if r > n {
+		r = n
+	}
+	for i := r; i >= l; i-- {
+		nxt := p[i]
+		if nxt >= l && nxt <= r {
+			jump[i] = jump[nxt]
+			cnt[i] = cnt[nxt] + 1
+		} else {
+			jump[i] = nxt
+			cnt[i] = 1
+		}
+	}
+}
+
+func solveCase(n, q int, p []int, queries [][3]int) string {
+	B := 1
+	for B*B < n {
+		B++
+	}
+	block := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		block[i] = (i - 1) / B
+	}
+	jump := make([]int, n+1)
+	cnt := make([]int, n+1)
+	blocks := (n + B - 1) / B
+	for b := 0; b < blocks; b++ {
+		rebuild(p, jump, cnt, block, b, B, n)
+	}
+	var sb strings.Builder
+	for _, qu := range queries {
+		t, x, y := qu[0], qu[1], qu[2]
+		if t == 1 {
+			p[x], p[y] = p[y], p[x]
+			rebuild(p, jump, cnt, block, block[x], B, n)
+			if block[x] != block[y] {
+				rebuild(p, jump, cnt, block, block[y], B, n)
+			}
+		} else {
+			i := x
+			k := y
+			for k > 0 {
+				if cnt[i] <= k {
+					k -= cnt[i]
+					i = jump[i]
+				} else {
+					i = p[i]
+					k--
+				}
+			}
+			fmt.Fprintf(&sb, "%d\n", i)
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	q := rng.Intn(20) + 1
+	p := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = i
+	}
+	queries := make([][3]int, q)
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(n) + 1
+			queries[i] = [3]int{1, x, y}
+		} else {
+			x := rng.Intn(n) + 1
+			k := rng.Intn(10) + 1
+			queries[i] = [3]int{2, x, k}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, q)
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&sb, "%d ", p[i])
+	}
+	sb.WriteByte('\n')
+	for _, qu := range queries {
+		fmt.Fprintf(&sb, "%d %d %d\n", qu[0], qu[1], qu[2])
+	}
+	return sb.String(), solveCase(n, q, p, queries)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1619 problems A-H
- each verifier generates random tests and checks output using an embedded reference implementation

## Testing
- `gofmt -w 1000-1999/1600-1699/1610-1619/1619/verifier*.go`

------
https://chatgpt.com/codex/tasks/task_e_6887354c2fec8324836b863615302fc5