### PR TITLE
Add verifiers for contest 1620

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1620/verifierA.go
+++ b/1000-1999/1600-1699/1620-1629/1620/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(in, &t)
+	var sb strings.Builder
+	for i := 0; i < t; i++ {
+		var s string
+		fmt.Fscan(in, &s)
+		cnt := 0
+		for j := 0; j < len(s); j++ {
+			if s[j] == 'N' {
+				cnt++
+			}
+		}
+		if cnt == 1 {
+			sb.WriteString("NO")
+		} else {
+			sb.WriteString("YES")
+		}
+		if i+1 < t {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(49) + 2
+		var s strings.Builder
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				s.WriteByte('E')
+			} else {
+				s.WriteByte('N')
+			}
+		}
+		sb.WriteString(s.String())
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := generateCase(rng)
+		expect := solve(input)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1620/verifierB.go
+++ b/1000-1999/1600-1699/1620-1629/1620/verifierB.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(in, &t)
+	var sb strings.Builder
+	for ; t > 0; t-- {
+		var w, h int64
+		fmt.Fscan(in, &w, &h)
+		ans := int64(0)
+		for side := 0; side < 4; side++ {
+			var k int
+			fmt.Fscan(in, &k)
+			var first, last int64
+			for i := 0; i < k; i++ {
+				var v int64
+				fmt.Fscan(in, &v)
+				if i == 0 {
+					first = v
+				}
+				if i == k-1 {
+					last = v
+				}
+			}
+			val := (last - first)
+			if side < 2 {
+				val *= h
+			} else {
+				val *= w
+			}
+			if val > ans {
+				ans = val
+			}
+		}
+		sb.WriteString(fmt.Sprint(ans))
+		if t > 1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func genLine(rng *rand.Rand, limit int64) (string, int64, int64) {
+	k := rng.Intn(4) + 2
+	arr := make([]int64, k)
+	for i := range arr {
+		arr[i] = rng.Int63n(limit + 1)
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", k)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String(), arr[0], arr[len(arr)-1]
+}
+
+func generateCase(rng *rand.Rand) string {
+	w := rng.Int63n(1000) + 1
+	h := rng.Int63n(1000) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", w, h)
+	line1, _, _ := genLine(rng, w)
+	sb.WriteString(line1)
+	line2, _, _ := genLine(rng, w)
+	sb.WriteString(line2)
+	line3, _, _ := genLine(rng, h)
+	sb.WriteString(line3)
+	line4, _, _ := genLine(rng, h)
+	sb.WriteString(line4)
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := generateCase(rng)
+		expect := solve(input)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1620/verifierC.go
+++ b/1000-1999/1600-1699/1620-1629/1620/verifierC.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var T int
+	fmt.Fscan(in, &T)
+	var sb strings.Builder
+	for ; T > 0; T-- {
+		var n, k int
+		var x int64
+		fmt.Fscan(in, &n, &k, &x)
+		var s string
+		fmt.Fscan(in, &s)
+		letters := make([]byte, 0, len(s))
+		bases := make([]int64, 0)
+		for i := 0; i < len(s); {
+			if s[i] == 'a' {
+				letters = append(letters, 'a')
+				i++
+			} else {
+				j := i
+				for j < len(s) && s[j] == '*' {
+					j++
+				}
+				base := int64(j-i)*int64(k) + 1
+				bases = append(bases, base)
+				letters = append(letters, '*')
+				i = j
+			}
+		}
+		x--
+		cntB := make([]int64, len(bases))
+		for i := len(bases) - 1; i >= 0; i-- {
+			cntB[i] = x % bases[i]
+			x /= bases[i]
+		}
+		var out strings.Builder
+		idx := 0
+		for _, ch := range letters {
+			if ch == 'a' {
+				out.WriteByte('a')
+			} else {
+				if cntB[idx] > 0 {
+					out.WriteString(strings.Repeat("b", int(cntB[idx])))
+				}
+				idx++
+			}
+		}
+		sb.WriteString(out.String())
+		if T > 1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(3) + 1
+	var sBuilder strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(3) == 0 {
+			sBuilder.WriteByte('*')
+		} else {
+			sBuilder.WriteByte('a')
+		}
+	}
+	s := sBuilder.String()
+	// compute total combinations
+	total := int64(1)
+	for i := 0; i < len(s); {
+		if s[i] == 'a' {
+			i++
+			continue
+		}
+		j := i
+		for j < len(s) && s[j] == '*' {
+			j++
+		}
+		base := int64(j-i)*int64(k) + 1
+		total *= base
+		i = j
+	}
+	if total <= 0 {
+		total = 1
+	}
+	x := rng.Int63n(total) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d\n%s\n", n, k, x, s)
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := generateCase(rng)
+		expect := solve(input)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1620/verifierD.go
+++ b/1000-1999/1600-1699/1620-1629/1620/verifierD.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	exe := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", exe, "1620D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(10)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := generateCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1620/verifierE.go
+++ b/1000-1999/1600-1699/1620-1629/1620/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	exe := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", exe, "1620E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	q := rng.Intn(8) + 1
+	var lines []string
+	type1 := 0
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			x := rng.Intn(10) + 1
+			lines = append(lines, fmt.Sprintf("1 %d", x))
+			type1++
+		} else {
+			x := rng.Intn(10) + 1
+			y := rng.Intn(10) + 1
+			lines = append(lines, fmt.Sprintf("2 %d %d", x, y))
+		}
+	}
+	if type1 == 0 {
+		x := rng.Intn(10) + 1
+		lines = append(lines, fmt.Sprintf("1 %d", x))
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(lines))
+	for _, l := range lines {
+		sb.WriteString(l)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := generateCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1620/verifierF.go
+++ b/1000-1999/1600-1699/1620-1629/1620/verifierF.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	exe := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", exe, "1620F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(11) - 5))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := generateCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1620/verifierG.go
+++ b/1000-1999/1600-1699/1620-1629/1620/verifierG.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	exe := filepath.Join(dir, "oracleG")
+	cmd := exec.Command("go", "build", "-o", exe, "1620G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	letters := []byte{'a', 'b', 'c'}
+	for i := 0; i < n; i++ {
+		a := rng.Intn(3)
+		b := rng.Intn(3)
+		c := rng.Intn(3)
+		if a+b+c == 0 {
+			a = 1
+		}
+		var s strings.Builder
+		s.WriteString(strings.Repeat("a", a))
+		s.WriteString(strings.Repeat("b", b))
+		s.WriteString(strings.Repeat("c", c))
+		if s.Len() == 0 {
+			s.WriteByte(letters[rng.Intn(len(letters))])
+		}
+		sb.WriteString(s.String())
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := generateCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifierA.go to validate contest 1620 problem A solutions
- add Go verifierB.go to validate contest 1620 problem B solutions
- add Go verifierC.go to validate contest 1620 problem C solutions
- add Go verifierD.go to validate contest 1620 problem D solutions
- add Go verifierE.go to validate contest 1620 problem E solutions
- add Go verifierF.go to validate contest 1620 problem F solutions
- add Go verifierG.go to validate contest 1620 problem G solutions

## Testing
- `go build 1000-1999/1600-1699/1620-1629/1620/verifierA.go`
- `go build 1000-1999/1600-1699/1620-1629/1620/verifierB.go`
- `go build 1000-1999/1600-1699/1620-1629/1620/verifierC.go`
- `go build 1000-1999/1600-1699/1620-1629/1620/verifierD.go`
- `go build 1000-1999/1600-1699/1620-1629/1620/verifierE.go`
- `go build 1000-1999/1600-1699/1620-1629/1620/verifierF.go`
- `go build 1000-1999/1600-1699/1620-1629/1620/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68873592461c8324bfdfb44373d9ef20