### PR TITLE
Add solution verifiers for contest 1661

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1661/verifierA.go
+++ b/1000-1999/1600-1699/1660-1669/1661/verifierA.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(a, b []int64) int64 {
+	n := len(a)
+	for i := 0; i < n; i++ {
+		if a[i] > b[i] {
+			a[i], b[i] = b[i], a[i]
+		}
+	}
+	var ans int64
+	abs := func(x int64) int64 {
+		if x < 0 {
+			return -x
+		}
+		return x
+	}
+	for i := 0; i+1 < n; i++ {
+		ans += abs(a[i]-a[i+1]) + abs(b[i]-b[i+1])
+	}
+	return ans
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	// deterministic edge cases
+	cases = append(cases, func() testCase {
+		a := []int64{1, 1}
+		b := []int64{1, 1}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString("2\n1 1\n1 1\n")
+		exp := fmt.Sprintf("%d", solveCase(append([]int64(nil), a...), append([]int64(nil), b...)))
+		return testCase{input: sb.String(), expected: exp}
+	}())
+	for len(cases) < 100 {
+		n := rng.Intn(24) + 2
+		a := make([]int64, n)
+		b := make([]int64, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Int63n(1_000_000_000) + 1
+			b[i] = rng.Int63n(1_000_000_000) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", b[i]))
+		}
+		sb.WriteByte('\n')
+		exp := fmt.Sprintf("%d", solveCase(append([]int64(nil), a...), append([]int64(nil), b...)))
+		cases = append(cases, testCase{input: sb.String(), expected: exp})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTests()
+	for i, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(tc.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1600-1699/1660-1669/1661/verifierB.go
+++ b/1000-1999/1600-1699/1660-1669/1661/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveVals(a []int) []int {
+	const mod = 32768
+	res := make([]int, len(a))
+	for i, v := range a {
+		best := 15
+		for add := 0; add <= 15; add++ {
+			val := (v + add) % mod
+			if val == 0 {
+				if add < best {
+					best = add
+				}
+				break
+			}
+			tz := bits.TrailingZeros(uint(val))
+			if tz > 15 {
+				tz = 15
+			}
+			ops := add + 15 - tz
+			if ops < best {
+				best = ops
+			}
+		}
+		res[i] = best
+	}
+	return res
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	// simple deterministic cases
+	cases = append(cases, func() testCase {
+		a := []int{0}
+		expVals := solveVals(a)
+		exp := fmt.Sprintf("%d", expVals[0])
+		return testCase{input: "1\n0\n", expected: exp}
+	}())
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(32768)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		vals := solveVals(a)
+		expBuf := make([]string, len(vals))
+		for i, v := range vals {
+			expBuf[i] = fmt.Sprintf("%d", v)
+		}
+		cases = append(cases, testCase{input: sb.String(), expected: strings.Join(expBuf, " ")})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTests()
+	for i, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		expect := strings.TrimSpace(tc.expected)
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1600-1699/1660-1669/1661/verifierC.go
+++ b/1000-1999/1600-1699/1660-1669/1661/verifierC.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func calc(h []int64, H int64) int64 {
+	var ones, twos int64
+	for _, x := range h {
+		diff := H - x
+		if diff > 0 {
+			ones += diff % 2
+			twos += diff / 2
+		}
+	}
+	ans := twos * 2
+	if tmp := ones*2 - 1; tmp > ans {
+		ans = tmp
+	}
+	return ans
+}
+
+func solveCase(h []int64) int64 {
+	mx := h[0]
+	for _, v := range h {
+		if v > mx {
+			mx = v
+		}
+	}
+	d1 := calc(h, mx)
+	d2 := calc(h, mx+1)
+	if d1 < d2 {
+		return d1
+	}
+	return d2
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	// edge case n=1
+	cases = append(cases, func() testCase {
+		h := []int64{1}
+		var sb strings.Builder
+		sb.WriteString("1\n1\n1\n")
+		exp := fmt.Sprintf("%d", solveCase(h))
+		return testCase{input: sb.String(), expected: exp}
+	}())
+	for len(cases) < 100 {
+		n := rng.Intn(20) + 1
+		h := make([]int64, n)
+		for i := 0; i < n; i++ {
+			h[i] = rng.Int63n(1_000_000_000) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", h[i]))
+		}
+		sb.WriteByte('\n')
+		exp := fmt.Sprintf("%d", solveCase(h))
+		cases = append(cases, testCase{input: sb.String(), expected: exp})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTests()
+	for i, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1600-1699/1660-1669/1661/verifierD.go
+++ b/1000-1999/1600-1699/1660-1669/1661/verifierD.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, k int, b []int64) int64 {
+	diff1 := make([]int64, n+2)
+	diff2 := make([]int64, n+2)
+	var cur1, cur2 int64
+	var ans int64
+	for i := n; i >= 1; i-- {
+		cur1 += diff1[i]
+		cur2 += diff2[i]
+		val := cur1*int64(i) + cur2
+		if val < b[i-1] {
+			delta := b[i-1] - val
+			if i >= k {
+				x := (delta + int64(k) - 1) / int64(k)
+				ans += x
+				l := i - k + 1
+				cur1 += x
+				cur2 += x * (1 - int64(l))
+				diff1[l-1] -= x
+				diff2[l-1] -= x * (1 - int64(l))
+			} else {
+				x := (delta + int64(i) - 1) / int64(i)
+				ans += x
+				cur1 += x
+			}
+		}
+	}
+	return ans
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	// simple case n=1
+	cases = append(cases, func() testCase {
+		n := 1
+		k := 1
+		b := []int64{1}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n%d\n", n, k, b[0]))
+		exp := fmt.Sprintf("%d", solveCase(n, k, b))
+		return testCase{input: sb.String(), expected: exp}
+	}())
+	for len(cases) < 100 {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(n) + 1
+		b := make([]int64, n)
+		for i := 0; i < n; i++ {
+			b[i] = rng.Int63n(1_000_000_000) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", b[i]))
+		}
+		sb.WriteByte('\n')
+		exp := fmt.Sprintf("%d", solveCase(n, k, b))
+		cases = append(cases, testCase{input: sb.String(), expected: exp})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTests()
+	for i, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1600-1699/1660-1669/1661/verifierE.go
+++ b/1000-1999/1600-1699/1660-1669/1661/verifierE.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Node struct {
+	comp   int
+	parent [6]int16
+	active [6]bool
+}
+
+func find(parent []int16, x int) int {
+	for int(parent[x]) != x {
+		x = int(parent[x])
+	}
+	return x
+}
+
+func union(parent []int16, x, y int) bool {
+	fx := find(parent, x)
+	fy := find(parent, y)
+	if fx == fy {
+		return false
+	}
+	parent[fy] = int16(fx)
+	return true
+}
+
+func buildLeaf(cols []string, idx int) Node {
+	var n Node
+	for i := 0; i < 6; i++ {
+		n.parent[i] = int16(i)
+	}
+	for r := 0; r < 3; r++ {
+		if cols[r][idx] == '1' {
+			n.active[r] = true
+			n.active[r+3] = true
+			union(n.parent[:], r, r+3)
+			if r > 0 && cols[r-1][idx] == '1' {
+				union(n.parent[:], r-1, r)
+				union(n.parent[:], r-1+3, r+3)
+			}
+		}
+	}
+	vis := make(map[int]bool)
+	for r := 0; r < 3; r++ {
+		if n.active[r] {
+			rt := find(n.parent[:], r)
+			if !vis[rt] {
+				vis[rt] = true
+				n.comp++
+			}
+		}
+	}
+	return n
+}
+
+func merge(a, b Node) Node {
+	parent := make([]int16, 12)
+	for i := range parent {
+		parent[i] = int16(i)
+	}
+	active := make([]bool, 12)
+	for i := 0; i < 6; i++ {
+		active[i] = a.active[i]
+		active[6+i] = b.active[i]
+	}
+	for i := 0; i < 6; i++ {
+		if !active[i] {
+			continue
+		}
+		for j := i + 1; j < 6; j++ {
+			if !active[j] {
+				continue
+			}
+			if find(a.parent[:], i) == find(a.parent[:], j) {
+				union(parent, i, j)
+			}
+		}
+	}
+	for i := 0; i < 6; i++ {
+		if !active[6+i] {
+			continue
+		}
+		for j := i + 1; j < 6; j++ {
+			if !active[6+j] {
+				continue
+			}
+			if find(b.parent[:], i) == find(b.parent[:], j) {
+				union(parent, 6+i, 6+j)
+			}
+		}
+	}
+	comp := a.comp + b.comp
+	for r := 0; r < 3; r++ {
+		if a.active[3+r] && b.active[r] {
+			if union(parent, 3+r, 6+r) {
+				comp--
+			}
+		}
+	}
+	var res Node
+	res.comp = comp
+	for i := 0; i < 6; i++ {
+		res.parent[i] = int16(i)
+	}
+	for i := 0; i < 3; i++ {
+		res.active[i] = a.active[i]
+	}
+	for i := 0; i < 3; i++ {
+		res.active[3+i] = b.active[3+i]
+	}
+	idxMap := []int{0, 1, 2, 9, 10, 11}
+	for i := 0; i < 6; i++ {
+		if !res.active[i] {
+			continue
+		}
+		for j := i + 1; j < 6; j++ {
+			if !res.active[j] {
+				continue
+			}
+			if find(parent, idxMap[i]) == find(parent, idxMap[j]) {
+				union(res.parent[:], i, j)
+			}
+		}
+	}
+	return res
+}
+
+func build(seg []Node, cols []string, id, l, r int) {
+	if l == r {
+		seg[id] = buildLeaf(cols, l)
+		return
+	}
+	mid := (l + r) / 2
+	build(seg, cols, id*2, l, mid)
+	build(seg, cols, id*2+1, mid+1, r)
+	seg[id] = merge(seg[id*2], seg[id*2+1])
+}
+
+func query(seg []Node, id, l, r, L, R int) Node {
+	if L <= l && r <= R {
+		return seg[id]
+	}
+	mid := (l + r) / 2
+	if R <= mid {
+		return query(seg, id*2, l, mid, L, R)
+	}
+	if L > mid {
+		return query(seg, id*2+1, mid+1, r, L, R)
+	}
+	left := query(seg, id*2, l, mid, L, mid)
+	right := query(seg, id*2+1, mid+1, r, mid+1, R)
+	return merge(left, right)
+}
+
+func solveCase(n int, rows []string, queries [][2]int) []int {
+	seg := make([]Node, 4*n)
+	build(seg, rows, 1, 0, n-1)
+	ans := make([]int, len(queries))
+	for i, q := range queries {
+		l := q[0] - 1
+		r := q[1] - 1
+		res := query(seg, 1, 0, n-1, l, r)
+		ans[i] = res.comp
+	}
+	return ans
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	// simple case
+	cases = append(cases, func() testCase {
+		n := 1
+		rows := []string{"1", "1", "1"}
+		queries := [][2]int{{1, 1}}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < 3; i++ {
+			sb.WriteString(rows[i])
+			sb.WriteByte('\n')
+		}
+		sb.WriteString("1\n1 1\n")
+		res := solveCase(n, rows, queries)
+		exp := fmt.Sprintf("%d", res[0])
+		return testCase{input: sb.String(), expected: exp}
+	}())
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 1
+		rows := make([]string, 3)
+		for i := 0; i < 3; i++ {
+			var sb strings.Builder
+			for j := 0; j < n; j++ {
+				if rng.Intn(2) == 1 {
+					sb.WriteByte('1')
+				} else {
+					sb.WriteByte('0')
+				}
+			}
+			rows[i] = sb.String()
+		}
+		q := rng.Intn(10) + 1
+		queries := make([][2]int, q)
+		for i := 0; i < q; i++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			queries[i] = [2]int{l, r}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < 3; i++ {
+			sb.WriteString(rows[i])
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", q))
+		for i := 0; i < q; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", queries[i][0], queries[i][1]))
+		}
+		res := solveCase(n, rows, queries)
+		var expBuf strings.Builder
+		for i, v := range res {
+			if i > 0 {
+				expBuf.WriteByte('\n')
+			}
+			expBuf.WriteString(fmt.Sprintf("%d", v))
+		}
+		cases = append(cases, testCase{input: sb.String(), expected: expBuf.String()})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTests()
+	for i, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(tc.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1600-1699/1660-1669/1661/verifierF.go
+++ b/1000-1999/1600-1699/1660-1669/1661/verifierF.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const inf int64 = 1<<63 - 1
+
+func cost(L, p int64) int64 {
+	if p <= 0 {
+		return inf
+	}
+	q := L / p
+	r := L % p
+	qq := uint64(q * q)
+	hi1, lo1 := bits.Mul64(qq, uint64(p-r))
+	qq1 := uint64(q+1) * uint64(q+1)
+	hi2, lo2 := bits.Mul64(qq1, uint64(r))
+	lo, carry := bits.Add64(lo1, lo2, 0)
+	hi, _ := bits.Add64(hi1, hi2, carry)
+	if hi > 0 || lo > uint64(inf) {
+		return inf
+	}
+	return int64(lo)
+}
+
+func delta(L, p int64) int64 {
+	c1 := cost(L, p)
+	c2 := cost(L, p+1)
+	if c1 == inf || c2 == inf {
+		return inf
+	}
+	return c1 - c2
+}
+
+func minParts(L, lam int64) int64 {
+	low, high := int64(1), L
+	for low < high {
+		mid := (low + high) >> 1
+		if delta(L, mid) <= lam {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	return low
+}
+
+func feasible(lengths []int64, lam, m int64) bool {
+	var total int64
+	for _, L := range lengths {
+		p := minParts(L, lam)
+		total += cost(L, p)
+		if total > m {
+			return false
+		}
+	}
+	return total <= m
+}
+
+func solveCase(a []int64, m int64) int64 {
+	n := len(a) - 1
+	lengths := make([]int64, n)
+	prev := int64(0)
+	for i := 0; i < n; i++ {
+		lengths[i] = a[i+1] - prev
+		prev = a[i+1]
+	}
+	lo, hi := int64(0), int64(1e18)
+	best := int64(0)
+	for lo <= hi {
+		mid := (lo + hi) >> 1
+		if feasible(lengths, mid, m) {
+			best = mid
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	parts := make([]int64, len(lengths))
+	var costNow int64
+	for i, L := range lengths {
+		p := minParts(L, best)
+		parts[i] = p
+		costNow += cost(L, p)
+	}
+	K := int64(0)
+	for _, p := range parts {
+		K += p - 1
+	}
+	leftover := m - costNow
+	type item struct {
+		d   int64
+		idx int
+	}
+	pq := make([]item, 0)
+	for i, L := range lengths {
+		if parts[i] > 1 {
+			d := delta(L, parts[i]-1)
+			pq = append(pq, item{d: d, idx: i})
+		}
+	}
+	sort.Slice(pq, func(i, j int) bool { return pq[i].d < pq[j].d })
+	for len(pq) > 0 {
+		it := pq[0]
+		if it.d > leftover {
+			break
+		}
+		leftover -= it.d
+		K--
+		idx := it.idx
+		parts[idx]--
+		if parts[idx] > 1 {
+			d := delta(lengths[idx], parts[idx]-1)
+			pq[0] = item{d: d, idx: idx}
+		} else {
+			pq = pq[1:]
+		}
+		sort.Slice(pq, func(i, j int) bool { return pq[i].d < pq[j].d })
+	}
+	return K
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func genTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	// simple case n=1
+	cases = append(cases, func() testCase {
+		a := []int64{0, 1}
+		m := int64(1)
+		var sb strings.Builder
+		sb.WriteString("1\n1\n1\n")
+		exp := fmt.Sprintf("%d", solveCase(a, m))
+		return testCase{input: sb.String(), expected: exp}
+	}())
+	for len(cases) < 100 {
+		n := rng.Intn(5) + 1
+		a := make([]int64, n+1)
+		cur := int64(0)
+		for i := 1; i <= n; i++ {
+			cur += int64(rng.Intn(100) + 1)
+			a[i] = cur
+		}
+		m := cur + int64(rng.Intn(1000)+1)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		exp := fmt.Sprintf("%d", solveCase(a, m))
+		cases = append(cases, testCase{input: sb.String(), expected: exp})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTests()
+	for i, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–F of contest 1661
- each verifier runs any binary (or Go source via `go run`) on 100 randomized tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`
- `go run verifierF.go ./solF`

------
https://chatgpt.com/codex/tasks/task_e_688740c9c7f88324a5b7d2297d067842