### PR TITLE
Add Go verifiers for Codeforces contest 1623

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1623/verifierA.go
+++ b/1000-1999/1600-1699/1620-1629/1623/verifierA.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(n, m, rb, cb, rd, cd int) int {
+	r, c := rb, cb
+	dr, dc := 1, 1
+	steps := 0
+	for {
+		if r == rd || c == cd {
+			return steps
+		}
+		if r+dr > n || r+dr < 1 {
+			dr = -dr
+		}
+		if c+dc > m || c+dc < 1 {
+			dc = -dc
+		}
+		r += dr
+		c += dc
+		steps++
+	}
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		rb := rng.Intn(n) + 1
+		cb := rng.Intn(m) + 1
+		rd := rng.Intn(n) + 1
+		cd := rng.Intn(m) + 1
+		input := fmt.Sprintf("1\n%d %d %d %d %d %d\n", n, m, rb, cb, rd, cd)
+		exp := fmt.Sprintf("%d", expected(n, m, rb, cb, rd, cd))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\noutput:\n%s\n", t+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1620-1629/1623/verifierB.go
+++ b/1000-1999/1600-1699/1620-1629/1623/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type interval struct {
+	l int
+	r int
+}
+
+type intervalAns struct {
+	l int
+	r int
+	d int
+}
+
+func expected(n int, intervals []interval) string {
+	ivs := make([]intervalAns, n)
+	for i, v := range intervals {
+		ivs[i] = intervalAns{l: v.l, r: v.r}
+	}
+	sort.Slice(ivs, func(i, j int) bool {
+		return (ivs[i].r - ivs[i].l) < (ivs[j].r - ivs[j].l)
+	})
+	flag := make([]bool, n+2)
+	for i := 0; i < n; i++ {
+		for k := ivs[i].l; k <= ivs[i].r; k++ {
+			if k >= 0 && k < len(flag) && !flag[k] {
+				ivs[i].d = k
+				flag[k] = true
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", ivs[i].l, ivs[i].r, ivs[i].d))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateIntervals(n int, rng *rand.Rand) []interval {
+	intervals := make([]interval, 0, n)
+	var dfs func(l, r int)
+	dfs = func(l, r int) {
+		if l > r {
+			return
+		}
+		d := rng.Intn(r-l+1) + l
+		intervals = append(intervals, interval{l: l, r: r})
+		if l <= d-1 {
+			dfs(l, d-1)
+		}
+		if d+1 <= r {
+			dfs(d+1, r)
+		}
+	}
+	dfs(1, n)
+	rng.Shuffle(len(intervals), func(i, j int) { intervals[i], intervals[j] = intervals[j], intervals[i] })
+	return intervals
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(7) + 1
+		intervals := generateIntervals(n, rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, iv := range intervals {
+			sb.WriteString(fmt.Sprintf("%d %d\n", iv.l, iv.r))
+		}
+		input := sb.String()
+		exp := strings.TrimSpace(expected(n, intervals))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\noutput:\n%s\n", t+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected:\n%s\nGot:\n%s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1620-1629/1623/verifierC.go
+++ b/1000-1999/1600-1699/1620-1629/1623/verifierC.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func canAchieve(h []int64, target int64) bool {
+	n := len(h)
+	b := make([]int64, n)
+	copy(b, h)
+	for i := n - 1; i >= 2; i-- {
+		if b[i] < target {
+			return false
+		}
+		d := (b[i] - target) / 3
+		if d > h[i]/3 {
+			d = h[i] / 3
+		}
+		b[i-1] += d
+		b[i-2] += 2 * d
+	}
+	return b[0] >= target && b[1] >= target
+}
+
+func expected(h []int64) int64 {
+	l, r := int64(0), int64(1e9)
+	for l < r {
+		mid := (l + r + 1) / 2
+		if canAchieve(h, mid) {
+			l = mid
+		} else {
+			r = mid - 1
+		}
+	}
+	return l
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(6) + 3
+		h := make([]int64, n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			h[i] = rng.Int63n(1000) + 1
+			sb.WriteString(fmt.Sprintf("%d ", h[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := fmt.Sprintf("%d", expected(h))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\noutput:\n%s\n", t+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1620-1629/1623/verifierD.go
+++ b/1000-1999/1600-1699/1620-1629/1623/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD int64 = 1_000_000_007
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func modInv(a int64) int64 { return modPow(a, MOD-2) }
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int64) int64 { return a / gcd(a, b) * b }
+
+func expected(n, m, rb, cb, rd, cd, p int64) int64 {
+	q := p * modInv(100) % MOD
+	r := (100 - p) * modInv(100) % MOD
+	cycleR := int64(2 * (n - 1))
+	cycleC := int64(2 * (m - 1))
+	cycle := lcm(cycleR, cycleC)
+	row := rb
+	col := cb
+	dr := int64(1)
+	dc := int64(1)
+	prefixPow := int64(1)
+	B := int64(0)
+	for t := int64(0); t < cycle; t++ {
+		good := row == rd || col == cd
+		if good {
+			term := (t % MOD) * q % MOD * prefixPow % MOD
+			B = (B + term) % MOD
+			prefixPow = prefixPow * r % MOD
+		}
+		if row+dr > n || row+dr < 1 {
+			dr = -dr
+		}
+		row += dr
+		if col+dc > m || col+dc < 1 {
+			dc = -dc
+		}
+		col += dc
+	}
+	F := prefixPow
+	Lmod := cycle % MOD
+	numerator := (B + F*Lmod%MOD) % MOD
+	denom := (1 - F + MOD) % MOD
+	return numerator * modInv(denom) % MOD
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		n := int64(rng.Intn(5) + 2)
+		m := int64(rng.Intn(5) + 2)
+		rb := int64(rng.Intn(int(n)) + 1)
+		cb := int64(rng.Intn(int(m)) + 1)
+		rd := int64(rng.Intn(int(n)) + 1)
+		cd := int64(rng.Intn(int(m)) + 1)
+		p := int64(rng.Intn(99) + 1)
+		input := fmt.Sprintf("1\n%d %d %d %d %d %d %d\n", n, m, rb, cb, rd, cd, p)
+		exp := fmt.Sprintf("%d", expected(n, m, rb, cb, rd, cd, p))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\noutput:\n%s\n", t+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1620-1629/1623/verifierE.go
+++ b/1000-1999/1600-1699/1620-1629/1623/verifierE.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func inOrder(n int, left, right []int) []int {
+	order := make([]int, 0, n)
+	stack := []int{}
+	curr := 1
+	for curr != 0 || len(stack) > 0 {
+		for curr != 0 {
+			stack = append(stack, curr)
+			curr = left[curr]
+		}
+		curr = stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, curr)
+		curr = right[curr]
+	}
+	return order
+}
+
+func expected(n, k int, s string, left, right, parent []int) string {
+	order := inOrder(n, left, right)
+	chars := []byte(s)
+	want := make([]bool, n)
+	i := 0
+	for i < n {
+		j := i + 1
+		for j < n && chars[order[j]-1] == chars[order[i]-1] {
+			j++
+		}
+		next := byte('{')
+		if j < n {
+			next = chars[order[j]-1]
+		}
+		if chars[order[i]-1] < next {
+			for t := i; t < j; t++ {
+				want[t] = true
+			}
+		}
+		i = j
+	}
+	dup := make([]bool, n+1)
+	dsu := make([]int, n+1)
+	for i := 0; i <= n; i++ {
+		dsu[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if dsu[x] != x {
+			dsu[x] = find(dsu[x])
+		}
+		return dsu[x]
+	}
+	remaining := k
+	for idx := 0; idx < n && remaining > 0; idx++ {
+		u := order[idx]
+		if dup[u] {
+			continue
+		}
+		if want[idx] {
+			path := make([]int, 0)
+			v := find(u)
+			for v != 0 && !dup[v] {
+				path = append(path, v)
+				v = find(parent[v])
+			}
+			if len(path) <= remaining {
+				for _, x := range path {
+					dup[x] = true
+					dsu[x] = find(parent[x])
+				}
+				remaining -= len(path)
+			}
+		}
+	}
+	var res []byte
+	stack := []int{}
+	curr := 1
+	for curr != 0 || len(stack) > 0 {
+		for curr != 0 {
+			stack = append(stack, curr)
+			curr = left[curr]
+		}
+		curr = stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		ch := chars[curr-1]
+		res = append(res, ch)
+		if dup[curr] {
+			res = append(res, ch)
+		}
+		curr = right[curr]
+	}
+	return string(res)
+}
+
+func generateTree(n int, rng *rand.Rand) (left, right, parent []int) {
+	left = make([]int, n+1)
+	right = make([]int, n+1)
+	parent = make([]int, n+1)
+	for child := 2; child <= n; child++ {
+		for {
+			p := rng.Intn(child-1) + 1
+			if rng.Intn(2) == 0 {
+				if left[p] == 0 {
+					left[p] = child
+					parent[child] = p
+					break
+				}
+			} else {
+				if right[p] == 0 {
+					right[p] = child
+					parent[child] = p
+					break
+				}
+			}
+		}
+	}
+	return
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(6) + 1
+		k := rng.Intn(n) + 1
+		letters := make([]byte, n)
+		for i := 0; i < n; i++ {
+			letters[i] = byte('a' + rng.Intn(3))
+		}
+		left, right, parent := generateTree(n, rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		sb.WriteString(fmt.Sprintf("%s\n", string(letters)))
+		for i := 1; i <= n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", left[i], right[i]))
+		}
+		input := sb.String()
+		exp := expected(n, k, string(letters), left, right, parent)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\noutput:\n%s\n", t+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- implement verifiers in Go for all problems of contest 1623
- each verifier generates at least 100 random cases and checks a supplied binary

## Testing
- `go build verifierA.go` etc.
- `go run verifierA.go ./a.out`
- `go run verifierB.go ./b.out`
- `go run verifierC.go ./c.out`
- `go run verifierD.go ./d.out`
- `go run verifierE.go ./e.out`

------
https://chatgpt.com/codex/tasks/task_e_688736645d4c83248695a1a4fae4a311