### PR TITLE
Add Go verifiers for contest 1634

### DIFF
--- a/1000-1999/1600-1699/1630-1639/1634/verifierA.go
+++ b/1000-1999/1600-1699/1630-1639/1634/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, k int
+	s    string
+}
+
+func isPalindrome(s string) bool {
+	i, j := 0, len(s)-1
+	for i < j {
+		if s[i] != s[j] {
+			return false
+		}
+		i++
+		j--
+	}
+	return true
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(42))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(10) + 1
+		k := rng.Intn(10)
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = byte('a' + rng.Intn(26))
+		}
+		cases[i] = testCase{n: n, k: k, s: string(b)}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		var in strings.Builder
+		fmt.Fprintf(&in, "1\n%d %d\n%s\n", tc.n, tc.k, tc.s)
+		expected := "1"
+		if tc.k != 0 && !isPalindrome(tc.s) {
+			expected = "2"
+		}
+		out, err := run(bin, in.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, expected, out, in.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1634/verifierB.go
+++ b/1000-1999/1600-1699/1630-1639/1634/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	x   int64
+	y   int64
+	arr []int64
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(43))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(8) + 1
+		x := rng.Int63n(20)
+		y := rng.Int63n(40)
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = rng.Int63n(20)
+		}
+		cases[i] = testCase{n: n, x: x, y: y, arr: arr}
+	}
+	return cases
+}
+
+func expected(tc testCase) string {
+	parity := int64(0)
+	for _, v := range tc.arr {
+		parity ^= v & 1
+	}
+	alice := (tc.x & 1) ^ parity
+	if alice == (tc.y & 1) {
+		return "Alice"
+	}
+	return "Bob"
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		var in strings.Builder
+		fmt.Fprintf(&in, "1\n%d %d %d\n", tc.n, tc.x, tc.y)
+		for j, v := range tc.arr {
+			if j > 0 {
+				in.WriteByte(' ')
+			}
+			fmt.Fprintf(&in, "%d", v)
+		}
+		in.WriteByte('\n')
+		exp := expected(tc)
+		out, err := run(bin, in.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, out, in.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1634/verifierC.go
+++ b/1000-1999/1600-1699/1630-1639/1634/verifierC.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(44))
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rng.Intn(6) + 1
+		k := rng.Intn(6) + 1
+		var in strings.Builder
+		fmt.Fprintf(&in, "1\n%d %d\n", n, k)
+		tests[i] = in.String()
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	solPath := "./solC.bin"
+	if err := exec.Command("go", "build", "-o", solPath, "1634C.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(solPath)
+
+	tests := genTests()
+	for i, t := range tests {
+		expect, err := run(solPath, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d\nexpected:\n%s\nGot:\n%s", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1634/verifierD.go
+++ b/1000-1999/1600-1699/1630-1639/1634/verifierD.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem D is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1600-1699/1630-1639/1634/verifierE.go
+++ b/1000-1999/1600-1699/1630-1639/1634/verifierE.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(45))
+	tests := make([]string, 100)
+	for i := range tests {
+		m := rng.Intn(3) + 1
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d\n", m)
+		for j := 0; j < m; j++ {
+			n := 2 * (rng.Intn(3) + 1)
+			fmt.Fprintf(&in, "%d\n", n)
+			for k := 0; k < n; k++ {
+				if k > 0 {
+					in.WriteByte(' ')
+				}
+				fmt.Fprintf(&in, "%d", rng.Intn(20)+1)
+			}
+			in.WriteByte('\n')
+		}
+		tests[i] = in.String()
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	solPath := "./solE.bin"
+	if err := exec.Command("go", "build", "-o", solPath, "1634E.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(solPath)
+
+	tests := genTests()
+	for i, t := range tests {
+		expect, err := run(solPath, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d\nexpected:\n%s\nGot:\n%s", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1634/verifierF.go
+++ b/1000-1999/1600-1699/1630-1639/1634/verifierF.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(46))
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rng.Intn(5) + 1
+		q := rng.Intn(5) + 1
+		mod := int64(rng.Intn(1000) + 2)
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d %d %d\n", n, q, mod)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				in.WriteByte(' ')
+			}
+			fmt.Fprintf(&in, "%d", rng.Int63n(mod))
+		}
+		in.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				in.WriteByte(' ')
+			}
+			fmt.Fprintf(&in, "%d", rng.Int63n(mod))
+		}
+		in.WriteByte('\n')
+		for j := 0; j < q; j++ {
+			if rng.Intn(2) == 0 {
+				in.WriteString("A ")
+			} else {
+				in.WriteString("B ")
+			}
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			fmt.Fprintf(&in, "%d %d\n", l, r)
+		}
+		tests[i] = in.String()
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	solPath := "./solF.bin"
+	if err := exec.Command("go", "build", "-o", solPath, "1634F.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(solPath)
+
+	tests := genTests()
+	for i, t := range tests {
+		expect, err := run(solPath, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d\nexpected:\n%s\nGot:\n%s", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go with palindrome check and random tests
- add verifierB.go computing parity logic
- add verifierC.go using official solver as reference
- add simple notifier for interactive problem D
- add verifierE.go and verifierF.go building reference solutions

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68873966b7048324960523ec983491d5