### PR TITLE
Add Go solution verifiers for contest 1638

### DIFF
--- a/1000-1999/1600-1699/1630-1639/1638/verifierA.go
+++ b/1000-1999/1600-1699/1630-1639/1638/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	p []int
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1638A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(500) + 1
+		p := rand.Perm(n)
+		for j := range p {
+			p[j]++
+		}
+		cases[i] = testCase{n: n, p: p}
+	}
+	return cases
+}
+
+func runCase(oracle, bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	cases := generateCases()
+	for i, c := range cases {
+		if err := runCase(oracle, bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1638/verifierB.go
+++ b/1000-1999/1600-1699/1630-1639/1638/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	arr []int
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1638B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(50) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(1_000_000_000) + 1
+		}
+		cases[i] = testCase{n: n, arr: arr}
+	}
+	return cases
+}
+
+func runCase(oracle, bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	cases := generateCases()
+	for i, c := range cases {
+		if err := runCase(oracle, bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1638/verifierC.go
+++ b/1000-1999/1600-1699/1630-1639/1638/verifierC.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	p []int
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1638C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(1000) + 1
+		p := rand.Perm(n)
+		for j := range p {
+			p[j]++
+		}
+		cases[i] = testCase{n: n, p: p}
+	}
+	return cases
+}
+
+func runCase(oracle, bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	cases := generateCases()
+	for i, c := range cases {
+		if err := runCase(oracle, bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1638/verifierD.go
+++ b/1000-1999/1600-1699/1630-1639/1638/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m int
+	grid [][]int
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1638D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(10) + 2
+		m := rng.Intn(10) + 2
+		grid := make([][]int, n)
+		for r := 0; r < n; r++ {
+			grid[r] = make([]int, m)
+			for c := 0; c < m; c++ {
+				grid[r][c] = rng.Intn(n*m) + 1
+			}
+		}
+		cases[i] = testCase{n: n, m: m, grid: grid}
+	}
+	return cases
+}
+
+func runCase(oracle, bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for i := 0; i < tc.n; i++ {
+		for j := 0; j < tc.m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(tc.grid[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	cases := generateCases()
+	for i, c := range cases {
+		if err := runCase(oracle, bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1638/verifierE.go
+++ b/1000-1999/1600-1699/1630-1639/1638/verifierE.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n       int
+	queries []string
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1638E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(20) + 1
+		qnum := rng.Intn(30) + 1
+		qs := make([]string, qnum)
+		for j := 0; j < qnum; j++ {
+			t := rng.Intn(3)
+			switch t {
+			case 0:
+				l := rng.Intn(n) + 1
+				r := rng.Intn(n) + 1
+				c := rng.Intn(n) + 1
+				qs[j] = fmt.Sprintf("C %d %d %d", l, r, c)
+			case 1:
+				c := rng.Intn(n) + 1
+				x := rng.Intn(1000) + 1
+				qs[j] = fmt.Sprintf("A %d %d", c, x)
+			default:
+				idx := rng.Intn(n) + 1
+				qs[j] = fmt.Sprintf("Q %d", idx)
+			}
+		}
+		cases[i] = testCase{n: n, queries: qs}
+	}
+	return cases
+}
+
+func runCase(oracle, bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, len(tc.queries)))
+	for _, q := range tc.queries {
+		sb.WriteString(q)
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	cases := generateCases()
+	for i, c := range cases {
+		if err := runCase(oracle, bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1630-1639/1638/verifierF.go
+++ b/1000-1999/1600-1699/1630-1639/1638/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	h []int64
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1638F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(50) + 1
+		h := make([]int64, n)
+		for j := range h {
+			h[j] = rng.Int63n(1_000_000_000) + 1
+		}
+		cases[i] = testCase{n: n, h: h}
+	}
+	return cases
+}
+
+func runCase(oracle, bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.h {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	cases := generateCases()
+	for i, c := range cases {
+		if err := runCase(oracle, bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go through verifierF.go for contest 1638
- verifiers build the corresponding reference solution and run 100 random tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68873a7f05408324a09b2aaec41f4ba3