### PR TITLE
Add Go verifiers for contest 1633

### DIFF
--- a/1000-1999/1600-1699/1630-1639/1633/verifierA.go
+++ b/1000-1999/1600-1699/1630-1639/1633/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(n int) int {
+	if n%7 == 0 {
+		return n
+	}
+	base := n - n%10
+	for i := 0; i < 10; i++ {
+		if (base+i)%7 == 0 {
+			return base + i
+		}
+	}
+	return n
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(990) + 10
+	expect := fmt.Sprintf("%d", solveA(n))
+	input := fmt.Sprintf("1\n%d\n", n)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1633/verifierB.go
+++ b/1000-1999/1600-1699/1630-1639/1633/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(s string) int {
+	zeros := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '0' {
+			zeros++
+		}
+	}
+	ones := len(s) - zeros
+	if zeros == ones {
+		return zeros - 1
+	}
+	if zeros < ones {
+		return zeros
+	}
+	return ones
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	l := r.Intn(100) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		if r.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	s := string(b)
+	expect := fmt.Sprintf("%d", solveB(s))
+	input := fmt.Sprintf("1\n%s\n", s)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1633/verifierC.go
+++ b/1000-1999/1600-1699/1630-1639/1633/verifierC.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(hC, dC, hM, dM, k, w, a int64) string {
+	for i := int64(0); i <= k; i++ {
+		attack := dC + i*w
+		health := hC + (k-i)*a
+		turnsHero := (hM + attack - 1) / attack
+		turnsMonster := (health + dM - 1) / dM
+		if turnsHero <= turnsMonster {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	hC := int64(r.Intn(100) + 1)
+	dC := int64(r.Intn(100) + 1)
+	hM := int64(r.Intn(100) + 1)
+	dM := int64(r.Intn(100) + 1)
+	k := int64(r.Intn(10))
+	w := int64(r.Intn(10) + 1)
+	a := int64(r.Intn(10) + 1)
+	expect := solveC(hC, dC, hM, dM, k, w, a)
+	input := fmt.Sprintf("1\n%d %d\n%d %d\n%d %d %d\n", hC, dC, hM, dM, k, w, a)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1633/verifierD.go
+++ b/1000-1999/1600-1699/1630-1639/1633/verifierD.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MaxB = 1000
+
+var dist [MaxB + 1]int
+
+func init() {
+	const INF = int(1e9)
+	for i := range dist {
+		dist[i] = INF
+	}
+	dist[1] = 0
+	q := []int{1}
+	for head := 0; head < len(q); head++ {
+		v := q[head]
+		for x := 1; x <= v; x++ {
+			nxt := v + v/x
+			if nxt <= MaxB && dist[nxt] > dist[v]+1 {
+				dist[nxt] = dist[v] + 1
+				q = append(q, nxt)
+			}
+		}
+	}
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveD(n, k int, bVals, cVals []int) int {
+	w := make([]int, n)
+	for i := 0; i < n; i++ {
+		w[i] = dist[bVals[i]]
+	}
+	cap := min(k, 12*n)
+	dp := make([]int, cap+1)
+	for i := 0; i < n; i++ {
+		cost := w[i]
+		val := cVals[i]
+		if cost > cap {
+			continue
+		}
+		for j := cap; j >= cost; j-- {
+			if dp[j-cost]+val > dp[j] {
+				dp[j] = dp[j-cost] + val
+			}
+		}
+	}
+	return dp[min(k, cap)]
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(5) + 1
+	k := r.Intn(20) + 1
+	b := make([]int, n)
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		b[i] = r.Intn(1000) + 1
+		c[i] = r.Intn(100) + 1
+	}
+	expect := fmt.Sprintf("%d", solveD(n, k, b, c))
+	input := fmt.Sprintf("1\n%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", b[i])
+	}
+	input += "\n"
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", c[i])
+	}
+	input += "\n"
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1633/verifierE.go
+++ b/1000-1999/1600-1699/1630-1639/1633/verifierE.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	u, v int
+	w    int
+}
+
+type DSU struct {
+	p, r []int
+}
+
+func NewDSU(n int) *DSU {
+	d := &DSU{p: make([]int, n), r: make([]int, n)}
+	for i := 0; i < n; i++ {
+		d.p[i] = i
+	}
+	return d
+}
+
+func (d *DSU) find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) union(x, y int) bool {
+	fx := d.find(x)
+	fy := d.find(y)
+	if fx == fy {
+		return false
+	}
+	if d.r[fx] < d.r[fy] {
+		fx, fy = fy, fx
+	}
+	d.p[fy] = fx
+	if d.r[fx] == d.r[fy] {
+		d.r[fx]++
+	}
+	return true
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func mstEdges(edges []Edge, n int, x int) []int {
+	es := make([]Edge, len(edges))
+	copy(es, edges)
+	sort.Slice(es, func(i, j int) bool {
+		d1 := abs(es[i].w - x)
+		d2 := abs(es[j].w - x)
+		if d1 == d2 {
+			return es[i].w < es[j].w
+		}
+		return d1 < d2
+	})
+	dsu := NewDSU(n + 1)
+	ws := make([]int, 0, n-1)
+	for _, e := range es {
+		if dsu.union(e.u, e.v) {
+			ws = append(ws, e.w)
+			if len(ws) == n-1 {
+				break
+			}
+		}
+	}
+	sort.Ints(ws)
+	return ws
+}
+
+type MSTInfo struct {
+	weights []int
+	prefix  []int64
+}
+
+func buildInfo(ws []int) MSTInfo {
+	prefix := make([]int64, len(ws)+1)
+	for i, w := range ws {
+		prefix[i+1] = prefix[i] + int64(w)
+	}
+	return MSTInfo{weights: ws, prefix: prefix}
+}
+
+func (info MSTInfo) cost(x int) int64 {
+	w := info.weights
+	idx := sort.Search(len(w), func(i int) bool { return w[i] > x })
+	sumLess := info.prefix[idx]
+	total := info.prefix[len(w)]
+	return int64(x)*int64(idx) - sumLess + (total - sumLess) - int64(x)*int64(len(w)-idx)
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(n, m int, edges []Edge, p, k, a, b, c int, q []int) int64 {
+	boundariesMap := make(map[int]struct{})
+	boundariesMap[0] = struct{}{}
+	boundariesMap[c] = struct{}{}
+	weights := make([]int, m)
+	for i, e := range edges {
+		weights[i] = e.w
+	}
+	for i := 0; i < m; i++ {
+		for j := i; j < m; j++ {
+			v := (weights[i] + weights[j] + 1) / 2
+			if v < 0 {
+				v = 0
+			}
+			if v > c {
+				v = c
+			}
+			boundariesMap[v] = struct{}{}
+		}
+	}
+	boundaries := make([]int, 0, len(boundariesMap))
+	for v := range boundariesMap {
+		boundaries = append(boundaries, v)
+	}
+	sort.Ints(boundaries)
+	starts := make([]int, 0)
+	for _, v := range boundaries {
+		if v < c {
+			starts = append(starts, v)
+		}
+	}
+	starts = append(starts, c)
+	infos := make([]MSTInfo, len(starts))
+	for i, st := range starts {
+		if st == c {
+			infos[i] = MSTInfo{}
+		} else {
+			ws := mstEdges(edges, n, st)
+			infos[i] = buildInfo(ws)
+		}
+	}
+	var xorResult int64
+	for _, x := range q {
+		idx := sort.Search(len(starts), func(i int) bool { return starts[i] > x }) - 1
+		if idx < 0 {
+			idx = 0
+		}
+		ans := infos[idx].cost(x)
+		xorResult ^= ans
+	}
+	return xorResult
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(5) + 2
+	m := r.Intn(5) + n - 1
+	edges := make([]Edge, m)
+	for i := 0; i < m; i++ {
+		u := r.Intn(n) + 1
+		v := r.Intn(n) + 1
+		for v == u {
+			v = r.Intn(n) + 1
+		}
+		w := r.Intn(20)
+		edges[i] = Edge{u: u, v: v, w: w}
+	}
+	p := r.Intn(3) + 1
+	k := p + r.Intn(3)
+	a := r.Intn(5) + 1
+	b := r.Intn(5) + 1
+	c := r.Intn(20) + 1
+	q := make([]int, k)
+	for i := 0; i < p; i++ {
+		q[i] = r.Intn(c)
+	}
+	for i := p; i < k; i++ {
+		q[i] = (q[i-1]*a + b) % c
+	}
+	expect := fmt.Sprintf("%d", solveE(n, m, edges, p, k, a, b, c, q))
+	input := fmt.Sprintf("%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		input += fmt.Sprintf("%d %d %d\n", edges[i].u, edges[i].v, edges[i].w)
+	}
+	input += fmt.Sprintf("%d %d %d %d %d\n", p, k, a, b, c)
+	for i := 0; i < p; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", q[i])
+	}
+	if p > 0 {
+		input += "\n"
+	}
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1633/verifierF.go
+++ b/1000-1999/1600-1699/1630-1639/1633/verifierF.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem F is interactive and cannot be automatically verified.")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1633 problems A–E
- add stub for interactive problem F

## Testing
- `go build 1000-1999/1600-1699/1630-1639/1633/verifierA.go`
- `go build 1000-1999/1600-1699/1630-1639/1633/verifierB.go`
- `go build 1000-1999/1600-1699/1630-1639/1633/verifierC.go`
- `go build 1000-1999/1600-1699/1630-1639/1633/verifierD.go`
- `go build 1000-1999/1600-1699/1630-1639/1633/verifierE.go`
- `go build 1000-1999/1600-1699/1630-1639/1633/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68873920c0f883248fd1bd0b449bb631