### PR TITLE
Add verifiers for contest 1621

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1621/verifierA.go
+++ b/1000-1999/1600-1699/1620-1629/1621/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testcaseA struct {
+	n int
+	k int
+}
+
+func solveCaseA(n, k int) []string {
+	if k > (n+1)/2 {
+		return []string{"-1"}
+	}
+	res := make([]string, n)
+	for i := 0; i < n; i++ {
+		line := make([]byte, n)
+		for j := 0; j < n; j++ {
+			line[j] = '.'
+		}
+		if i%2 == 0 && i/2 < k {
+			line[i] = 'R'
+		}
+		res[i] = string(line)
+	}
+	return res
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCaseA(rng *rand.Rand) (string, []string) {
+	t := rng.Intn(3) + 1
+	cases := make([]testcaseA, t)
+	input := fmt.Sprintf("%d\n", t)
+	var allOut []string
+	for i := 0; i < t; i++ {
+		n := rng.Intn(6) + 1
+		k := rng.Intn(n + 1)
+		cases[i] = testcaseA{n, k}
+		input += fmt.Sprintf("%d %d\n", n, k)
+		outLines := solveCaseA(n, k)
+		allOut = append(allOut, outLines...)
+	}
+	return input, allOut
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, outLines := generateCaseA(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		gotLines := strings.Split(strings.TrimSpace(got), "\n")
+		if len(gotLines) != len(outLines) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, len(outLines), len(gotLines), in)
+			os.Exit(1)
+		}
+		for j := range outLines {
+			if strings.TrimSpace(gotLines[j]) != outLines[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, outLines[j], gotLines[j], in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1621/verifierB.go
+++ b/1000-1999/1600-1699/1620-1629/1621/verifierB.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const INF int64 = 1 << 60
+
+type segment struct {
+	l int64
+	r int64
+	c int64
+}
+
+func solveCaseB(segs []segment) []string {
+	lmin := int64(INF)
+	rmax := int64(-INF)
+	costL := int64(INF)
+	costR := int64(INF)
+	best := int64(INF)
+	res := make([]string, len(segs))
+	for i, s := range segs {
+		if s.l < lmin {
+			lmin = s.l
+			costL = s.c
+			best = INF
+		} else if s.l == lmin && s.c < costL {
+			costL = s.c
+		}
+		if s.r > rmax {
+			rmax = s.r
+			costR = s.c
+			best = INF
+		} else if s.r == rmax && s.c < costR {
+			costR = s.c
+		}
+		if s.l == lmin && s.r == rmax && s.c < best {
+			best = s.c
+		}
+		ans := costL + costR
+		if best < ans {
+			ans = best
+		}
+		res[i] = fmt.Sprintf("%d", ans)
+	}
+	return res
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCaseB(rng *rand.Rand) (string, []string) {
+	t := rng.Intn(3) + 1
+	input := fmt.Sprintf("%d\n", t)
+	var outLines []string
+	for ; t > 0; t-- {
+		n := rng.Intn(6) + 1
+		segs := make([]segment, n)
+		input += fmt.Sprintf("%d\n", n)
+		for i := 0; i < n; i++ {
+			l := int64(rng.Intn(10) + 1)
+			r := int64(rng.Intn(10-int(l)+1)) + l
+			c := int64(rng.Intn(20) + 1)
+			segs[i] = segment{l, r, c}
+			input += fmt.Sprintf("%d %d %d\n", l, r, c)
+		}
+		out := solveCaseB(segs)
+		outLines = append(outLines, out...)
+	}
+	return input, outLines
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		gotLines := strings.Split(strings.TrimSpace(got), "\n")
+		if len(gotLines) != len(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, len(exp), len(gotLines), in)
+			os.Exit(1)
+		}
+		for j := range exp {
+			if strings.TrimSpace(gotLines[j]) != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp[j], gotLines[j], in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1621/verifierC.go
+++ b/1000-1999/1600-1699/1620-1629/1621/verifierC.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem C is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1600-1699/1620-1629/1621/verifierD.go
+++ b/1000-1999/1600-1699/1620-1629/1621/verifierD.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCaseD(n int, c [][]int64) int64 {
+	size := 2 * n
+	var sum int64
+	for i := n; i < size; i++ {
+		for j := n; j < size; j++ {
+			sum += c[i][j]
+		}
+	}
+	candidates := []int64{
+		c[0][n], c[0][size-1], c[n-1][n], c[n-1][size-1],
+		c[n][0], c[n][n-1], c[size-1][0], c[size-1][n-1],
+	}
+	best := candidates[0]
+	for _, v := range candidates[1:] {
+		if v < best {
+			best = v
+		}
+	}
+	return sum + best
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	size := 2 * n
+	c := make([][]int64, size)
+	for i := 0; i < size; i++ {
+		c[i] = make([]int64, size)
+		for j := 0; j < size; j++ {
+			c[i][j] = int64(rng.Intn(10))
+		}
+	}
+	input := fmt.Sprintf("1\n%d\n", n)
+	for i := 0; i < size; i++ {
+		for j := 0; j < size; j++ {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", c[i][j])
+		}
+		input += "\n"
+	}
+	exp := fmt.Sprintf("%d", solveCaseD(n, c))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1621/verifierE.go
+++ b/1000-1999/1600-1699/1620-1629/1621/verifierE.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func ceilDiv(a int64, b int64) int64 {
+	if b == 0 {
+		return 0
+	}
+	if a >= 0 {
+		return (a + b - 1) / b
+	}
+	return a / b
+}
+
+func feasible(teachers []int, req []int64) bool {
+	sort.Ints(teachers)
+	reqInts := make([]int64, len(req))
+	copy(reqInts, req)
+	sort.Slice(reqInts, func(i, j int) bool { return reqInts[i] < reqInts[j] })
+	off := len(teachers) - len(reqInts)
+	if off < 0 {
+		return false
+	}
+	for i := 0; i < len(reqInts); i++ {
+		if int64(teachers[off+i]) < reqInts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func solveCaseE(n, m int, teachers []int, groups [][]int) string {
+	req := make([]int64, m)
+	sums := make([]int64, m)
+	sizes := make([]int, m)
+	for i := 0; i < m; i++ {
+		sum := int64(0)
+		for _, v := range groups[i] {
+			sum += int64(v)
+		}
+		sums[i] = sum
+		sizes[i] = len(groups[i])
+		req[i] = ceilDiv(sum, int64(len(groups[i])))
+	}
+	res := ""
+	for i := 0; i < m; i++ {
+		for _, age := range groups[i] {
+			newSum := sums[i] - int64(age)
+			newSize := sizes[i] - 1
+			newReq := ceilDiv(newSum, int64(newSize))
+			old := req[i]
+			req[i] = newReq
+			if feasible(append([]int(nil), teachers...), req) {
+				res += "1"
+			} else {
+				res += "0"
+			}
+			req[i] = old
+		}
+	}
+	return res
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(n-1) + 1
+	teachers := make([]int, n)
+	for i := range teachers {
+		teachers[i] = rng.Intn(10) + 1
+	}
+	groups := make([][]int, m)
+	input := fmt.Sprintf("1\n%d %d\n", n, m)
+	for _, t := range teachers {
+		input += fmt.Sprintf("%d ", t)
+	}
+	input = strings.TrimSpace(input) + "\n"
+	for i := 0; i < m; i++ {
+		k := rng.Intn(3) + 2
+		groups[i] = make([]int, k)
+		input += fmt.Sprintf("%d ", k)
+		for j := 0; j < k; j++ {
+			age := rng.Intn(10) + 1
+			groups[i][j] = age
+			input += fmt.Sprintf("%d ", age)
+		}
+		input = strings.TrimSpace(input) + "\n"
+	}
+	exp := solveCaseE(n, m, teachers, groups)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1621/verifierF.go
+++ b/1000-1999/1600-1699/1620-1629/1621/verifierF.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveCaseF(n int, a, b, c int64, s string) int64 {
+	cnt00 := 0
+	cnt11 := 0
+	for i := 0; i+1 < n; i++ {
+		if s[i] == '0' && s[i+1] == '0' {
+			cnt00++
+		}
+		if s[i] == '1' && s[i+1] == '1' {
+			cnt11++
+		}
+	}
+	singles := 0
+	i := 0
+	for i < n {
+		if s[i] == '0' {
+			j := i
+			for j < n && s[j] == '0' {
+				j++
+			}
+			if j-i == 1 && i > 0 && j < n {
+				singles++
+			}
+			i = j
+		} else {
+			i++
+		}
+	}
+	ans := int64(min(cnt00, cnt11)) * (a + b)
+	if cnt00 > cnt11 {
+		ans += a
+	} else if cnt11 > cnt00 {
+		ans += b
+	}
+	if b > c {
+		ans += (b - c) * int64(singles)
+	}
+	return ans
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCaseF(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	a := int64(rng.Intn(5) + 1)
+	b := int64(rng.Intn(5) + 1)
+	c := int64(rng.Intn(5) + 1)
+	s := make([]byte, n)
+	for i := range s {
+		if rng.Intn(2) == 0 {
+			s[i] = '0'
+		} else {
+			s[i] = '1'
+		}
+	}
+	input := fmt.Sprintf("1\n%d %d %d %d\n%s\n", n, a, b, c, string(s))
+	exp := fmt.Sprintf("%d", solveCaseF(n, a, b, c, string(s)))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseF(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1621/verifierG.go
+++ b/1000-1999/1600-1699/1620-1629/1621/verifierG.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int = 1_000_000_007
+
+func weight(a []int, idx []int) int {
+	if len(idx) == 0 {
+		return 0
+	}
+	last := idx[len(idx)-1]
+	maxAfter := 0
+	for i := last + 1; i < len(a); i++ {
+		if a[i] > maxAfter {
+			maxAfter = a[i]
+		}
+	}
+	w := 0
+	for _, p := range idx {
+		if a[p] < maxAfter {
+			w++
+		}
+	}
+	return w % MOD
+}
+
+func dfs(a []int, start int, subseq []int, ans *int) {
+	if len(subseq) > 0 {
+		*ans = (*ans + weight(a, subseq)) % MOD
+	}
+	for i := start; i < len(a); i++ {
+		if len(subseq) == 0 || a[i] > a[subseq[len(subseq)-1]] {
+			subseq = append(subseq, i)
+			dfs(a, i+1, subseq, ans)
+			subseq = subseq[:len(subseq)-1]
+		}
+	}
+}
+
+func solveCaseG(a []int) int {
+	ans := 0
+	dfs(a, 0, []int{}, &ans)
+	return ans % MOD
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCaseG(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(10) + 1
+	}
+	input := fmt.Sprintf("1\n%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	exp := fmt.Sprintf("%d", solveCaseG(a))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseG(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1621/verifierH.go
+++ b/1000-1999/1600-1699/1620-1629/1621/verifierH.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to int
+	w  int64
+}
+
+type Seg struct {
+	zone  int
+	start int64
+	end   int64
+}
+
+type solverH struct {
+	n     int
+	g     [][]Edge
+	k     int
+	zones []int
+	pass  []int64
+	fine  []int64
+	T     int64
+
+	dist      []int64
+	tin       []int
+	tout      []int
+	timer     int
+	zoneNodes [][]int
+	counts    [][]int64
+}
+
+func (s *solverH) addEdge(u, v int, w int64) {
+	s.g[u] = append(s.g[u], Edge{v, w})
+	s.g[v] = append(s.g[v], Edge{u, w})
+}
+
+func (s *solverH) dfsDist(u, p int, d int64) {
+	s.timer++
+	s.tin[u] = s.timer
+	s.dist[u] = d
+	s.zoneNodes[s.zones[u]] = append(s.zoneNodes[s.zones[u]], u)
+	for _, e := range s.g[u] {
+		if e.to == p {
+			continue
+		}
+		s.dfsDist(e.to, u, d+e.w)
+	}
+	s.tout[u] = s.timer + 1
+}
+
+func (s *solverH) countScans(dv, start, end int64) int64 {
+	L := dv - end
+	if L < s.T {
+		L = s.T
+	}
+	R := dv - start
+	if R <= L {
+		return 0
+	}
+	return (R-1)/s.T - (L-1)/s.T
+}
+
+func (s *solverH) dfsCounts(u, p int, segs []Seg) {
+	dv := s.dist[u]
+	for _, seg := range segs {
+		c := s.countScans(dv, seg.start, seg.end)
+		s.counts[u][seg.zone] += c
+	}
+	for _, e := range s.g[u] {
+		if e.to == p {
+			continue
+		}
+		zc := s.zones[e.to]
+		if len(segs) > 0 && segs[len(segs)-1].zone == zc {
+			oldEnd := segs[len(segs)-1].end
+			segs[len(segs)-1].end = s.dist[e.to]
+			s.dfsCounts(e.to, u, segs)
+			segs[len(segs)-1].end = oldEnd
+		} else {
+			seg := Seg{zone: zc, start: segs[len(segs)-1].end, end: s.dist[e.to]}
+			segs = append(segs, seg)
+			s.dfsCounts(e.to, u, segs)
+			segs = segs[:len(segs)-1]
+		}
+	}
+}
+
+type queryH struct {
+	tp  int
+	ch  string
+	val int64
+	u   int
+}
+
+func (s *solverH) solve(queries []queryH) []string {
+	s.dist = make([]int64, s.n+1)
+	s.tin = make([]int, s.n+1)
+	s.tout = make([]int, s.n+1)
+	s.zoneNodes = make([][]int, s.k)
+	s.timer = 0
+	s.dfsDist(1, 0, 0)
+
+	s.counts = make([][]int64, s.n+1)
+	for i := 0; i <= s.n; i++ {
+		s.counts[i] = make([]int64, s.k)
+	}
+	segs := []Seg{{zone: s.zones[1], start: 0, end: 0}}
+	s.dfsCounts(1, 0, segs)
+
+	res := []string{}
+	for _, q := range queries {
+		switch q.tp {
+		case 1:
+			idx := int(q.ch[0] - 'A')
+			s.pass[idx] = q.val
+		case 2:
+			idx := int(q.ch[0] - 'A')
+			s.fine[idx] = q.val
+		case 3:
+			u := q.u
+			z := s.zones[u]
+			nodes := s.zoneNodes[z]
+			l := sort.Search(len(nodes), func(i int) bool { return s.tin[nodes[i]] >= s.tin[u] })
+			r := sort.Search(len(nodes), func(i int) bool { return s.tin[nodes[i]] >= s.tout[u] })
+			best := int64(1<<63 - 1)
+			for i := l; i < r; i++ {
+				v := nodes[i]
+				cost := int64(0)
+				for j := 0; j < s.k; j++ {
+					if j == z {
+						continue
+					}
+					cnt := s.counts[v][j]
+					p := s.pass[j]
+					f := s.fine[j]
+					if p < f*cnt {
+						cost += p
+					} else {
+						cost += f * cnt
+					}
+				}
+				if cost < best {
+					best = cost
+				}
+			}
+			if best == int64(1<<63-1) {
+				best = 0
+			}
+			res = append(res, fmt.Sprintf("%d", best))
+		}
+	}
+	return res
+}
+
+func solveCaseH(n int, edges [][3]int, k int, zoneStr string, pass, fine []int64, T int64, queries []queryH) []string {
+	s := &solverH{n: n, k: k, T: T}
+	s.g = make([][]Edge, n+1)
+	for _, e := range edges {
+		s.addEdge(e[0], e[1], int64(e[2]))
+	}
+	s.zones = make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		s.zones[i] = int(zoneStr[i-1] - 'A')
+	}
+	s.pass = append([]int64(nil), pass...)
+	s.fine = append([]int64(nil), fine...)
+	return s.solve(queries)
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCaseH(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(4) + 1
+	edges := make([][3]int, n-1)
+	for i := 0; i < n-1; i++ {
+		u := i + 1
+		v := i + 2
+		w := rng.Intn(5) + 1
+		edges[i] = [3]int{u, v, w}
+	}
+	k := rng.Intn(3) + 1
+	zones := make([]byte, n)
+	zones[0] = 'A'
+	for i := 1; i < n; i++ {
+		maxZone := int(zones[i-1]-'A') + rng.Intn(2)
+		if maxZone >= k {
+			maxZone = k - 1
+		}
+		zones[i] = byte('A' + maxZone)
+	}
+	pass := make([]int64, k)
+	fine := make([]int64, k)
+	for i := 0; i < k; i++ {
+		pass[i] = int64(rng.Intn(5) + 1)
+		fine[i] = int64(rng.Intn(5) + 1)
+	}
+	T := int64(rng.Intn(5) + 1)
+	qn := rng.Intn(3) + 1
+	queries := make([]queryH, qn)
+	input := fmt.Sprintf("1\n%d\n", n)
+	for _, e := range edges {
+		input += fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2])
+	}
+	input += fmt.Sprintf("%d\n%s\n", k, string(zones))
+	for i := 0; i < k; i++ {
+		input += fmt.Sprintf("%d ", pass[i])
+	}
+	input = strings.TrimSpace(input) + "\n"
+	for i := 0; i < k; i++ {
+		input += fmt.Sprintf("%d ", fine[i])
+	}
+	input = strings.TrimSpace(input) + "\n"
+	input += fmt.Sprintf("%d\n%d\n", T, qn)
+	for i := 0; i < qn; i++ {
+		tp := rng.Intn(3) + 1
+		if tp == 1 {
+			ch := string('A' + byte(rng.Intn(k)))
+			val := int64(rng.Intn(5) + 1)
+			queries[i] = queryH{tp: 1, ch: ch, val: val}
+			input += fmt.Sprintf("1 %s %d\n", ch, val)
+		} else if tp == 2 {
+			ch := string('A' + byte(rng.Intn(k)))
+			val := int64(rng.Intn(5) + 1)
+			queries[i] = queryH{tp: 2, ch: ch, val: val}
+			input += fmt.Sprintf("2 %s %d\n", ch, val)
+		} else {
+			u := rng.Intn(n) + 1
+			queries[i] = queryH{tp: 3, u: u}
+			input += fmt.Sprintf("3 %d\n", u)
+		}
+	}
+	expLines := solveCaseH(n, edges, k, string(zones), pass, fine, T, queries)
+	return input, expLines
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseH(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		gotLines := strings.Split(strings.TrimSpace(got), "\n")
+		if len(gotLines) != len(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, len(exp), len(gotLines), in)
+			os.Exit(1)
+		}
+		for j := range exp {
+			if strings.TrimSpace(gotLines[j]) != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp[j], gotLines[j], in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1621/verifierI.go
+++ b/1000-1999/1600-1699/1620-1629/1621/verifierI.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func lexSmaller(a []int, i1 int, b []int, i2 int, length int) bool {
+	for k := 0; k < length; k++ {
+		if a[i1+k] < b[i2+k] {
+			return true
+		} else if a[i1+k] > b[i2+k] {
+			return false
+		}
+	}
+	return false
+}
+
+func op(arr []int) []int {
+	n := len(arr)
+	D := make([]int, n)
+	copy(D, arr)
+	for i := 1; i <= n; i++ {
+		bestIdx := 0
+		for s := 1; s <= n-i; s++ {
+			if lexSmaller(D, s, D, bestIdx, i) {
+				bestIdx = s
+			}
+		}
+		copy(D[n-i:], D[bestIdx:bestIdx+i])
+	}
+	return D
+}
+
+func solveCaseI(A []int, queries [][2]int) []int {
+	n := len(A)
+	B := make([][]int, n+1)
+	B[0] = make([]int, n)
+	copy(B[0], A)
+	for i := 1; i <= n; i++ {
+		B[i] = op(B[i-1])
+	}
+	res := make([]int, len(queries))
+	for idx, q := range queries {
+		i, j := q[0], q[1]
+		if i > n {
+			i = n
+		}
+		if j > n {
+			j = n
+		}
+		res[idx] = B[i][j-1]
+	}
+	return res
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCaseI(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(5) + 1
+	A := make([]int, n)
+	for i := range A {
+		A[i] = rng.Intn(10) + 1
+	}
+	qn := rng.Intn(4) + 1
+	queries := make([][2]int, qn)
+	input := fmt.Sprintf("1\n%d\n", n)
+	for i, v := range A {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	input += fmt.Sprintf("%d\n", qn)
+	for i := 0; i < qn; i++ {
+		x := rng.Intn(n+2) + 1
+		y := rng.Intn(n+2) + 1
+		queries[i] = [2]int{x, y}
+		input += fmt.Sprintf("%d %d\n", x, y)
+	}
+	resVals := solveCaseI(A, queries)
+	outLines := make([]string, qn)
+	for i, v := range resVals {
+		outLines[i] = fmt.Sprintf("%d", v)
+	}
+	return input, outLines
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expLines := generateCaseI(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		gotLines := strings.Split(strings.TrimSpace(got), "\n")
+		if len(gotLines) != len(expLines) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, len(expLines), len(gotLines), in)
+			os.Exit(1)
+		}
+		for j := range expLines {
+			if strings.TrimSpace(gotLines[j]) != expLines[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expLines[j], gotLines[j], in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest 1621
- include 100 randomized tests per problem
- stub out interactive problem C

## Testing
- `go run verifierA.go ./binA`


------
https://chatgpt.com/codex/tasks/task_e_688735d844708324b861a0b4287c0b6f