### PR TITLE
Add verifiers for contest 1657

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1657/verifierA.go
+++ b/1000-1999/1600-1699/1650-1659/1657/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct{ x, y int }
+
+func genTestsA() []testCaseA {
+	rng := rand.New(rand.NewSource(42))
+	tests := []testCaseA{
+		{0, 0}, {3, 4}, {5, 12}, {1, 0}, {0, 1},
+	}
+	for len(tests) < 100 {
+		tests = append(tests, testCaseA{rng.Intn(51), rng.Intn(51)})
+	}
+	return tests
+}
+
+func solveA(tc testCaseA) string {
+	if tc.x == 0 && tc.y == 0 {
+		return "0"
+	}
+	d2 := tc.x*tc.x + tc.y*tc.y
+	r := int(math.Round(math.Sqrt(float64(d2))))
+	if r*r == d2 {
+		return "1"
+	}
+	return "2"
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := genTestsA()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d\n", tc.x, tc.y)
+		exp := solveA(tc)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1657/verifierB.go
+++ b/1000-1999/1600-1699/1650-1659/1657/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// test case for problem B
+
+type testCaseB struct {
+	n int
+	B int64
+	x int64
+	y int64
+}
+
+func genTestsB() []testCaseB {
+	rng := rand.New(rand.NewSource(43))
+	tests := []testCaseB{
+		{1, 1, 1, 1}, {3, 5, 2, 1}, {5, 10, 3, 4},
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(20) + 1
+		B := rng.Int63n(100) + 1
+		x := rng.Int63n(50) + 1
+		y := rng.Int63n(50) + 1
+		tests = append(tests, testCaseB{n, int64(B), x, y})
+	}
+	return tests
+}
+
+func solveB(tc testCaseB) string {
+	cur := int64(0)
+	sum := int64(0)
+	for i := 0; i < tc.n; i++ {
+		if cur+tc.x <= tc.B {
+			cur += tc.x
+		} else {
+			cur -= tc.y
+		}
+		sum += cur
+	}
+	return fmt.Sprint(sum)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := genTestsB()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d %d %d\n", tc.n, tc.B, tc.x, tc.y)
+		exp := solveB(tc)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1657/verifierC.go
+++ b/1000-1999/1600-1699/1650-1659/1657/verifierC.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const base uint64 = 911382323
+
+type testCaseC struct {
+	s string
+}
+
+func genTestsC() []testCaseC {
+	rng := rand.New(rand.NewSource(44))
+	tests := []testCaseC{
+		{"()"}, {"(("}, {"())("}, {"(()())"},
+	}
+	letters := []byte{'(', ')'}
+	for len(tests) < 100 {
+		n := rng.Intn(12) + 1
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b[i] = letters[rng.Intn(2)]
+		}
+		tests = append(tests, testCaseC{string(b)})
+	}
+	return tests
+}
+
+func solveC(tc testCaseC) string {
+	b := []byte(tc.s)
+	n := len(b)
+	pow := make([]uint64, n+1)
+	pref := make([]uint64, n+1)
+	pow[0] = 1
+	for i := 0; i < n; i++ {
+		pref[i+1] = pref[i]*base + uint64(b[i])
+		pow[i+1] = pow[i] * base
+	}
+	rev := make([]byte, n)
+	for i := 0; i < n; i++ {
+		rev[i] = b[n-1-i]
+	}
+	rpref := make([]uint64, n+1)
+	for i := 0; i < n; i++ {
+		rpref[i+1] = rpref[i]*base + uint64(rev[i])
+	}
+	isPal := func(l, r int) bool {
+		hf := pref[r+1] - pref[l]*pow[r-l+1]
+		hr := rpref[n-l] - rpref[n-1-r]*pow[r-l+1]
+		return hf == hr
+	}
+	i := 0
+	ops := 0
+	for i < n {
+		bal := 0
+		minBal := 0
+		found := false
+		for j := i; j < n; j++ {
+			if b[j] == '(' {
+				bal++
+			} else {
+				bal--
+			}
+			if bal < minBal {
+				minBal = bal
+			}
+			if bal == 0 && minBal >= 0 {
+				ops++
+				i = j + 1
+				found = true
+				break
+			}
+			if j-i+1 >= 2 && isPal(i, j) {
+				ops++
+				i = j + 1
+				found = true
+				break
+			}
+		}
+		if !found {
+			break
+		}
+	}
+	return fmt.Sprintf("%d %d", ops, n-i)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	tests := genTestsC()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d\n%s\n", len(tc.s), tc.s)
+		exp := solveC(tc)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1657/verifierD.go
+++ b/1000-1999/1600-1699/1650-1659/1657/verifierD.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type unit struct {
+	c int
+	d int64
+	h int64
+}
+type monster struct {
+	D int64
+	H int64
+}
+
+type testCaseD struct {
+	n        int
+	C        int
+	units    []unit
+	monsters []monster
+}
+
+func genTestsD() []testCaseD {
+	rng := rand.New(rand.NewSource(45))
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rng.Intn(4) + 1
+		C := rng.Intn(20) + 5
+		units := make([]unit, n)
+		for j := 0; j < n; j++ {
+			c := rng.Intn(C) + 1
+			d := int64(rng.Intn(10) + 1)
+			h := int64(rng.Intn(10) + 1)
+			units[j] = unit{c, d, h}
+		}
+		m := rng.Intn(3) + 1
+		mons := make([]monster, m)
+		for j := 0; j < m; j++ {
+			D := int64(rng.Intn(15) + 1)
+			H := int64(rng.Intn(30) + 1)
+			mons[j] = monster{D, H}
+		}
+		tests[i] = testCaseD{n, C, units, mons}
+	}
+	return tests
+}
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "1657D_ref")
+	cmd := exec.Command("go", "build", "-o", exe, "1657D.go")
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	tests := genTestsD()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.C)
+		for _, u := range tc.units {
+			fmt.Fprintf(&sb, "%d %d %d\n", u.c, u.d, u.h)
+		}
+		fmt.Fprintf(&sb, "%d\n", len(tc.monsters))
+		for _, m := range tc.monsters {
+			fmt.Fprintf(&sb, "%d %d\n", m.D, m.H)
+		}
+		input := sb.String()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1657/verifierE.go
+++ b/1000-1999/1600-1699/1650-1659/1657/verifierE.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCaseE struct{ n, k int }
+
+func genTestsE() []testCaseE {
+	rng := rand.New(rand.NewSource(46))
+	tests := []testCaseE{{2, 1}, {3, 2}, {4, 3}}
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 2
+		k := rng.Intn(8) + 1
+		tests = append(tests, testCaseE{n, k})
+	}
+	return tests
+}
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "1657E_ref")
+	cmd := exec.Command("go", "build", "-o", exe, "1657E.go")
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	tests := genTestsE()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d\n", tc.n, tc.k)
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1657/verifierF.go
+++ b/1000-1999/1600-1699/1650-1659/1657/verifierF.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type query struct {
+	x, y int
+	s    string
+}
+
+type testCaseF struct {
+	n     int
+	edges [][2]int
+	qs    []query
+}
+
+func genTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	return edges
+}
+
+func genTestsF() []testCaseF {
+	rng := rand.New(rand.NewSource(47))
+	tests := make([]testCaseF, 100)
+	for i := range tests {
+		n := rng.Intn(6) + 2
+		edges := genTree(rng, n)
+		q := rng.Intn(3) + 1
+		qs := make([]query, q)
+		for j := 0; j < q; j++ {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(n) + 1
+			// path length upper bound n
+			l := rng.Intn(n) + 1
+			b := make([]byte, l)
+			for k := 0; k < l; k++ {
+				b[k] = byte('a' + rng.Intn(3))
+			}
+			qs[j] = query{x, y, string(b)}
+		}
+		tests[i] = testCaseF{n, edges, qs}
+	}
+	return tests
+}
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "1657F_ref")
+	cmd := exec.Command("go", "build", "-o", exe, "1657F.go")
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	tests := genTestsF()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, len(tc.qs))
+		for _, e := range tc.edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+		}
+		for _, q := range tc.qs {
+			fmt.Fprintf(&sb, "%d %d %s\n", q.x, q.y, q.s)
+		}
+		input := sb.String()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A-F of contest 1657
- verifiers A-C embed expected logic and random test generation
- verifiers D-F compile the provided reference solutions and compare outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68873fb19c008324a7d46beffa7b2031