### PR TITLE
Add verifiers for contest 1652

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1652/verifierA.go
+++ b/1000-1999/1600-1699/1650-1659/1652/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(8) + 2
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d ", r.Intn(1000))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialA"
+	if err := exec.Command("go", "build", "-o", official, "1652A.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1652/verifierB.go
+++ b/1000-1999/1600-1699/1650-1659/1652/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + r.Intn(26))
+	}
+	return string(b)
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(20) + 1
+		s := randString(r, n)
+		tests = append(tests, fmt.Sprintf("1\n%s\n", s))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialB"
+	if err := exec.Command("go", "build", "-o", official, "1652B.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1652/verifierC.go
+++ b/1000-1999/1600-1699/1650-1659/1652/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(3))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d ", r.Intn(20)+1)
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialC"
+	if err := exec.Command("go", "build", "-o", official, "1652C.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1652/verifierD.go
+++ b/1000-1999/1600-1699/1650-1659/1652/verifierD.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(4))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(5) + 2
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 2; i <= n; i++ {
+			u := r.Intn(i-1) + 1
+			x := r.Intn(5) + 1
+			y := r.Intn(5) + 1
+			sb.WriteString(fmt.Sprintf("%d %d %d %d\n", u, i, x, y))
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialD"
+	if err := exec.Command("go", "build", "-o", official, "1652D.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1652/verifierE.go
+++ b/1000-1999/1600-1699/1650-1659/1652/verifierE.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(5))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(9) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d ", r.Intn(50)+1)
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialE"
+	if err := exec.Command("go", "build", "-o", official, "1652E.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1652/verifierF.go
+++ b/1000-1999/1600-1699/1650-1659/1652/verifierF.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + r.Intn(26))
+	}
+	return string(b)
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(6))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(4) + 1
+		s := randString(r, 1<<uint(n))
+		tests = append(tests, fmt.Sprintf("%d\n%s\n", n, s))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialF"
+	if err := exec.Command("go", "build", "-o", official, "1652F.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1652/verifierG.go
+++ b/1000-1999/1600-1699/1650-1659/1652/verifierG.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTree(r *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		u := r.Intn(i-1) + 1
+		edges = append(edges, [2]int{u, i})
+	}
+	return edges
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(7))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(5) + 2
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		ones := 0
+		for i := 0; i < n; i++ {
+			val := r.Intn(2)
+			if i == n-1 && ones == 0 {
+				val = 1
+			}
+			if val == 1 {
+				ones++
+			}
+			fmt.Fprintf(&sb, "%d ", val)
+		}
+		sb.WriteByte('\n')
+		edges := generateTree(r, n)
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialG"
+	if err := exec.Command("go", "build", "-o", official, "1652G.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`..`verifierG.go` with 100 random test cases each
- verifiers compile the official solutions and check a candidate binary against them

## Testing
- `go vet ./...` *(fails: directory prefix does not contain module)*
- `go build ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68873e5387408324911d410d76d32a2c