### PR TITLE
Add verifiers for CF 1635

### DIFF
--- a/1000-1999/1600-1699/1630-1639/1635/verifierA.go
+++ b/1000-1999/1600-1699/1630-1639/1635/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1635A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(arr []int) []byte {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(19) + 2 // 2..20
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(1 << 30)
+	}
+	return buildCase(arr)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([][]byte, 0, 100)
+	tests = append(tests, buildCase([]int{0, 0}))
+	tests = append(tests, buildCase([]int{1, 2}))
+	tests = append(tests, buildCase([]int{5, 1, 2, 3}))
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1635/verifierB.go
+++ b/1000-1999/1600-1699/1630-1639/1635/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1635B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(arr []int) []byte {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(19) + 2 // 2..20
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(1_000_000_000) + 1
+	}
+	return buildCase(arr)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(43))
+	tests := make([][]byte, 0, 100)
+	tests = append(tests, buildCase([]int{1, 2}))
+	tests = append(tests, buildCase([]int{5, 3, 4, 2, 1}))
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1635/verifierC.go
+++ b/1000-1999/1600-1699/1630-1639/1635/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1635C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(arr []int) []byte {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(8) + 3 // 3..10
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(200) - 100
+	}
+	return buildCase(arr)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(44))
+	tests := make([][]byte, 0, 100)
+	tests = append(tests, buildCase([]int{1, 2, 3}))
+	tests = append(tests, buildCase([]int{3, 2, 1}))
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1635/verifierD.go
+++ b/1000-1999/1600-1699/1630-1639/1635/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1635D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(n, p int, arr []int) []byte {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, p))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(5) + 1
+	p := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(1000) + 1
+	}
+	return buildCase(n, p, arr)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(45))
+	tests := make([][]byte, 0, 100)
+	tests = append(tests, buildCase(1, 1, []int{1}))
+	tests = append(tests, buildCase(2, 5, []int{1, 2}))
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1635/verifierE.go
+++ b/1000-1999/1600-1699/1630-1639/1635/verifierE.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1635E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(n, m int, rels [][3]int) []byte {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, r := range rels {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", r[0], r[1], r[2]))
+	}
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(n*n) + 1
+	rels := make([][3]int, m)
+	for i := 0; i < m; i++ {
+		typ := rng.Intn(2) + 1
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		for v == u {
+			v = rng.Intn(n) + 1
+		}
+		rels[i] = [3]int{typ, u, v}
+	}
+	return buildCase(n, m, rels)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(46))
+	tests := make([][]byte, 0, 100)
+	tests = append(tests, buildCase(1, 0, nil))
+	tests = append(tests, buildCase(2, 1, [][3]int{{1, 1, 2}}))
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1635/verifierF.go
+++ b/1000-1999/1600-1699/1630-1639/1635/verifierF.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1635F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(n, q int, xs, ws []int64, qs [][2]int) []byte {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", xs[i], ws[i]))
+	}
+	for _, qu := range qs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", qu[0], qu[1]))
+	}
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(5) + 2
+	q := rng.Intn(5) + 1
+	xs := make([]int64, n)
+	ws := make([]int64, n)
+	cur := int64(0)
+	for i := 0; i < n; i++ {
+		cur += int64(rng.Intn(10) + 1)
+		xs[i] = cur
+		ws[i] = int64(rng.Intn(10) + 1)
+	}
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n-1) + 1
+		r := rng.Intn(n-l) + l + 1
+		queries[i] = [2]int{l, r}
+	}
+	return buildCase(n, q, xs, ws, queries)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(47))
+	tests := make([][]byte, 0, 100)
+	xs := []int64{0, 1}
+	ws := []int64{1, 1}
+	tests = append(tests, buildCase(2, 1, xs, ws, [][2]int{{1, 2}}))
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1635 (A–F)
- each verifier builds the reference solution and runs ~100 generated tests

## Testing
- `go build 1000-1999/1600-1699/1630-1639/1635/verifierA.go`
- `go build 1000-1999/1600-1699/1630-1639/1635/verifierB.go`
- `go build 1000-1999/1600-1699/1630-1639/1635/verifierC.go`
- `go build 1000-1999/1600-1699/1630-1639/1635/verifierD.go`
- `go build 1000-1999/1600-1699/1630-1639/1635/verifierE.go`
- `go build 1000-1999/1600-1699/1630-1639/1635/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688739accb308324a9d80cf9623c9f60