### PR TITLE
Add Go solution verifiers for contest 1632

### DIFF
--- a/1000-1999/1600-1699/1630-1639/1632/verifierA.go
+++ b/1000-1999/1600-1699/1630-1639/1632/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(n int, s string) string {
+	if n == 1 {
+		return "YES"
+	}
+	if n == 2 && s[0] != s[1] {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	s := string(b)
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	return input, solveA(n, s)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if strings.ToUpper(outStr) != expected {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1632/verifierB.go
+++ b/1000-1999/1600-1699/1630-1639/1632/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(n int) []int {
+	m := n - 1
+	d := 1
+	for d<<1 <= m {
+		d <<= 1
+	}
+	res := make([]int, 0, n)
+	for x := m; x >= d; x-- {
+		res = append(res, x)
+	}
+	d--
+	res = append(res, 0)
+	for d > 0 {
+		res = append(res, d)
+		d--
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(100) + 2
+	input := fmt.Sprintf("1\n%d\n", n)
+	return input, solveB(n)
+}
+
+func runCase(bin, input string, exp []int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	parts := strings.Fields(strings.TrimSpace(out.String()))
+	if len(parts) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(parts))
+	}
+	for i, p := range parts {
+		var v int
+		if _, err := fmt.Sscan(p, &v); err != nil {
+			return fmt.Errorf("bad int on position %d: %v", i+1, err)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("pos %d expected %d got %d", i+1, exp[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1632/verifierC.go
+++ b/1000-1999/1600-1699/1630-1639/1632/verifierC.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(a, b int) int {
+	if a == b {
+		return 0
+	}
+	ans := b - a
+	for B := b; B <= b*2; B++ {
+		cost := B - b
+		y := a | B
+		cost += y - B
+		cost++
+		if cost < ans {
+			ans = cost
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	a := rng.Intn(1_000_000) + 1
+	b := rng.Intn(1_000_000-a) + a + 1
+	input := fmt.Sprintf("1\n%d %d\n", a, b)
+	return input, solveC(a, b)
+}
+
+func runCase(bin, input string, exp int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var val int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &val); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if val != exp {
+		return fmt.Errorf("expected %d got %d", exp, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1632/verifierD.go
+++ b/1000-1999/1600-1699/1630-1639/1632/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct {
+	g int
+	l int
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solveD(arr []int) []int {
+	const BIG = 1000000007
+	segs := []pair{}
+	ans := 0
+	res := make([]int, len(arr))
+	for i, x := range arr {
+		newSegs := []pair{{x, i}}
+		for _, p := range segs {
+			g := gcd(p.g, x)
+			last := &newSegs[len(newSegs)-1]
+			if last.g == g {
+				if p.l < last.l {
+					last.l = p.l
+				}
+			} else {
+				newSegs = append(newSegs, pair{g, p.l})
+			}
+		}
+		bad := false
+		for _, p := range newSegs {
+			if p.g == i-p.l+1 {
+				bad = true
+				break
+			}
+		}
+		if bad {
+			ans++
+			segs = []pair{{BIG, i}}
+		} else {
+			segs = newSegs
+		}
+		res[i] = ans
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	return sb.String(), solveD(arr)
+}
+
+func runCase(bin, input string, exp []int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	parts := strings.Fields(strings.TrimSpace(out.String()))
+	if len(parts) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(parts))
+	}
+	for i, p := range parts {
+		var v int
+		if _, err := fmt.Sscan(p, &v); err != nil {
+			return fmt.Errorf("bad int at pos %d: %v", i+1, err)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("pos %d expected %d got %d", i+1, exp[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1632/verifierE1.go
+++ b/1000-1999/1600-1699/1630-1639/1632/verifierE1.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pair struct {
+	delta int
+	depth int
+	dist  int
+}
+
+func solveE1(n int, edges [][2]int) []int {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	dist := make([][]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			dist[i][j] = -1
+		}
+		queue := []int{i}
+		dist[i][i] = 0
+		for head := 0; head < len(queue); head++ {
+			cur := queue[head]
+			for _, nb := range adj[cur] {
+				if dist[i][nb] == -1 {
+					dist[i][nb] = dist[i][cur] + 1
+					queue = append(queue, nb)
+				}
+			}
+		}
+	}
+	depth := dist[0]
+	e1 := 0
+	for _, d := range depth {
+		if d > e1 {
+			e1 = d
+		}
+	}
+	ans := make([]int, n+1)
+	for x := 1; x <= n; x++ {
+		ans[x] = e1
+	}
+	arr := make([]pair, n)
+	prefix := make([]int, n+1)
+	suffix := make([]int, n+1)
+	for v := 1; v < n; v++ {
+		for u := 0; u < n; u++ {
+			arr[u] = pair{
+				delta: depth[u] - dist[v][u],
+				depth: depth[u],
+				dist:  dist[v][u],
+			}
+		}
+		sort.Slice(arr, func(i, j int) bool { return arr[i].delta < arr[j].delta })
+		prefix[0] = 0
+		for i := 0; i < n; i++ {
+			if arr[i].depth > prefix[i] {
+				prefix[i+1] = arr[i].depth
+			} else {
+				prefix[i+1] = prefix[i]
+			}
+		}
+		suffix[n] = 0
+		for i := n - 1; i >= 0; i-- {
+			if arr[i].dist > suffix[i+1] {
+				suffix[i] = arr[i].dist
+			} else {
+				suffix[i] = suffix[i+1]
+			}
+		}
+		for x := 1; x <= n; x++ {
+			idx := sort.Search(n, func(i int) bool { return arr[i].delta > x })
+			val := prefix[idx]
+			tmp := x + suffix[idx]
+			if tmp > val {
+				val = tmp
+			}
+			if val < ans[x] {
+				ans[x] = val
+			}
+		}
+	}
+	return ans[1:]
+}
+
+func randTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges = append(edges, [2]int{i, p})
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(8) + 2
+	edges := randTree(rng, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	ans := solveE1(n, edges)
+	return sb.String(), ans
+}
+
+func runCase(bin, input string, exp []int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	parts := strings.Fields(strings.TrimSpace(out.String()))
+	if len(parts) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(parts))
+	}
+	for i, p := range parts {
+		var v int
+		if _, err := fmt.Sscan(p, &v); err != nil {
+			return fmt.Errorf("bad int at pos %d: %v", i+1, err)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("pos %d expected %d got %d", i+1, exp[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1632/verifierE2.go
+++ b/1000-1999/1600-1699/1630-1639/1632/verifierE2.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE2(n int, edges [][2]int) []int {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	d := make([]int, n)
+	maxH := 0
+	var dfs func(int, int, int) int
+	dfs = func(u, p, dep int) int {
+		h1, h2 := dep, dep
+		for _, v := range adj[u] {
+			if v == p {
+				continue
+			}
+			q := dfs(v, u, dep+1)
+			if q > h1 {
+				h2 = h1
+				h1 = q
+			} else if q > h2 {
+				h2 = q
+			}
+		}
+		if h1 > maxH {
+			maxH = h1
+		}
+		x := h1
+		if h2 < x {
+			x = h2
+		}
+		x--
+		if x >= 0 {
+			val := h1 + h2 - 2*dep + 1
+			if val > d[x] {
+				d[x] = val
+			}
+		}
+		return h1
+	}
+	dfs(0, -1, 0)
+	for i := n - 2; i >= 0; i-- {
+		if d[i+1] > d[i] {
+			d[i] = d[i+1]
+		}
+	}
+	ans := 0
+	res := make([]int, n)
+	for i := 1; i <= n; i++ {
+		for ans < maxH && d[ans]/2+i > ans {
+			ans++
+		}
+		res[i-1] = ans
+	}
+	return res
+}
+
+func randTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges = append(edges, [2]int{i, p})
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(8) + 2
+	edges := randTree(rng, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	ans := solveE2(n, edges)
+	return sb.String(), ans
+}
+
+func runCase(bin, input string, exp []int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	parts := strings.Fields(strings.TrimSpace(out.String()))
+	if len(parts) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(parts))
+	}
+	for i, p := range parts {
+		var v int
+		if _, err := fmt.Sscan(p, &v); err != nil {
+			return fmt.Errorf("bad int at pos %d: %v", i+1, err)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("pos %d expected %d got %d", i+1, exp[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for contest 1632 problems A–E2
- each verifier generates 100 random test cases and checks a given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE1.go`
- `go build verifierE2.go`


------
https://chatgpt.com/codex/tasks/task_e_688738dacb548324af2feeaed179f0c3