### PR TITLE
Add Go verifiers for contest 1650

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1650/verifierA.go
+++ b/1000-1999/1600-1699/1650-1659/1650/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(r, &t)
+	var s, c string
+	fmt.Fscan(r, &s)
+	fmt.Fscan(r, &c)
+	for i := 0; i < len(s); i++ {
+		if s[i] == c[0] && i%2 == 0 {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func randString(rng *rand.Rand) string {
+	length := rng.Intn(25)*2 + 1
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	s := randString(rng)
+	c := byte('a' + rng.Intn(26))
+	input := fmt.Sprintf("1\n%s\n%c\n", s, c)
+	out := oracle(input)
+	return input, out
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input, expected := genCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1650/verifierB.go
+++ b/1000-1999/1600-1699/1650-1659/1650/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(r, &t)
+	var l, rVal, a int
+	fmt.Fscan(r, &l, &rVal, &a)
+	ans := rVal/a + rVal%a
+	candidate := rVal - rVal%a - 1
+	if candidate >= l {
+		v := candidate/a + candidate%a
+		if v > ans {
+			ans = v
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	l := rng.Intn(1000) + 1
+	rVal := l + rng.Intn(1000)
+	a := rng.Intn(1000) + 1
+	input := fmt.Sprintf("1\n%d %d %d\n", l, rVal, a)
+	out := oracle(input)
+	return input, out
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < 100; i++ {
+		input, expected := genCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1650/verifierC.go
+++ b/1000-1999/1600-1699/1650-1659/1650/verifierC.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type point struct {
+	x, w int
+	id   int
+}
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(reader, &t)
+	var n, m int
+	fmt.Fscan(reader, &n, &m)
+	pts := make([]point, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(reader, &pts[i].x, &pts[i].w)
+		pts[i].id = i + 1
+	}
+	sort.Slice(pts, func(i, j int) bool {
+		if pts[i].w != pts[j].w {
+			return pts[i].w < pts[j].w
+		}
+		return pts[i].x < pts[j].x
+	})
+	selected := pts[:2*n]
+	sum := 0
+	for _, p := range selected {
+		sum += p.w
+	}
+	sort.Slice(selected, func(i, j int) bool {
+		return selected[i].x < selected[j].x
+	})
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", sum))
+	l, r := 0, len(selected)-1
+	for l < r {
+		sb.WriteString(fmt.Sprintf("%d %d\n", selected[l].id, selected[r].id))
+		l++
+		r--
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := 2*n + rng.Intn(3)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, m)
+	usedX := map[int]bool{}
+	pts := make([]point, m)
+	for i := 0; i < m; i++ {
+		x := rng.Intn(1000) - 500
+		for usedX[x] {
+			x = rng.Intn(1000) - 500
+		}
+		usedX[x] = true
+		w := rng.Intn(20) - 10
+		fmt.Fprintf(&sb, "%d %d\n", x, w)
+		pts[i] = point{x: x, w: w, id: i + 1}
+	}
+	input := sb.String()
+	out := oracle(input)
+	return input, out
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < 100; i++ {
+		input, expected := genCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1650/verifierD.go
+++ b/1000-1999/1600-1699/1650-1659/1650/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(reader, &t)
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	d := make([]int, n)
+	for i := n; i >= 1; i-- {
+		pos := 0
+		for j := 0; j < i; j++ {
+			if a[j] == i {
+				pos = j + 1
+				break
+			}
+		}
+		di := pos % i
+		d[i-1] = di
+		if di > 0 {
+			prefix := append([]int{}, a[di:i]...)
+			prefix = append(prefix, a[:di]...)
+			copy(a[:i], prefix)
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", d[i]))
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", perm[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	out := oracle(input)
+	return input, out
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < 100; i++ {
+		input, expected := genCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1650/verifierE.go
+++ b/1000-1999/1600-1699/1650-1659/1650/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(exe string, test string) (string, error) {
+	return run(exe, "1\n"+test)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	d := rng.Intn(100) + n + 1
+	vals := rng.Perm(d)
+	arr := vals[:n]
+	for i := range arr {
+		arr[i]++
+	}
+	sort.Ints(arr)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, d)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracleExe, oracleCleanup, err := buildExecutable("1650E.go")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build oracle: %v\n", err)
+		os.Exit(1)
+	}
+	defer oracleCleanup()
+	rng := rand.New(rand.NewSource(5))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		expected, err := oracle(oracleExe, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, "1\n"+tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1650/verifierF.go
+++ b/1000-1999/1600-1699/1650-1659/1650/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(exe string, test string) (string, error) {
+	return run(exe, "1\n"+test)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + n
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d", rng.Intn(50)+1)
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		e := rng.Intn(n) + 1
+		t := rng.Intn(20) + 1
+		p := rng.Intn(100) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", e, t, p)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracleExe, oracleCleanup, err := buildExecutable("1650F.go")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build oracle: %v\n", err)
+		os.Exit(1)
+	}
+	defer oracleCleanup()
+	rng := rand.New(rand.NewSource(6))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		expected, err := oracle(oracleExe, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, "1\n"+tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1650/verifierG.go
+++ b/1000-1999/1600-1699/1650-1659/1650/verifierG.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(exe string, test string) (string, error) {
+	return run(exe, "1\n"+test)
+}
+
+func genConnectedGraph(rng *rand.Rand, n, m int) [][2]int {
+	edges := make([][2]int, 0, m)
+	parent := make([]int, n)
+	for i := 0; i < n; i++ {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(a, b int) {
+		pa, pb := find(a), find(b)
+		if pa != pb {
+			parent[pb] = pa
+		}
+	}
+	// create spanning tree first
+	for i := 1; i < n; i++ {
+		u := rng.Intn(i)
+		edges = append(edges, [2]int{u, i})
+		union(u, i)
+	}
+	for len(edges) < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		ok := true
+		for _, e := range edges {
+			if e[0] == u && e[1] == v {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			edges = append(edges, [2]int{u, v})
+		}
+	}
+	return edges
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	maxEdges := n * (n - 1) / 2
+	extra := rng.Intn(maxEdges - (n - 1) + 1)
+	m := (n - 1) + extra
+	s := rng.Intn(n) + 1
+	t := rng.Intn(n) + 1
+	for t == s {
+		t = rng.Intn(n) + 1
+	}
+	edges := genConnectedGraph(rng, n, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	fmt.Fprintf(&sb, "%d %d\n", s, t)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracleExe, oracleCleanup, err := buildExecutable("1650G.go")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build oracle: %v\n", err)
+		os.Exit(1)
+	}
+	defer oracleCleanup()
+	rng := rand.New(rand.NewSource(7))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		expected, err := oracle(oracleExe, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, "1\n"+tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go and verifierB.go with random test generators
- add verifierC.go and verifierD.go implementing reference solutions
- add verifierE.go, verifierF.go and verifierG.go which compile the official solutions as oracles
- each verifier runs 100 randomized tests

## Testing
- `go run verifierA.go ./A_bin`
- `go run verifierE.go ./E_bin`
- `go run verifierF.go ./F_bin`
- `go run verifierG.go ./G_bin`

------
https://chatgpt.com/codex/tasks/task_e_68873dc78a288324ae4e004e380bee0d