### PR TITLE
Add contest 1625 verifiers

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1625/verifierA.go
+++ b/1000-1999/1600-1699/1620-1629/1625/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1625A.go")
+	bin := filepath.Join(os.TempDir(), "oracle1625A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(20) + 1
+		l := r.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, l)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", r.Intn(1<<l))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1600-1699/1620-1629/1625/verifierB.go
+++ b/1000-1999/1600-1699/1620-1629/1625/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1625B.go")
+	bin := filepath.Join(os.TempDir(), "oracle1625B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(20) + 2
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", r.Intn(30))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1600-1699/1620-1629/1625/verifierC.go
+++ b/1000-1999/1600-1699/1620-1629/1625/verifierC.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1625C.go")
+	bin := filepath.Join(os.TempDir(), "oracle1625C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(8) + 1
+	l := n + r.Intn(20) + 1
+	k := r.Intn(n) + 1
+	d := make([]int, n)
+	cur := 0
+	for i := 0; i < n; i++ {
+		cur += r.Intn(5) + 1
+		d[i] = cur
+	}
+	if cur >= l {
+		l = cur + r.Intn(5) + 1
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = r.Intn(10) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, l, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", d[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1600-1699/1620-1629/1625/verifierD.go
+++ b/1000-1999/1600-1699/1620-1629/1625/verifierD.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1625D.go")
+	bin := filepath.Join(os.TempDir(), "oracle1625D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(8) + 2
+	k := r.Intn(100) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", r.Intn(200))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1600-1699/1620-1629/1625/verifierE1.go
+++ b/1000-1999/1600-1699/1620-1629/1625/verifierE1.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1625E1.go")
+	bin := filepath.Join(os.TempDir(), "oracle1625E1.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randParens(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if r.Intn(2) == 0 {
+			b[i] = '('
+		} else {
+			b[i] = ')'
+		}
+	}
+	return string(b)
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(20) + 1
+	q := r.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	s := randParens(r, n)
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := r.Intn(n) + 1
+		r2 := l + r.Intn(n-l+1)
+		t := 1
+		fmt.Fprintf(&sb, "%d %d %d\n", t, l, r2)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1600-1699/1620-1629/1625/verifierE2.go
+++ b/1000-1999/1600-1699/1620-1629/1625/verifierE2.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1625E2.go")
+	bin := filepath.Join(os.TempDir(), "oracle1625E2.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randParens(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if r.Intn(2) == 0 {
+			b[i] = '('
+		} else {
+			b[i] = ')'
+		}
+	}
+	return string(b)
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(20) + 1
+	q := r.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	s := randParens(r, n)
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		t := r.Intn(2) + 1
+		l := r.Intn(n) + 1
+		r2 := l + r.Intn(n-l+1)
+		fmt.Fprintf(&sb, "%d %d %d\n", t, l, r2)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces contest 1625 (problems A-E2)
- each verifier builds the provided reference solution and runs 100 randomized tests comparing outputs

## Testing
- `go build 1000-1999/1600-1699/1620-1629/1625/verifierA.go`
- `go build 1000-1999/1600-1699/1620-1629/1625/verifierB.go`
- `go build 1000-1999/1600-1699/1620-1629/1625/verifierC.go`
- `go build 1000-1999/1600-1699/1620-1629/1625/verifierD.go`
- `go build 1000-1999/1600-1699/1620-1629/1625/verifierE1.go`
- `go build 1000-1999/1600-1699/1620-1629/1625/verifierE2.go`


------
https://chatgpt.com/codex/tasks/task_e_688736f06244832499df064cfef7782f