### PR TITLE
Add verifiers for CF1628

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1628/verifierA.go
+++ b/1000-1999/1600-1699/1620-1629/1628/verifierA.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(a []int) []int {
+	n := len(a)
+	freq := make([]int, n+2)
+	for _, v := range a {
+		if v <= n+1 {
+			freq[v]++
+		}
+	}
+	res := make([]int, 0)
+	for i := 0; i < n; {
+		mex := 0
+		for mex <= n+1 && freq[mex] > 0 {
+			mex++
+		}
+		if mex == 0 {
+			freq[a[i]]--
+			res = append(res, 0)
+			i++
+			continue
+		}
+		seen := make([]bool, mex)
+		need := mex
+		j := i
+		for j < n && need > 0 {
+			v := a[j]
+			freq[v]--
+			if v < mex && !seen[v] {
+				seen[v] = true
+				need--
+			}
+			j++
+		}
+		res = append(res, mex)
+		i = j
+	}
+	return res
+}
+
+func buildInput(n int, a []int) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func expected(res []int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(res)))
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	var bin string
+	if len(os.Args) == 2 {
+		bin = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		bin = os.Args[2]
+	} else {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rng.Intn(n + 1)
+		}
+		input := buildInput(n, a)
+		res := solve(a)
+		exp := expected(res)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("case %d wrong answer\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1628/verifierB.go
+++ b/1000-1999/1600-1699/1620-1629/1628/verifierB.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func reverseStr(s string) string {
+	bs := []byte(s)
+	for i, j := 0, len(bs)-1; i < j; i, j = i+1, j-1 {
+		bs[i], bs[j] = bs[j], bs[i]
+	}
+	return string(bs)
+}
+
+func solve(words []string) string {
+	set2 := make(map[string]bool)
+	set3 := make(map[string]bool)
+	for _, w := range words {
+		if len(w) == 1 {
+			return "YES"
+		}
+		rev := reverseStr(w)
+		if len(w) == 2 {
+			if w[0] == w[1] {
+				return "YES"
+			}
+			if set2[rev] || set3[rev] {
+				return "YES"
+			}
+			for c := byte('a'); c <= byte('c'); c++ {
+				key := rev + string(c)
+				if set3[key] {
+					return "YES"
+				}
+			}
+			set2[w] = true
+		} else if len(w) == 3 {
+			if w[0] == w[2] {
+				return "YES"
+			}
+			if set3[rev] {
+				return "YES"
+			}
+			key := rev[:2]
+			if set2[key] {
+				return "YES"
+			}
+			set3[w] = true
+		}
+	}
+	return "NO"
+}
+
+func buildInput(words []string) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(words)))
+	for i, w := range words {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(w)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	var bin string
+	if len(os.Args) == 2 {
+		bin = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		bin = os.Args[2]
+	} else {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	letters := []byte("abc")
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 1
+		words := make([]string, n)
+		for j := range words {
+			l := rng.Intn(3) + 1
+			b := make([]byte, l)
+			for k := range b {
+				b[k] = letters[rng.Intn(len(letters))]
+			}
+			words[j] = string(b)
+		}
+		input := buildInput(words)
+		exp := solve(words)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("case %d wrong answer\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1628/verifierC.go
+++ b/1000-1999/1600-1699/1620-1629/1628/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(mat [][]int) int {
+	res := 0
+	for i := range mat {
+		for j := range mat[i] {
+			res ^= mat[i][j]
+		}
+	}
+	return res
+}
+
+func buildInput(mat [][]int) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	n := len(mat)
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", mat[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	var bin string
+	if len(os.Args) == 2 {
+		bin = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		bin = os.Args[2]
+	} else {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		mat := make([][]int, n)
+		for r := 0; r < n; r++ {
+			mat[r] = make([]int, n)
+			for c := 0; c < n; c++ {
+				mat[r][c] = rng.Intn(20)
+			}
+		}
+		input := buildInput(mat)
+		exp := fmt.Sprintf("%d", solve(mat))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("case %d wrong answer\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1628/verifierD1.go
+++ b/1000-1999/1600-1699/1620-1629/1628/verifierD1.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1e9 + 7
+
+var fact [2001]int64
+var invfact [2001]int64
+var pow2 [2001]int64
+var invPow2 [2001]int64
+
+func powmod(a, e int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func initComb() {
+	fact[0] = 1
+	for i := 1; i <= 2000; i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	invfact[2000] = powmod(fact[2000], MOD-2)
+	for i := 2000; i >= 1; i-- {
+		invfact[i-1] = invfact[i] * int64(i) % MOD
+	}
+	pow2[0] = 1
+	for i := 1; i <= 2000; i++ {
+		pow2[i] = pow2[i-1] * 2 % MOD
+	}
+	invPow2[2000] = powmod(pow2[2000], MOD-2)
+	for i := 2000; i >= 1; i-- {
+		invPow2[i-1] = invPow2[i] * 2 % MOD
+	}
+}
+
+func C(n, k int) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	return fact[n] * invfact[k] % MOD * invfact[n-k] % MOD
+}
+
+func solve(n, m int, k int64) int64 {
+	sum := int64(0)
+	for x := 0; x < m; x++ {
+		sum = (sum + int64(m-x)*C(n, x)) % MOD
+	}
+	ans := k % MOD * sum % MOD * invPow2[n-1] % MOD
+	return ans
+}
+
+func buildInput(n, m int, k int64) string {
+	return fmt.Sprintf("1\n%d %d %d\n", n, m, k)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	var bin string
+	if len(os.Args) == 2 {
+		bin = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		bin = os.Args[2]
+	} else {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	initComb()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(n) + 1
+		k := int64(rng.Intn(5) + 1)
+		input := buildInput(n, m, k)
+		exp := fmt.Sprintf("%d", solve(n, m, k))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("case %d wrong answer\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1628/verifierD2.go
+++ b/1000-1999/1600-1699/1620-1629/1628/verifierD2.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, m int, k int64) int64 {
+	if m == 0 || m > n {
+		return 0
+	}
+	mod := big.NewInt(1_000_000_007)
+	inv := func(x *big.Int) *big.Int {
+		exp := new(big.Int).Sub(mod, big.NewInt(2))
+		return new(big.Int).Exp(x, exp, mod)
+	}
+	half := big.NewRat(1, 2)
+	prev := make([]*big.Rat, m+2)
+	curr := make([]*big.Rat, m+2)
+	for i := range prev {
+		prev[i] = new(big.Rat)
+		curr[i] = new(big.Rat)
+	}
+	for i := 1; i <= n; i++ {
+		upto := m
+		if i < m {
+			upto = i
+		}
+		for j := 1; j <= upto; j++ {
+			if j == i {
+				curr[j].SetInt64(int64(i))
+				curr[j].Mul(curr[j], big.NewRat(k, 1))
+				continue
+			}
+			delta := new(big.Rat).Sub(prev[j], prev[j-1])
+			cmp0 := delta.Cmp(new(big.Rat))
+			twoK := new(big.Rat).SetInt64(2 * k)
+			if cmp0 <= 0 {
+				curr[j].Set(prev[j])
+			} else if delta.Cmp(twoK) >= 0 {
+				curr[j].Set(prev[j-1])
+				curr[j].Add(curr[j], big.NewRat(k, 1))
+			} else {
+				curr[j].Set(prev[j-1])
+				delta.Mul(delta, half)
+				curr[j].Add(curr[j], delta)
+			}
+		}
+		if i <= m {
+			curr[i+1] = new(big.Rat)
+		}
+		prev, curr = curr, prev
+	}
+	ans := prev[m]
+	p := new(big.Int).Mod(ans.Num(), mod)
+	q := new(big.Int).Mod(ans.Denom(), mod)
+	qInv := inv(q)
+	p.Mul(p, qInv)
+	p.Mod(p, mod)
+	return p.Int64()
+}
+
+func buildInput(n, m int, k int64) string {
+	return fmt.Sprintf("1\n%d %d %d\n", n, m, k)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	var bin string
+	if len(os.Args) == 2 {
+		bin = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		bin = os.Args[2]
+	} else {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(n) + 1
+		k := int64(rng.Intn(5) + 1)
+		input := buildInput(n, m, k)
+		exp := fmt.Sprintf("%d", solve(n, m, k))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("case %d wrong answer\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1628/verifierE.go
+++ b/1000-1999/1600-1699/1620-1629/1628/verifierE.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const LOG = 20
+
+type Edge struct {
+	to int
+	w  int
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func dfs(v, p, w int, adj [][]Edge, up, mx [][]int, depth []int) {
+	up[v][0] = p
+	mx[v][0] = w
+	for i := 1; i < LOG; i++ {
+		up[v][i] = up[up[v][i-1]][i-1]
+		if up[v][i] == 0 {
+			mx[v][i] = mx[v][i-1]
+		} else {
+			mx[v][i] = max(mx[v][i-1], mx[up[v][i-1]][i-1])
+		}
+	}
+	for _, e := range adj[v] {
+		if e.to == p {
+			continue
+		}
+		depth[e.to] = depth[v] + 1
+		dfs(e.to, v, e.w, adj, up, mx, depth)
+	}
+}
+
+func maxEdge(u, v int, up, mx [][]int, depth []int) int {
+	if u == v {
+		return 0
+	}
+	res := 0
+	if depth[u] < depth[v] {
+		u, v = v, u
+	}
+	diff := depth[u] - depth[v]
+	for i := LOG - 1; i >= 0; i-- {
+		if diff>>i&1 == 1 {
+			if mx[u][i] > res {
+				res = mx[u][i]
+			}
+			u = up[u][i]
+		}
+	}
+	if u == v {
+		return res
+	}
+	for i := LOG - 1; i >= 0; i-- {
+		if up[u][i] != up[v][i] {
+			if mx[u][i] > res {
+				res = mx[u][i]
+			}
+			if mx[v][i] > res {
+				res = mx[v][i]
+			}
+			u = up[u][i]
+			v = up[v][i]
+		}
+	}
+	if mx[u][0] > res {
+		res = mx[u][0]
+	}
+	if mx[v][0] > res {
+		res = mx[v][0]
+	}
+	return res
+}
+
+func solve(n int, edges [][3]int, queries [][]int) []int {
+	adj := make([][]Edge, n+1)
+	for _, e := range edges {
+		u, v, w := e[0], e[1], e[2]
+		adj[u] = append(adj[u], Edge{v, w})
+		adj[v] = append(adj[v], Edge{u, w})
+	}
+	up := make([][]int, n+1)
+	mx := make([][]int, n+1)
+	for i := 0; i <= n; i++ {
+		up[i] = make([]int, LOG)
+		mx[i] = make([]int, LOG)
+	}
+	depth := make([]int, n+1)
+	dfs(1, 1, 0, adj, up, mx, depth)
+	open := make([]bool, n+1)
+	var ans []int
+	for _, q := range queries {
+		if q[0] == 1 {
+			l, r := q[1], q[2]
+			for i := l; i <= r; i++ {
+				open[i] = true
+			}
+		} else if q[0] == 2 {
+			l, r := q[1], q[2]
+			for i := l; i <= r; i++ {
+				open[i] = false
+			}
+		} else {
+			x := q[1]
+			best := -1
+			for i := 1; i <= n; i++ {
+				if open[i] && i != x {
+					w := maxEdge(x, i, up, mx, depth)
+					if w > best {
+						best = w
+					}
+				}
+			}
+			ans = append(ans, best)
+		}
+	}
+	return ans
+}
+
+func buildInput(n int, edges [][3]int, queries [][]int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(queries)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+	}
+	for _, q := range queries {
+		if q[0] == 1 || q[0] == 2 {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", q[0], q[1], q[2]))
+		} else {
+			sb.WriteString(fmt.Sprintf("3 %d\n", q[1]))
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	var bin string
+	if len(os.Args) == 2 {
+		bin = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		bin = os.Args[2]
+	} else {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 2
+		edges := make([][3]int, n-1)
+		for v := 2; v <= n; v++ {
+			u := rng.Intn(v-1) + 1
+			w := rng.Intn(10) + 1
+			edges[v-2] = [3]int{u, v, w}
+		}
+		q := rng.Intn(5) + 1
+		queries := make([][]int, q)
+		for j := 0; j < q; j++ {
+			t := rng.Intn(3) + 1
+			if t == 1 || t == 2 {
+				l := rng.Intn(n) + 1
+				r := rng.Intn(n) + 1
+				if l > r {
+					l, r = r, l
+				}
+				queries[j] = []int{t, l, r}
+			} else {
+				x := rng.Intn(n) + 1
+				queries[j] = []int{3, x}
+			}
+		}
+		input := buildInput(n, edges, queries)
+		res := solve(n, edges, queries)
+		var exp strings.Builder
+		for idx, v := range res {
+			if idx > 0 {
+				exp.WriteByte('\n')
+			}
+			exp.WriteString(fmt.Sprintf("%d", v))
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp.String() {
+			fmt.Printf("case %d wrong answer\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, input, exp.String(), out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1620-1629/1628/verifierF.go
+++ b/1000-1999/1600-1699/1620-1629/1628/verifierF.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Point struct {
+	x, y float64
+}
+
+type Segment struct {
+	a, b Point
+}
+
+func sub(a, b Point) Point     { return Point{a.x - b.x, a.y - b.y} }
+func dot(a, b Point) float64   { return a.x*b.x + a.y*b.y }
+func cross(a, b Point) float64 { return a.x*b.y - a.y*b.x }
+func norm(a Point) float64     { return math.Hypot(a.x, a.y) }
+func normalize(a Point) Point {
+	r := norm(a)
+	if r == 0 {
+		return Point{0, 0}
+	}
+	return Point{a.x / r, a.y / r}
+}
+func angleDiff(a, b Point) float64 {
+	a = normalize(a)
+	b = normalize(b)
+	c := math.Abs(dot(a, b))
+	if c > 1 {
+		c = 1
+	}
+	return math.Acos(c)
+}
+func isOnRay(p, d, t Point) (bool, float64) {
+	v := sub(t, p)
+	if math.Abs(cross(v, d)) > 1e-9 {
+		return false, 0
+	}
+	k := dot(v, d) / dot(d, d)
+	if k >= -1e-9 {
+		return true, k
+	}
+	return false, 0
+}
+func intersectRaySegment(p, d Point, s Segment) (bool, float64) {
+	a := s.a
+	b := s.b
+	v := sub(b, a)
+	w := sub(a, p)
+	denom := cross(d, v)
+	if math.Abs(denom) < 1e-9 {
+		if math.Abs(cross(w, d)) < 1e-9 {
+			t1 := dot(sub(a, p), d) / dot(d, d)
+			t2 := dot(sub(b, p), d) / dot(d, d)
+			best := math.Inf(1)
+			if t1 >= -1e-9 {
+				best = math.Min(best, t1)
+			}
+			if t2 >= -1e-9 {
+				best = math.Min(best, t2)
+			}
+			if best < math.Inf(1) {
+				return true, best
+			}
+		}
+		return false, 0
+	}
+	t := cross(w, v) / denom
+	u := cross(w, d) / denom
+	if t >= -1e-9 && u >= -1e-9 && u <= 1+1e-9 {
+		return true, t
+	}
+	return false, 0
+}
+func attempt(start, d Point, segs []Segment) bool {
+	p := start
+	visited := make(map[[2]int]bool)
+	for iter := 0; iter <= len(segs); iter++ {
+		hasT, distT := isOnRay(p, d, Point{0, 0})
+		bestDist := math.Inf(1)
+		bestIdx := -1
+		for i, s := range segs {
+			ok, dist := intersectRaySegment(p, d, s)
+			if ok && dist > 1e-9 && dist < bestDist {
+				bestDist = dist
+				bestIdx = i
+			}
+		}
+		if hasT && (bestIdx == -1 || distT <= bestDist+1e-9) {
+			return true
+		}
+		if bestIdx == -1 {
+			return false
+		}
+		seg := segs[bestIdx]
+		v := sub(seg.b, seg.a)
+		endpoint := seg.b
+		slideVec := v
+		if dot(d, v) < 0 {
+			endpoint = seg.a
+			slideVec = Point{-v.x, -v.y}
+		}
+		if angleDiff(d, slideVec) >= math.Pi/4-1e-9 {
+			return false
+		}
+		key := [2]int{int(endpoint.x*1000 + 0.5), int(endpoint.y*1000 + 0.5)}
+		if visited[key] {
+			return false
+		}
+		visited[key] = true
+		p = endpoint
+	}
+	return false
+}
+
+func solve(segs []Segment, queries []Point) []string {
+	var res []string
+	for _, start := range queries {
+		dirs := []Point{{-start.x, -start.y}}
+		for _, s := range segs {
+			dirs = append(dirs, Point{-s.a.x, -s.a.y}, Point{-s.b.x, -s.b.y})
+		}
+		found := false
+		for _, d := range dirs {
+			if d.x == 0 && d.y == 0 {
+				continue
+			}
+			if attempt(start, d, segs) {
+				found = true
+				break
+			}
+		}
+		if found {
+			res = append(res, "YES")
+		} else {
+			res = append(res, "NO")
+		}
+	}
+	return res
+}
+
+func buildInput(segs []Segment, queries []Point) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(segs)))
+	for _, s := range segs {
+		sb.WriteString(fmt.Sprintf("%f %f %f %f\n", s.a.x, s.a.y, s.b.x, s.b.y))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", len(queries)))
+	for _, q := range queries {
+		sb.WriteString(fmt.Sprintf("%f %f\n", q.x, q.y))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	var bin string
+	if len(os.Args) == 2 {
+		bin = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		bin = os.Args[2]
+	} else {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(3) + 1
+		segs := make([]Segment, n)
+		for j := 0; j < n; j++ {
+			ax := rng.Float64()*6 - 3
+			ay := rng.Float64()*6 - 3
+			bx := ax + rng.Float64()*2 - 1
+			by := ay + rng.Float64()*2 - 1
+			segs[j] = Segment{Point{ax, ay}, Point{bx, by}}
+		}
+		q := rng.Intn(3) + 1
+		queries := make([]Point, q)
+		for j := range queries {
+			queries[j] = Point{rng.Float64()*6 - 3, rng.Float64()*6 - 3}
+		}
+		input := buildInput(segs, queries)
+		res := solve(segs, queries)
+		exp := strings.Join(res, "\n")
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("case %d wrong answer\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for contest 1628 problems A–F
- each verifier generates 100 random tests and can execute either binaries or Go files

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD1.go`
- `go build verifierD2.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go run verifierA.go -- 1628A.go`
- `go run verifierB.go -- 1628B.go`

------
https://chatgpt.com/codex/tasks/task_e_688737c2abe08324a90fdfa636fc79fa