### PR TITLE
Add verifiers for Codeforces Round 1660

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1660/verifierA.go
+++ b/1000-1999/1600-1699/1660-1669/1660/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildBinary(src, tag string) (string, error) {
+	if strings.HasSuffix(src, ".go") {
+		out := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", src, err, string(outb))
+		}
+		return out, nil
+	}
+	return src, nil
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func solveCase(a, b int) int {
+	if a == 0 {
+		return 1
+	}
+	return a + 2*b + 1
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	a := r.Intn(100000001)
+	b := r.Intn(100000001)
+	input := fmt.Sprintf("1\n%d %d\n", a, b)
+	expect := fmt.Sprintf("%d\n", solveCase(a, b))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candSrc := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "1660A.go")
+
+	cand, err := buildBinary(candSrc, "candA.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildBinary(refSrc, "refA.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		// sanity check using the reference solution
+		if err := runCase(ref, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		if err := runCase(cand, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1660/verifierB.go
+++ b/1000-1999/1600-1699/1660-1669/1660/verifierB.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+func buildBinary(src, tag string) (string, error) {
+	if strings.HasSuffix(src, ".go") {
+		out := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", src, err, string(outb))
+		}
+		return out, nil
+	}
+	return src, nil
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func solveCase(arr []int) string {
+	n := len(arr)
+	if n == 1 {
+		if arr[0] == 1 {
+			return "YES"
+		}
+		return "NO"
+	}
+	sort.Ints(arr)
+	if arr[n-1]-arr[n-2] <= 1 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = r.Intn(10) + 1
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", arr[i])
+	}
+	b.WriteByte('\n')
+	input := b.String()
+	expect := fmt.Sprintf("%s\n", solveCase(arr))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candSrc := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "1660B.go")
+
+	cand, err := buildBinary(candSrc, "candB.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildBinary(refSrc, "refB.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(ref, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		if err := runCase(cand, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1660/verifierC.go
+++ b/1000-1999/1600-1699/1660-1669/1660/verifierC.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildBinary(src, tag string) (string, error) {
+	if strings.HasSuffix(src, ".go") {
+		out := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", src, err, string(outb))
+		}
+		return out, nil
+	}
+	return src, nil
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func solveCase(s string) int {
+	dp := make([]int, 26)
+	for i := 0; i < 26; i++ {
+		dp[i] = math.MinInt32
+	}
+	dpNo := 0
+	for _, ch := range s {
+		idx := int(ch - 'a')
+		newDp := make([]int, 26)
+		copy(newDp, dp)
+		newDpNo := dpNo
+		if newDp[idx] < dpNo {
+			newDp[idx] = dpNo
+		}
+		for c := 0; c < 26; c++ {
+			if newDp[idx] < dp[c] {
+				newDp[idx] = dp[c]
+			}
+		}
+		if dp[idx] != math.MinInt32 && dp[idx]+2 > newDpNo {
+			newDpNo = dp[idx] + 2
+		}
+		dp = newDp
+		dpNo = newDpNo
+	}
+	return len(s) - dpNo
+}
+
+func randString(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(r.Intn(26) + 'a')
+	}
+	return string(b)
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(20) + 1
+	s := randString(r, n)
+	input := fmt.Sprintf("1\n%s\n", s)
+	expect := fmt.Sprintf("%d\n", solveCase(s))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candSrc := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "1660C.go")
+
+	cand, err := buildBinary(candSrc, "candC.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildBinary(refSrc, "refC.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(ref, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		if err := runCase(cand, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1660/verifierD.go
+++ b/1000-1999/1600-1699/1660-1669/1660/verifierD.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildBinary(src, tag string) (string, error) {
+	if strings.HasSuffix(src, ".go") {
+		out := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", src, err, string(outb))
+		}
+		return out, nil
+	}
+	return src, nil
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solveCase(arr []int) (int, int) {
+	n := len(arr)
+	p, l, r := 0, 0, 0
+	j := -1
+	for i := 0; i <= n; i++ {
+		if i == n || arr[i] == 0 {
+			mn0x, mn0y := 0, j+1
+			mn1x, mn1y := n, -1
+			pw, sign := 0, 0
+			for k := j + 1; k < i; k++ {
+				if arr[k] < 0 {
+					sign ^= 1
+				}
+				if abs(arr[k]) == 2 {
+					pw++
+				}
+				if sign == 0 {
+					if pw-mn0x > p {
+						p = pw - mn0x
+						l = mn0y
+						r = k + 1
+					}
+				} else {
+					if pw-mn1x > p {
+						p = pw - mn1x
+						l = mn1y
+						r = k + 1
+					}
+				}
+				if sign == 0 {
+					if pw < mn0x {
+						mn0x = pw
+						mn0y = k + 1
+					}
+				} else {
+					if pw < mn1x {
+						mn1x = pw
+						mn1y = k + 1
+					}
+				}
+			}
+			j = i
+		}
+	}
+	return l, n - r
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = r.Intn(5) - 2 // -2..2
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", arr[i])
+	}
+	b.WriteByte('\n')
+	l, y := solveCase(arr)
+	expect := fmt.Sprintf("%d %d\n", l, y)
+	return b.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candSrc := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "1660D.go")
+
+	cand, err := buildBinary(candSrc, "candD.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildBinary(refSrc, "refD.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(ref, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		if err := runCase(cand, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1660/verifierE.go
+++ b/1000-1999/1600-1699/1660-1669/1660/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildBinary(src, tag string) (string, error) {
+	if strings.HasSuffix(src, ".go") {
+		out := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", src, err, string(outb))
+		}
+		return out, nil
+	}
+	return src, nil
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func solveCase(n int, rows []string) int {
+	diag := make([]int, n)
+	total := 0
+	for i := 0; i < n; i++ {
+		row := rows[i]
+		for j := 0; j < n; j++ {
+			if row[j] == '1' {
+				total++
+				diff := (i - j + n) % n
+				diag[diff]++
+			}
+		}
+	}
+	best := 0
+	for i := 0; i < n; i++ {
+		if diag[i] > best {
+			best = diag[i]
+		}
+	}
+	return n + total - 2*best
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(10) + 1
+	rows := make([]string, n)
+	for i := range rows {
+		b := make([]byte, n)
+		for j := range b {
+			if r.Intn(2) == 1 {
+				b[j] = '1'
+			} else {
+				b[j] = '0'
+			}
+		}
+		rows[i] = string(b)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(rows[i])
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expect := fmt.Sprintf("%d\n", solveCase(n, rows))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candSrc := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "1660E.go")
+
+	cand, err := buildBinary(candSrc, "candE.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildBinary(refSrc, "refE.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(ref, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		if err := runCase(cand, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1660/verifierF1.go
+++ b/1000-1999/1600-1699/1660-1669/1660/verifierF1.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildBinary(src, tag string) (string, error) {
+	if strings.HasSuffix(src, ".go") {
+		out := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", src, err, string(outb))
+		}
+		return out, nil
+	}
+	return src, nil
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func solveCase(n int, s string) int {
+	ans := 0
+	for i := 0; i < n; i++ {
+		diff := 0
+		pairs := 0
+		run := 0
+		for j := i; j < n; j++ {
+			if s[j] == '-' {
+				diff++
+				run++
+				if run%2 == 0 {
+					pairs++
+				}
+			} else {
+				diff--
+				run = 0
+			}
+			if diff >= 0 && diff%3 == 0 && pairs >= diff/3 {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func randString(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if r.Intn(2) == 0 {
+			b[i] = '+'
+		} else {
+			b[i] = '-'
+		}
+	}
+	return string(b)
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(10) + 1
+	s := randString(r, n)
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	expect := fmt.Sprintf("%d\n", solveCase(n, s))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF1.go /path/to/binary")
+		return
+	}
+	candSrc := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "1660F1.go")
+
+	cand, err := buildBinary(candSrc, "candF1.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildBinary(refSrc, "refF1.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(ref, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		if err := runCase(cand, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1660/verifierF2.go
+++ b/1000-1999/1600-1699/1660-1669/1660/verifierF2.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type BIT struct {
+	n    int
+	tree []int
+}
+
+func NewBIT(n int) *BIT {
+	b := &BIT{n: n + 2, tree: make([]int, n+3)}
+	return b
+}
+
+func (b *BIT) Add(idx, val int) {
+	idx++
+	for idx <= b.n {
+		b.tree[idx] += val
+		idx += idx & -idx
+	}
+}
+
+func (b *BIT) Sum(idx int) int {
+	if idx < 0 {
+		return 0
+	}
+	if idx >= b.n {
+		idx = b.n - 1
+	}
+	idx++
+	res := 0
+	for idx > 0 {
+		res += b.tree[idx]
+		idx -= idx & -idx
+	}
+	return res
+}
+
+func buildBinary(src, tag string) (string, error) {
+	if strings.HasSuffix(src, ".go") {
+		out := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", src, err, string(outb))
+		}
+		return out, nil
+	}
+	return src, nil
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func solveCase(n int, s string) int64 {
+	size := 2*n + 5
+	bits := []*BIT{NewBIT(size), NewBIT(size), NewBIT(size)}
+	offset := n + 2
+	sum := 0
+	bits[sum%3].Add(sum+offset, 1)
+	var ans int64
+	for i := 0; i < n; i++ {
+		if s[i] == '+' {
+			sum--
+		} else {
+			sum++
+		}
+		mod := ((sum % 3) + 3) % 3
+		idx := sum + offset
+		ans += int64(bits[mod].Sum(idx))
+		bits[mod].Add(idx, 1)
+	}
+	return ans
+}
+
+func randString(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if r.Intn(2) == 0 {
+			b[i] = '+'
+		} else {
+			b[i] = '-'
+		}
+	}
+	return string(b)
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(50) + 1
+	s := randString(r, n)
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	expect := fmt.Sprintf("%d\n", solveCase(n, s))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF2.go /path/to/binary")
+		return
+	}
+	candSrc := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "1660F2.go")
+
+	cand, err := buildBinary(candSrc, "candF2.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildBinary(refSrc, "refF2.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(ref, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		if err := runCase(cand, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest 1660
- verifiers build the candidate binary, run 100 random tests and compare with the official solution logic

## Testing
- `gofmt -w 1000-1999/1600-1699/1660-1669/1660/verifierA.go`
- `gofmt -w 1000-1999/1600-1699/1660-1669/1660/verifierB.go`
- `gofmt -w 1000-1999/1600-1699/1660-1669/1660/verifierC.go`
- `gofmt -w 1000-1999/1600-1699/1660-1669/1660/verifierD.go`
- `gofmt -w 1000-1999/1600-1699/1660-1669/1660/verifierE.go`
- `gofmt -w 1000-1999/1600-1699/1660-1669/1660/verifierF1.go`
- `gofmt -w 1000-1999/1600-1699/1660-1669/1660/verifierF2.go`


------
https://chatgpt.com/codex/tasks/task_e_68874083d7848324b722576fdaae0b28