### PR TITLE
Fix 626D verifier exit logic

### DIFF
--- a/0-999/600-699/620-629/626/verifierD.go
+++ b/0-999/600-699/620-629/626/verifierD.go
@@ -66,5 +66,10 @@ func main() {
 		}
 		fmt.Printf("case %d failed: expected %s got %s\n", i+1, t.Out, got)
 	}
-	fmt.Printf("passed %d/%d\n", passed, len(tests))
+	if passed == len(tests) {
+		fmt.Println("All tests passed")
+	} else {
+		fmt.Printf("passed %d/%d\n", passed, len(tests))
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
## Summary
- modify verifier for problem 626D to exit with failure when any case fails
- print "All tests passed" when all cases succeed

## Testing
- `go build 0-999/600-699/620-629/626/verifierD.go`

------
https://chatgpt.com/codex/tasks/task_e_68873a3b46cc8324890f5edb03dd9ea0