### PR TITLE
Add Go verifiers for CF contest 1651

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1651/verifierA.go
+++ b/1000-1999/1600-1699/1650-1659/1651/verifierA.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func runBinary(path string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(path, ".go") {
+        cmd = exec.Command("go", "run", path)
+    } else {
+        cmd = exec.Command(path)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return strings.TrimSpace(string(out)), err
+}
+
+func expected(n int) string {
+    return fmt.Sprintf("%d", (1<<uint(n))-1)
+}
+
+func main() {
+    args := os.Args[1:]
+    if len(args) > 0 && args[0] == "--" {
+        args = args[1:]
+    }
+    if len(args) != 1 {
+        fmt.Fprintln(os.Stderr, "usage: verifierA <binary>")
+        os.Exit(1)
+    }
+    path := args[0]
+    rand.Seed(time.Now().UnixNano())
+
+    for i := 0; i < 100; i++ {
+        n := rand.Intn(30) + 1
+        input := fmt.Sprintf("1\n%d\n", n)
+        want := expected(n)
+        got, err := runBinary(path, input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != want {
+            fmt.Fprintf(os.Stderr, "test %d failed: n=%d expected %s got %s\n", i+1, n, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1600-1699/1650-1659/1651/verifierB.go
+++ b/1000-1999/1600-1699/1650-1659/1651/verifierB.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func runBinary(path string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(path, ".go") {
+        cmd = exec.Command("go", "run", path)
+    } else {
+        cmd = exec.Command(path)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return strings.TrimSpace(string(out)), err
+}
+
+func expected(n int) string {
+    if n > 19 {
+        return "NO"
+    }
+    vals := make([]string, n)
+    val := 1
+    for i := 0; i < n; i++ {
+        vals[i] = fmt.Sprintf("%d", val)
+        val *= 3
+    }
+    return "YES\n" + strings.Join(vals, " ")
+}
+
+func main() {
+    args := os.Args[1:]
+    if len(args) > 0 && args[0] == "--" {
+        args = args[1:]
+    }
+    if len(args) != 1 {
+        fmt.Fprintln(os.Stderr, "usage: verifierB <binary>")
+        os.Exit(1)
+    }
+    path := args[0]
+    rand.Seed(time.Now().UnixNano())
+
+    for i := 0; i < 100; i++ {
+        n := rand.Intn(30) + 1
+        input := fmt.Sprintf("1\n%d\n", n)
+        want := expected(n)
+        got, err := runBinary(path, input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != strings.TrimSpace(want) {
+            fmt.Fprintf(os.Stderr, "test %d failed: n=%d expected %q got %q\n", i+1, n, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1600-1699/1650-1659/1651/verifierC.go
+++ b/1000-1999/1600-1699/1650-1659/1651/verifierC.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func runBinary(path string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(path, ".go") {
+        cmd = exec.Command("go", "run", path)
+    } else {
+        cmd = exec.Command(path)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return strings.TrimSpace(string(out)), err
+}
+
+func abs(x int) int {
+    if x < 0 {
+        return -x
+    }
+    return x
+}
+
+func solveOnce(a, b []int) int64 {
+    n := len(a)
+    minA1, minAn := 1<<60, 1<<60
+    minB1, minBn := 1<<60, 1<<60
+    for i := 0; i < n; i++ {
+        v := abs(a[0] - b[i])
+        if v < minA1 {
+            minA1 = v
+        }
+        v = abs(a[n-1] - b[i])
+        if v < minAn {
+            minAn = v
+        }
+    }
+    for i := 0; i < n; i++ {
+        v := abs(b[0] - a[i])
+        if v < minB1 {
+            minB1 = v
+        }
+        v = abs(b[n-1] - a[i])
+        if v < minBn {
+            minBn = v
+        }
+    }
+    ans := int64(minA1 + minAn + minB1 + minBn)
+    candidate := int64(abs(a[0]-b[0]) + abs(a[n-1]-b[n-1]))
+    if candidate < ans {
+        ans = candidate
+    }
+    candidate = int64(abs(a[0]-b[n-1]) + abs(a[n-1]-b[0]))
+    if candidate < ans {
+        ans = candidate
+    }
+    candidate = int64(abs(a[0]-b[0]) + minAn + minBn)
+    if candidate < ans {
+        ans = candidate
+    }
+    candidate = int64(abs(a[n-1]-b[n-1]) + minA1 + minB1)
+    if candidate < ans {
+        ans = candidate
+    }
+    candidate = int64(abs(a[0]-b[n-1]) + minAn + minB1)
+    if candidate < ans {
+        ans = candidate
+    }
+    candidate = int64(abs(a[n-1]-b[0]) + minA1 + minBn)
+    if candidate < ans {
+        ans = candidate
+    }
+    return ans
+}
+
+func main() {
+    args := os.Args[1:]
+    if len(args) > 0 && args[0] == "--" {
+        args = args[1:]
+    }
+    if len(args) != 1 {
+        fmt.Fprintln(os.Stderr, "usage: verifierC <binary>")
+        os.Exit(1)
+    }
+    path := args[0]
+    rand.Seed(time.Now().UnixNano())
+
+    for test := 0; test < 100; test++ {
+        n := rand.Intn(5) + 1
+        a := make([]int, n)
+        b := make([]int, n)
+        for i := 0; i < n; i++ {
+            a[i] = rand.Intn(20)
+        }
+        for i := 0; i < n; i++ {
+            b[i] = rand.Intn(20)
+        }
+        var buf bytes.Buffer
+        writer := bufio.NewWriter(&buf)
+        fmt.Fprintln(writer, 1)
+        fmt.Fprintln(writer, n)
+        for i := 0; i < n; i++ {
+            if i > 0 {
+                fmt.Fprint(writer, " ")
+            }
+            fmt.Fprint(writer, a[i])
+        }
+        fmt.Fprintln(writer)
+        for i := 0; i < n; i++ {
+            if i > 0 {
+                fmt.Fprint(writer, " ")
+            }
+            fmt.Fprint(writer, b[i])
+        }
+        fmt.Fprintln(writer)
+        writer.Flush()
+        input := buf.String()
+        want := fmt.Sprintf("%d", solveOnce(a, b))
+        got, err := runBinary(path, input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", test+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != want {
+            fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected %s got %s\n", test+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1600-1699/1650-1659/1651/verifierD.go
+++ b/1000-1999/1600-1699/1650-1659/1651/verifierD.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "runtime"
+    "strings"
+    "time"
+)
+
+func runBinary(path string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(path, ".go") {
+        cmd = exec.Command("go", "run", path)
+    } else {
+        cmd = exec.Command(path)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return strings.TrimSpace(string(out)), err
+}
+
+func referenceOutput(input string) (string, error) {
+    _, file, _, ok := runtime.Caller(0)
+    if !ok {
+        return "", fmt.Errorf("cannot determine caller")
+    }
+    dir := filepath.Dir(file)
+    path := filepath.Join(dir, "1651D.go")
+    return runBinary(path, input)
+}
+
+func uniquePairs(n int) [][2]int {
+    used := make(map[[2]int]bool)
+    res := make([][2]int, 0, n)
+    for len(res) < n {
+        x := rand.Intn(50) + 1
+        y := rand.Intn(50) + 1
+        p := [2]int{x, y}
+        if !used[p] {
+            used[p] = true
+            res = append(res, p)
+        }
+    }
+    return res
+}
+
+func main() {
+    args := os.Args[1:]
+    if len(args) > 0 && args[0] == "--" {
+        args = args[1:]
+    }
+    if len(args) != 1 {
+        fmt.Fprintln(os.Stderr, "usage: verifierD <binary>")
+        os.Exit(1)
+    }
+    path := args[0]
+    rand.Seed(time.Now().UnixNano())
+
+    for test := 0; test < 100; test++ {
+        n := rand.Intn(4) + 1
+        pts := uniquePairs(n)
+        var buf bytes.Buffer
+        fmt.Fprintln(&buf, n)
+        for _, p := range pts {
+            fmt.Fprintf(&buf, "%d %d\n", p[0], p[1])
+        }
+        input := buf.String()
+        want, err := referenceOutput(input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "failed to run reference: %v\n", err)
+            os.Exit(1)
+        }
+        got, err := runBinary(path, input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", test+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != strings.TrimSpace(want) {
+            fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", test+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1600-1699/1650-1659/1651/verifierE.go
+++ b/1000-1999/1600-1699/1650-1659/1651/verifierE.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "runtime"
+    "strings"
+    "time"
+)
+
+func runBinary(path string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(path, ".go") {
+        cmd = exec.Command("go", "run", path)
+    } else {
+        cmd = exec.Command(path)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return strings.TrimSpace(string(out)), err
+}
+
+func referenceOutput(input string) (string, error) {
+    _, file, _, _ := runtime.Caller(0)
+    path := filepath.Join(filepath.Dir(file), "1651E.go")
+    return runBinary(path, input)
+}
+
+func buildGraph(n int) [][2]int {
+    edges := make([][2]int, 0, 2*n)
+    for i := 1; i <= n; i++ {
+        edges = append(edges, [2]int{i, n + i})
+        j := i % n + 1
+        edges = append(edges, [2]int{i, n + j})
+    }
+    return edges
+}
+
+func main() {
+    args := os.Args[1:]
+    if len(args) > 0 && args[0] == "--" {
+        args = args[1:]
+    }
+    if len(args) != 1 {
+        fmt.Fprintln(os.Stderr, "usage: verifierE <binary>")
+        os.Exit(1)
+    }
+    path := args[0]
+    rand.Seed(time.Now().UnixNano())
+
+    for test := 0; test < 100; test++ {
+        n := rand.Intn(3) + 2
+        edges := buildGraph(n)
+        var buf bytes.Buffer
+        fmt.Fprintln(&buf, n)
+        for _, e := range edges {
+            fmt.Fprintf(&buf, "%d %d\n", e[0], e[1])
+        }
+        input := buf.String()
+        want, err := referenceOutput(input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "reference error: %v\n", err)
+            os.Exit(1)
+        }
+        got, err := runBinary(path, input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", test+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != strings.TrimSpace(want) {
+            fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", test+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1600-1699/1650-1659/1651/verifierF.go
+++ b/1000-1999/1600-1699/1650-1659/1651/verifierF.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "runtime"
+    "strings"
+    "time"
+)
+
+func runBinary(path string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(path, ".go") {
+        cmd = exec.Command("go", "run", path)
+    } else {
+        cmd = exec.Command(path)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return strings.TrimSpace(string(out)), err
+}
+
+func referenceOutput(input string) (string, error) {
+    _, file, _, _ := runtime.Caller(0)
+    path := filepath.Join(filepath.Dir(file), "1651F.go")
+    return runBinary(path, input)
+}
+
+func main() {
+    args := os.Args[1:]
+    if len(args) > 0 && args[0] == "--" {
+        args = args[1:]
+    }
+    if len(args) != 1 {
+        fmt.Fprintln(os.Stderr, "usage: verifierF <binary>")
+        os.Exit(1)
+    }
+    path := args[0]
+    rand.Seed(time.Now().UnixNano())
+
+    for test := 0; test < 100; test++ {
+        n := rand.Intn(3) + 1
+        var buf bytes.Buffer
+        fmt.Fprintln(&buf, n)
+        for i := 0; i < n; i++ {
+            c := rand.Int63n(20) + 1
+            r := rand.Int63n(c) + 1
+            fmt.Fprintf(&buf, "%d %d\n", c, r)
+        }
+        q := rand.Intn(3) + 1
+        fmt.Fprintln(&buf, q)
+        t := int64(0)
+        for j := 0; j < q; j++ {
+            t += rand.Int63n(5) + 1
+            h := rand.Int63n(50) + 1
+            fmt.Fprintf(&buf, "%d %d\n", t, h)
+        }
+        input := buf.String()
+        want, err := referenceOutput(input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "reference error: %v\n", err)
+            os.Exit(1)
+        }
+        got, err := runBinary(path, input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", test+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != strings.TrimSpace(want) {
+            fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", test+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1651
- verifiers generate 100+ random tests and can run given binaries or Go files

## Testing
- `go run verifierA.go -- 1651A.go`
- `go run verifierB.go -- 1651B.go`
- `go run verifierC.go -- 1651C.go`
- `go run verifierD.go -- 1651D.go`
- `go run verifierE.go -- 1651E.go`
- `go run verifierF.go -- 1651F.go`


------
https://chatgpt.com/codex/tasks/task_e_68873e0d5c108324abd26251d3c0f258