### PR TITLE
Add Go verifiers for contest 1665

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1665/verifierA.go
+++ b/1000-1999/1600-1699/1660-1669/1665/verifierA.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseA struct {
+	n int64
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput()
+		if err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runBinary(bin string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func lcm(a, b int64) int64 {
+	g := gcd(a, b)
+	if g == 0 {
+		return 0
+	}
+	return a / g * b
+}
+
+func generateTestsA() ([]testCaseA, []byte) {
+	rng := rand.New(rand.NewSource(1))
+	t := 100
+	tests := make([]testCaseA, t)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Int63n(1_000_000_000-4) + 4
+		tests[i] = testCaseA{n: n}
+		fmt.Fprintf(&buf, "%d\n", n)
+	}
+	return tests, buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	binPath, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	tests, input := generateTestsA()
+	out, err := runBinary(binPath, input)
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Split(bufio.ScanWords)
+
+	for idx, tc := range tests {
+		var vals [4]int64
+		for i := 0; i < 4; i++ {
+			if !scanner.Scan() {
+				fmt.Printf("missing value at test %d\n", idx+1)
+				os.Exit(1)
+			}
+			v, err := strconv.ParseInt(scanner.Text(), 10, 64)
+			if err != nil {
+				fmt.Printf("invalid integer at test %d: %v\n", idx+1, err)
+				os.Exit(1)
+			}
+			vals[i] = v
+		}
+		a, b, c, d := vals[0], vals[1], vals[2], vals[3]
+		if a <= 0 || b <= 0 || c <= 0 || d <= 0 {
+			fmt.Printf("test %d has non-positive value\n", idx+1)
+			os.Exit(1)
+		}
+		if a+b+c+d != tc.n {
+			fmt.Printf("test %d sum mismatch: got %d expected %d\n", idx+1, a+b+c+d, tc.n)
+			os.Exit(1)
+		}
+		if gcd(a, b) != lcm(c, d) {
+			fmt.Printf("test %d gcd/lcm mismatch\n", idx+1)
+			os.Exit(1)
+		}
+	}
+
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1660-1669/1665/verifierB.go
+++ b/1000-1999/1600-1699/1660-1669/1665/verifierB.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseB struct {
+	n   int
+	arr []int
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput()
+		if err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runBinary(bin string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func expectedB(arr []int) int {
+	freq := make(map[int]int)
+	mx := 0
+	n := len(arr)
+	for _, v := range arr {
+		freq[v]++
+		if freq[v] > mx {
+			mx = freq[v]
+		}
+	}
+	ops := 0
+	for mx < n {
+		ops++
+		diff := n - mx
+		add := mx
+		if diff < add {
+			add = diff
+		}
+		ops += add
+		mx += add
+	}
+	return ops
+}
+
+func generateTestsB() ([]testCaseB, []byte) {
+	rng := rand.New(rand.NewSource(2))
+	t := 100
+	tests := make([]testCaseB, t)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(7) - 3
+		}
+		tests[i] = testCaseB{n: n, arr: arr}
+		fmt.Fprintf(&buf, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprintf(&buf, "%d", arr[j])
+		}
+		buf.WriteByte('\n')
+	}
+	return tests, buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	tests, input := generateTestsB()
+	out, err := runBinary(bin, input)
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Split(bufio.ScanWords)
+	for idx, tc := range tests {
+		if !scanner.Scan() {
+			fmt.Printf("missing output for test %d\n", idx+1)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Printf("invalid integer on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		exp := expectedB(tc.arr)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %d got %d\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1660-1669/1665/verifierC.go
+++ b/1000-1999/1600-1699/1660-1669/1665/verifierC.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type testCaseC struct {
+	n       int
+	parents []int
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput()
+		if err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runBinary(bin string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func expectedC(n int, parents []int) int {
+	cnt := make([]int, n)
+	for i := 2; i <= n; i++ {
+		p := parents[i-2]
+		cnt[p-1]++
+	}
+	arr := []int{}
+	for _, c := range cnt {
+		if c > 0 {
+			arr = append(arr, c)
+		}
+	}
+	arr = append(arr, 1)
+	sort.Slice(arr, func(i, j int) bool { return arr[i] > arr[j] })
+	m := len(arr)
+	for i := 0; i < m; i++ {
+		arr[i] -= m - i
+		if arr[i] < 0 {
+			arr[i] = 0
+		}
+	}
+	b := []int{}
+	for _, v := range arr {
+		if v > 0 {
+			b = append(b, v)
+		}
+	}
+	if len(b) == 0 {
+		return m
+	}
+	sort.Slice(b, func(i, j int) bool { return b[i] > b[j] })
+	lo, hi := 0, n+5
+	for lo < hi {
+		mid := (lo + hi) / 2
+		sum := 0
+		for _, v := range b {
+			if v > mid {
+				sum += v - mid
+			}
+		}
+		if sum <= mid {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return m + lo
+}
+
+func generateTestsC() ([]testCaseC, []byte) {
+	rng := rand.New(rand.NewSource(3))
+	t := 100
+	tests := make([]testCaseC, t)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(20) + 2
+		parents := make([]int, n-1)
+		for j := 2; j <= n; j++ {
+			parents[j-2] = rng.Intn(j-1) + 1
+		}
+		tests[i] = testCaseC{n: n, parents: parents}
+		fmt.Fprintf(&buf, "%d\n", n)
+		for j := 0; j < n-1; j++ {
+			if j > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprintf(&buf, "%d", parents[j])
+		}
+		buf.WriteByte('\n')
+	}
+	return tests, buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	tests, input := generateTestsC()
+	out, err := runBinary(bin, input)
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Split(bufio.ScanWords)
+	for idx, tc := range tests {
+		if !scanner.Scan() {
+			fmt.Printf("missing output for test %d\n", idx+1)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Printf("invalid integer on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		exp := expectedC(tc.n, tc.parents)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %d got %d\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1660-1669/1665/verifierD.go
+++ b/1000-1999/1600-1699/1660-1669/1665/verifierD.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput()
+		if err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runCase(bin string, x int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	inw := bufio.NewWriter(stdin)
+	outr := bufio.NewReader(stdout)
+	fmt.Fprintln(inw, 1)
+	inw.Flush()
+	queries := 0
+	for {
+		line, err := outr.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("read error: %v stderr:%s", err, stderr.String())
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "?") {
+			queries++
+			if queries > 30 {
+				return fmt.Errorf("too many queries")
+			}
+			fields := strings.Fields(line)
+			if len(fields) != 3 {
+				return fmt.Errorf("invalid query format")
+			}
+			a, _ := strconv.Atoi(fields[1])
+			b, _ := strconv.Atoi(fields[2])
+			g := gcd(x+a, x+b)
+			fmt.Fprintln(inw, g)
+			inw.Flush()
+		} else if strings.HasPrefix(line, "!") {
+			valStr := strings.TrimSpace(line[1:])
+			val, _ := strconv.Atoi(valStr)
+			stdin.Close()
+			err := cmd.Wait()
+			if err != nil {
+				return fmt.Errorf("runtime error: %v stderr:%s", err, stderr.String())
+			}
+			if val != x {
+				return fmt.Errorf("wrong answer: expected %d got %d", x, val)
+			}
+			return nil
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < 100; i++ {
+		x := rng.Intn(1_000_000_000) + 1
+		if err := runCase(bin, x); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1665/verifierE.go
+++ b/1000-1999/1600-1699/1660-1669/1665/verifierE.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type query struct{ l, r int }
+
+type testCaseE struct {
+	n       int
+	arr     []int
+	q       int
+	queries []query
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput()
+		if err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runBinary(bin string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func expectedE(arr []int, l, r int) int {
+	ans := int(^uint(0) >> 1)
+	for i := l; i < r; i++ {
+		for j := i + 1; j <= r; j++ {
+			val := arr[i] | arr[j]
+			if val < ans {
+				ans = val
+			}
+		}
+	}
+	return ans
+}
+
+func generateTestsE() ([]testCaseE, []byte) {
+	rng := rand.New(rand.NewSource(5))
+	t := 100
+	tests := make([]testCaseE, t)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(15) + 2
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(1 << 10)
+		}
+		q := rng.Intn(10) + 1
+		qs := make([]query, q)
+		fmt.Fprintf(&buf, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprintf(&buf, "%d", arr[j])
+		}
+		buf.WriteByte('\n')
+		fmt.Fprintf(&buf, "%d\n", q)
+		for j := 0; j < q; j++ {
+			l := rng.Intn(n - 1)
+			r := l + 1 + rng.Intn(n-l-1)
+			qs[j] = query{l: l + 1, r: r + 1}
+			fmt.Fprintf(&buf, "%d %d\n", l+1, r+1)
+		}
+		tests[i] = testCaseE{n: n, arr: arr, q: q, queries: qs}
+	}
+	return tests, buf.Bytes()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	tests, input := generateTestsE()
+	out, err := runBinary(bin, input)
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Split(bufio.ScanWords)
+	for idx, tc := range tests {
+		for j := 0; j < tc.q; j++ {
+			if !scanner.Scan() {
+				fmt.Printf("missing output for test %d query %d\n", idx+1, j+1)
+				os.Exit(1)
+			}
+			got, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Printf("invalid integer on test %d query %d: %v\n", idx+1, j+1, err)
+				os.Exit(1)
+			}
+			exp := expectedE(tc.arr, tc.queries[j].l-1, tc.queries[j].r-1)
+			if got != exp {
+				fmt.Printf("test %d query %d failed: expected %d got %d\n", idx+1, j+1, exp, got)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to check problem A solutions
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go to simulate interactive gcd queries
- add verifierE.go for problem E

## Testing
- `gofmt -w 1000-1999/1600-1699/1660-1669/1665/verifierA.go 1000-1999/1600-1699/1660-1669/1665/verifierB.go 1000-1999/1600-1699/1660-1669/1665/verifierC.go 1000-1999/1600-1699/1660-1669/1665/verifierD.go 1000-1999/1600-1699/1660-1669/1665/verifierE.go`
- `go vet 1000-1999/1600-1699/1660-1669/1665/*.go`


------
https://chatgpt.com/codex/tasks/task_e_688741e1afa4832496cf257e81c81226