### PR TITLE
Add solution verifiers for Codeforces 1658

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1658/verifierA.go
+++ b/1000-1999/1600-1699/1650-1659/1658/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1658A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1))
+	cases := make([]Case, 0, 105)
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(4) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Intn(100) + 1
+			fmt.Fprintf(&sb, "%d\n", n)
+			for k := 0; k < n; k++ {
+				if rng.Intn(2) == 0 {
+					sb.WriteByte('0')
+				} else {
+					sb.WriteByte('1')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	cases = append(cases, Case{"1\n1\n0\n"})
+	cases = append(cases, Case{"1\n2\n00\n"})
+	cases = append(cases, Case{"1\n3\n010\n"})
+	cases = append(cases, Case{"2\n3\n000\n1\n1\n"})
+	cases = append(cases, Case{"1\n1\n1\n"})
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runExe(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, c.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1658/verifierB.go
+++ b/1000-1999/1600-1699/1650-1659/1658/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1658B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(2))
+	cases := make([]Case, 0, 105)
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Intn(1000) + 1
+			fmt.Fprintf(&sb, "%d\n", n)
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	cases = append(cases, Case{"1\n1\n"})
+	cases = append(cases, Case{"1\n2\n"})
+	cases = append(cases, Case{"1\n3\n"})
+	cases = append(cases, Case{"1\n4\n"})
+	cases = append(cases, Case{"1\n6\n"})
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runExe(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, c.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1658/verifierC.go
+++ b/1000-1999/1600-1699/1650-1659/1658/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1658C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(3))
+	cases := make([]Case, 0, 105)
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Intn(20) + 1
+			fmt.Fprintf(&sb, "%d\n", n)
+			for k := 0; k < n; k++ {
+				if k > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprintf(&sb, "%d", rng.Intn(n)+1)
+			}
+			sb.WriteByte('\n')
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	cases = append(cases, Case{"1\n1\n1\n"})
+	cases = append(cases, Case{"1\n2\n1 1\n"})
+	cases = append(cases, Case{"1\n3\n1 2 3\n"})
+	cases = append(cases, Case{"1\n6\n2 3 1 2 3 4\n"})
+	cases = append(cases, Case{"2\n1\n1\n1\n1\n"})
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runExe(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, c.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1658/verifierD1.go
+++ b/1000-1999/1600-1699/1650-1659/1658/verifierD1.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "refD1.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1658D1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(4))
+	cases := make([]Case, 0, 105)
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Intn(20) + 1
+			l := rng.Intn((1 << 17) - n)
+			r := l + n - 1
+			x := rng.Intn(1 << 17)
+			fmt.Fprintf(&sb, "%d %d\n", l, r)
+			for k := 0; k < n; k++ {
+				if k > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprintf(&sb, "%d", (l+k)^x)
+			}
+			sb.WriteByte('\n')
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	cases = append(cases, Case{"1\n0 3\n3 2 1 0\n"})
+	cases = append(cases, Case{"1\n1 3\n0 2 3\n"})
+	cases = append(cases, Case{"1\n2 2\n0\n"})
+	cases = append(cases, Case{"1\n0 0\n0\n"})
+	cases = append(cases, Case{"2\n0 1\n1 0\n0 0\n0\n"})
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runExe(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, c.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1658/verifierD2.go
+++ b/1000-1999/1600-1699/1650-1659/1658/verifierD2.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "refD2.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1658D2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(5))
+	cases := make([]Case, 0, 105)
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Intn(20) + 1
+			l := rng.Intn((1 << 17) - n)
+			r := l + n - 1
+			x := rng.Intn(1 << 17)
+			fmt.Fprintf(&sb, "%d %d\n", l, r)
+			for k := 0; k < n; k++ {
+				if k > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprintf(&sb, "%d", (l+k)^x)
+			}
+			sb.WriteByte('\n')
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	cases = append(cases, Case{"1\n0 3\n7 6 5 4\n"})
+	cases = append(cases, Case{"1\n1 4\n4 7 6 5\n"})
+	cases = append(cases, Case{"1\n2 4\n3 1 2\n"})
+	cases = append(cases, Case{"1\n0 0\n0\n"})
+	cases = append(cases, Case{"2\n0 1\n1 0\n0 0\n0\n"})
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runExe(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, c.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1658/verifierE.go
+++ b/1000-1999/1600-1699/1650-1659/1658/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1658E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(6))
+	cases := make([]Case, 0, 105)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 3
+		k := rng.Intn(n-2) + 1
+		nums := make([]int, n*n)
+		for j := range nums {
+			nums[j] = j + 1
+		}
+		rng.Shuffle(len(nums), func(a, b int) { nums[a], nums[b] = nums[b], nums[a] })
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		idx := 0
+		for r := 0; r < n; r++ {
+			for c := 0; c < n; c++ {
+				if c > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(strconv.Itoa(nums[idx]))
+				idx++
+			}
+			sb.WriteByte('\n')
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	cases = append(cases, Case{"3 1\n1 2 3\n4 5 6\n7 8 9\n"})
+	cases = append(cases, Case{"4 2\n1 2 3 4\n5 6 7 8\n9 10 11 12\n13 14 15 16\n"})
+	cases = append(cases, Case{"3 1\n9 1 2\n3 4 5\n6 7 8\n"})
+	cases = append(cases, Case{"5 2\n1 2 3 4 5\n6 7 8 9 10\n11 12 13 14 15\n16 17 18 19 20\n21 22 23 24 25\n"})
+	cases = append(cases, Case{"3 1\n1 3 5\n7 9 2\n4 6 8\n"})
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runExe(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, c.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1650-1659/1658/verifierF.go
+++ b/1000-1999/1600-1699/1650-1659/1658/verifierF.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1658F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(7))
+	cases := make([]Case, 0, 105)
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Intn(50) + 1
+			m := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "%d %d\n", n, m)
+			for k := 0; k < n; k++ {
+				if rng.Intn(2) == 0 {
+					sb.WriteByte('0')
+				} else {
+					sb.WriteByte('1')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	cases = append(cases, Case{"1\n1 1\n0\n"})
+	cases = append(cases, Case{"1\n4 2\n1100\n"})
+	cases = append(cases, Case{"1\n8 6\n11000011\n"})
+	cases = append(cases, Case{"1\n4 4\n0101\n"})
+	cases = append(cases, Case{"2\n3 1\n101\n2 2\n01\n"})
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		exp, err := runExe(ref, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, c.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest **1658**
- each verifier builds the reference solution and runs >=100 randomized test cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD1.go`
- `go build verifierD2.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68873ff7a28083249e5ec1f0e0a90185