### PR TITLE
Add Go verifiers for contest 1626

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1626/verifierA.go
+++ b/1000-1999/1600-1699/1620-1629/1626/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) string {
+	var cnt [26]int
+	var rep []byte
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		idx := ch - 'a'
+		cnt[idx]++
+		if cnt[idx] == 2 {
+			rep = append(rep, ch)
+		}
+	}
+	ans := make([]byte, 0, len(s))
+	ans = append(ans, rep...)
+	ans = append(ans, rep...)
+	for ch := byte('a'); ch <= 'z'; ch++ {
+		if cnt[ch-'a'] == 1 {
+			ans = append(ans, ch)
+		}
+	}
+	return string(ans)
+}
+
+func runCase(bin, s string) error {
+	input := fmt.Sprintf("1\n%s\n", s)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expected(s)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	length := rng.Intn(52) + 1
+	counts := [26]int{}
+	b := make([]byte, length)
+	for i := 0; i < length; i++ {
+		for {
+			c := byte(rng.Intn(26))
+			if counts[c] < 2 {
+				counts[c]++
+				b[i] = 'a' + c
+				break
+			}
+		}
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{"a", "aa", "ab", "abac", "zz", "abcdef", "abacaba"}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for idx, s := range cases {
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1626/verifierB.go
+++ b/1000-1999/1600-1699/1620-1629/1626/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(x string) string {
+	bs := []byte(x)
+	n := len(bs)
+	for i := n - 1; i >= 1; i-- {
+		d1 := int(bs[i-1] - '0')
+		d2 := int(bs[i] - '0')
+		sum := d1 + d2
+		if sum >= 10 {
+			res := make([]byte, 0, n)
+			res = append(res, bs[:i-1]...)
+			res = append(res, byte('0'+sum/10))
+			res = append(res, byte('0'+sum%10))
+			res = append(res, bs[i+1:]...)
+			return string(res)
+		}
+	}
+	sum := int(bs[0] - '0' + bs[1] - '0')
+	res := make([]byte, 0, n-1)
+	res = append(res, byte('0'+sum))
+	res = append(res, bs[2:]...)
+	return string(res)
+}
+
+func runCase(bin, s string) error {
+	input := fmt.Sprintf("1\n%s\n", s)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := solve(s)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	length := rng.Intn(18) + 2
+	b := make([]byte, length)
+	b[0] = '1' + byte(rng.Intn(9))
+	for i := 1; i < length; i++ {
+		b[i] = byte(rng.Intn(10)) + '0'
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{"10057", "10", "99", "1234", "1010", "90876"}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for idx, s := range cases {
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1626/verifierC.go
+++ b/1000-1999/1600-1699/1620-1629/1626/verifierC.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n int, k, h []int64) int64 {
+	curL := k[n-1] - h[n-1] + 1
+	curR := k[n-1]
+	var ans int64
+	for i := n - 2; i >= 0; i-- {
+		start := k[i] - h[i] + 1
+		end := k[i]
+		if end >= curL {
+			if start < curL {
+				curL = start
+			}
+		} else {
+			length := curR - curL + 1
+			ans += length * (length + 1) / 2
+			curL = start
+			curR = end
+		}
+	}
+	length := curR - curL + 1
+	ans += length * (length + 1) / 2
+	return ans
+}
+
+func runCase(bin string, n int, k, h []int64) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(k[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(h[i]))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	exp := fmt.Sprint(expected(n, k, h))
+	if gotStr != exp {
+		return fmt.Errorf("expected %s got %s", exp, gotStr)
+	}
+	return nil
+}
+
+func randCase(rng *rand.Rand) (int, []int64, []int64) {
+	n := rng.Intn(10) + 1
+	k := make([]int64, n)
+	h := make([]int64, n)
+	cur := int64(0)
+	for i := 0; i < n; i++ {
+		cur += int64(rng.Intn(5) + 1)
+		k[i] = cur
+		h[i] = int64(rng.Intn(5) + 1)
+	}
+	return n, k, h
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []struct {
+		n    int
+		k, h []int64
+	}
+	cases = append(cases, struct {
+		n    int
+		k, h []int64
+	}{1, []int64{1}, []int64{1}})
+	cases = append(cases, struct {
+		n    int
+		k, h []int64
+	}{2, []int64{2, 4}, []int64{1, 2}})
+	for i := 0; i < 100; i++ {
+		n, k, h := randCase(rng)
+		cases = append(cases, struct {
+			n    int
+			k, h []int64
+		}{n, k, h})
+	}
+	for idx, tc := range cases {
+		if err := runCase(bin, tc.n, tc.k, tc.h); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1626/verifierD.go
+++ b/1000-1999/1600-1699/1620-1629/1626/verifierD.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func nextPow2(x int) int {
+	if x <= 1 {
+		return 1
+	}
+	return 1 << (bits.Len(uint(x - 1)))
+}
+
+func expected(n int, arr []int) int {
+	freq := make([]int, n+2)
+	for _, x := range arr {
+		if x >= 1 && x <= n {
+			freq[x]++
+		}
+	}
+	pre := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		pre[i] = pre[i-1] + freq[i]
+	}
+	powers := []int{}
+	for p := 1; p <= 2*n; p <<= 1 {
+		powers = append(powers, p)
+	}
+	ans := int(1e9)
+	for i := 0; i <= n; i++ {
+		c1 := pre[i]
+		cost1 := nextPow2(c1) - c1
+		for _, limit := range powers {
+			target := pre[i] + limit
+			j := sort.Search(len(pre), func(k int) bool { return pre[k] > target }) - 1
+			if j < i+1 {
+				continue
+			}
+			c2 := pre[j] - pre[i]
+			c3 := n - pre[j]
+			cost2 := nextPow2(c2) - c2
+			cost3 := nextPow2(c3) - c3
+			total := cost1 + cost2 + cost3
+			if total < ans {
+				ans = total
+			}
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, n int, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprint(n))
+	sb.WriteByte('\n')
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := fmt.Sprint(expected(n, arr))
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randCase(rng *rand.Rand) (int, []int) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n*2 + 1)
+	}
+	return n, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []struct {
+		n   int
+		arr []int
+	}
+	cases = append(cases, struct {
+		n   int
+		arr []int
+	}{3, []int{1, 2, 3}})
+	cases = append(cases, struct {
+		n   int
+		arr []int
+	}{5, []int{1, 1, 1, 1, 1}})
+	for i := 0; i < 100; i++ {
+		n, arr := randCase(rng)
+		cases = append(cases, struct {
+			n   int
+			arr []int
+		}{n, arr})
+	}
+	for idx, tc := range cases {
+		if err := runCase(bin, tc.n, tc.arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1626/verifierE.go
+++ b/1000-1999/1600-1699/1620-1629/1626/verifierE.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func bfs(start int, g [][]int) []int {
+	n := len(g)
+	dist := make([]int, n)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := []int{start}
+	dist[start] = 0
+	for head := 0; head < len(q); head++ {
+		v := q[head]
+		for _, to := range g[v] {
+			if dist[to] == -1 {
+				dist[to] = dist[v] + 1
+				q = append(q, to)
+			}
+		}
+	}
+	return dist
+}
+
+func expected(n int, colors []int, edges [][2]int) string {
+	g := make([][]int, n)
+	blacks := []int{}
+	for i, c := range colors {
+		if c == 1 {
+			blacks = append(blacks, i)
+		}
+	}
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	if len(blacks) >= 3 {
+		ans := make([]byte, 0, 2*n-1)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				ans = append(ans, ' ')
+			}
+			ans = append(ans, '1')
+		}
+		return string(ans)
+	}
+	if len(blacks) != 2 {
+		return ""
+	}
+	b1 := blacks[0]
+	b2 := blacks[1]
+	d1 := bfs(b1, g)
+	d2 := bfs(b2, g)
+	dist := d1[b2]
+	ans := make([]byte, 0, 2*n)
+	for i := 0; i < n; i++ {
+		t := (d1[i] + d2[i] - dist) / 2
+		w := d1[i] - t
+		ch := '0'
+		if w <= 1 || dist-w <= 1 {
+			ch = '1'
+		}
+		if i > 0 {
+			ans = append(ans, ' ')
+		}
+		ans = append(ans, byte(ch))
+	}
+	return string(ans)
+}
+
+func runCase(bin string, n int, colors []int, edges [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprint(n))
+	sb.WriteByte('\n')
+	for i, c := range colors {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(c))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	input := sb.String()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expected(n, colors, edges)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func randCase(rng *rand.Rand) (int, []int, [][2]int) {
+	n := rng.Intn(10) + 2
+	colors := make([]int, n)
+	cnt := 0
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			colors[i] = 1
+			cnt++
+		} else {
+			colors[i] = 0
+		}
+	}
+	if cnt < 2 {
+		colors[0] = 1
+		colors[1] = 1
+	}
+	edges := randTree(rng, n)
+	return n, colors, edges
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []struct {
+		n int
+		c []int
+		e [][2]int
+	}
+	cases = append(cases, struct {
+		n int
+		c []int
+		e [][2]int
+	}{2, []int{1, 1}, [][2]int{{0, 1}}})
+	cases = append(cases, struct {
+		n int
+		c []int
+		e [][2]int
+	}{3, []int{1, 0, 1}, [][2]int{{0, 1}, {1, 2}}})
+	for i := 0; i < 100; i++ {
+		n, c, e := randCase(rng)
+		cases = append(cases, struct {
+			n int
+			c []int
+			e [][2]int
+		}{n, c, e})
+	}
+	for idx, tc := range cases {
+		if err := runCase(bin, tc.n, tc.c, tc.e); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1626/verifierF.go
+++ b/1000-1999/1600-1699/1620-1629/1626/verifierF.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 998244353
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		b >>= 1
+	}
+	return res
+}
+
+func modInv(a int64) int64 { return modPow(a, MOD-2) }
+
+func expected(n, a0, x, y, k, M int64) int64 {
+	L := int64(1)
+	for i := int64(1); i <= k; i++ {
+		L = L * i / gcd(L, i)
+	}
+	invN := modInv(n % MOD)
+	mulStay := (MOD + 1 - invN) % MOD
+	dp := make([]int64, L)
+	next := make([]int64, L)
+	for step := k; step >= 1; step-- {
+		s := int64(step)
+		for r := int64(0); r < L; r++ {
+			m := r % s
+			val := (invN*(r+dp[r-m]) + mulStay*dp[r]) % MOD
+			next[r] = val
+		}
+		dp, next = next, dp
+	}
+	constPart := (L % MOD) * (k % MOD) % MOD * invN % MOD
+	ans := int64(0)
+	val := a0
+	for i := int64(0); i < n; i++ {
+		q := val / L
+		r := val % L
+		ans += dp[r]
+		ans += (q % MOD) * constPart % MOD
+		ans %= MOD
+		val = (val*x + y) % M
+	}
+	ans = ans * modPow(n%MOD, k) % MOD
+	return ans
+}
+
+func runCase(bin string, n, a0, x, y, k, M int64) error {
+	input := fmt.Sprintf("%d %d %d %d %d %d\n", n, a0, x, y, k, M)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := fmt.Sprint(expected(n, a0, x, y, k, M))
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randCase(rng *rand.Rand) (int64, int64, int64, int64, int64, int64) {
+	n := int64(rng.Intn(5) + 1)
+	a0 := int64(rng.Intn(10))
+	x := int64(rng.Intn(10) + 1)
+	y := int64(rng.Intn(10))
+	k := int64(rng.Intn(4) + 1)
+	M := int64(rng.Intn(20) + 1)
+	return n, a0, x, y, k, M
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases [][6]int64
+	cases = append(cases, [6]int64{1, 0, 1, 0, 1, 2})
+	cases = append(cases, [6]int64{2, 3, 2, 1, 2, 5})
+	for i := 0; i < 100; i++ {
+		n, a0, x, y, k, M := randCase(rng)
+		cases = append(cases, [6]int64{n, a0, x, y, k, M})
+	}
+	for idx, c := range cases {
+		if err := runCase(bin, c[0], c[1], c[2], c[3], c[4], c[5]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1626 problems A–F
- each verifier generates over 100 cases and compares output with an internal solution

## Testing
- `go build 1000-1999/1600-1699/1620-1629/1626/verifierA.go`
- `go build 1000-1999/1600-1699/1620-1629/1626/verifierB.go`
- `go build 1000-1999/1600-1699/1620-1629/1626/verifierC.go`
- `go build 1000-1999/1600-1699/1620-1629/1626/verifierD.go`
- `go build 1000-1999/1600-1699/1620-1629/1626/verifierE.go`
- `go build 1000-1999/1600-1699/1620-1629/1626/verifierF.go`
- `go run 1000-1999/1600-1699/1620-1629/1626/verifierA.go ./a.out`

------
https://chatgpt.com/codex/tasks/task_e_68873736b9988324bfd7d42f53756829