### PR TITLE
Add Go solution verifiers for contest 1659

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1659/verifierA.go
+++ b/1000-1999/1600-1699/1650-1659/1659/verifierA.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(in string) (string, error) {
+	cmd := exec.Command("go", "run", "1659A.go")
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(98) + 3
+		b := rand.Intn(n/2) + 1
+		r := n - b
+		input := fmt.Sprintf("1\n%d %d %d\n", n, r, b)
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed: expected %s got %s\n", t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1650-1659/1659/verifierB.go
+++ b/1000-1999/1600-1699/1650-1659/1659/verifierB.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(in string) (string, error) {
+	cmd := exec.Command("go", "run", "1659B.go")
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(20)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 1 {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('0')
+			}
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed: expected %s got %s\ninput:%s\n", t, exp, got, strings.ReplaceAll(input, "\n", " "))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1650-1659/1659/verifierC.go
+++ b/1000-1999/1600-1699/1650-1659/1659/verifierC.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(in string) (string, error) {
+	cmd := exec.Command("go", "run", "1659C.go")
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(10) + 1
+		a := rand.Intn(20) + 1
+		b := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d %d %d\n", n, a, b)
+		cur := 0
+		for i := 0; i < n; i++ {
+			cur += rand.Intn(10) + 1
+			fmt.Fprintf(&sb, "%d ", cur)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed: expected %s got %s\ninput:%s\n", t, exp, got, strings.ReplaceAll(input, "\n", " "))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1650-1659/1659/verifierD.go
+++ b/1000-1999/1600-1699/1650-1659/1659/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func run(bin, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(in string) (string, error) {
+	cmd := exec.Command("go", "run", "1659D.go")
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	n := rand.Intn(10) + 1
+	A := make([]int, n)
+	for i := 0; i < n; i++ {
+		A[i] = rand.Intn(2)
+	}
+	C := make([]int, n)
+	for k := 1; k <= n; k++ {
+		tmp := append([]int(nil), A...)
+		sort.Ints(tmp[:k])
+		for i := 0; i < n; i++ {
+			C[i] += tmp[i]
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", C[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		input := genCase()
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\nexpected: %s\ngot: %s\n", t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1650-1659/1659/verifierE.go
+++ b/1000-1999/1600-1699/1650-1659/1659/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type edge struct{ u, v, w int }
+
+func run(bin, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(in string) (string, error) {
+	cmd := exec.Command("go", "run", "1659E.go")
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	n := rand.Intn(7) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rand.Intn(min(maxEdges, 10)-(n-1)+1) + (n - 1)
+	edges := make([]edge, 0, m)
+	parent := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(a, b int) {
+		fa, fb := find(a), find(b)
+		if fa != fb {
+			parent[fb] = fa
+		}
+	}
+	// Build tree edges
+	for i := 2; i <= n; i++ {
+		j := rand.Intn(i-1) + 1
+		w := rand.Intn(16)
+		edges = append(edges, edge{j, i, w})
+		union(j, i)
+	}
+	used := make(map[string]bool)
+	for _, e := range edges {
+		used[fmt.Sprintf("%d-%d", min(e.u, e.v), max(e.u, e.v))] = true
+	}
+	for len(edges) < m {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		key := fmt.Sprintf("%d-%d", min(u, v), max(u, v))
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		w := rand.Intn(16)
+		edges = append(edges, edge{u, v, w})
+	}
+	q := rand.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(edges))
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e.u, e.v, e.w)
+	}
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < q; i++ {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d\n", u, v)
+	}
+	return sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		input := genCase()
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\nexpected: %s\ngot: %s\n", t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1650-1659/1659/verifierF.go
+++ b/1000-1999/1600-1699/1650-1659/1659/verifierF.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(in string) (string, error) {
+	cmd := exec.Command("go", "run", "1659F.go")
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	n := rand.Intn(8) + 3
+	x := rand.Intn(n) + 1
+	type edge struct{ u, v int }
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ { // build tree
+		j := rand.Intn(i-1) + 1
+		edges = append(edges, edge{j, i})
+	}
+	perm := rand.Perm(n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, x)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		input := genCase()
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d exec failed: %v\n", t, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\nexpected: %s\ngot: %s\n", t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for all problems in contest 1659
- each verifier runs 100 randomized tests using the repository reference solution

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6887403d9f0c83249d0635b8fb047dc3