### PR TITLE
Add solution verifiers for CF contest 1667

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1667/verifierA.go
+++ b/1000-1999/1600-1699/1660-1669/1667/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	input string
+}
+
+func genTestCase() TestCase {
+	n := rand.Intn(7) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Int63n(1e6)+1))
+	}
+	sb.WriteByte('\n')
+	return TestCase{input: sb.String()}
+}
+
+func runBin(path string, in string) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	user := os.Args[1]
+	ref := "./refA.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1667A.go").Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		tc := genTestCase()
+		exp, err := runBin(ref, tc.input)
+		if err != nil {
+			fmt.Println("reference failed on test", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBin(user, tc.input)
+		if err != nil {
+			fmt.Println("runtime error on test", i+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected:%s\nfound:%s\n", i+1, tc.input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1660-1669/1667/verifierB.go
+++ b/1000-1999/1600-1699/1660-1669/1667/verifierB.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func genInput() string {
+	t := 100
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(7) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(11)-5))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runBin(path, in string) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	user := os.Args[1]
+	ref := "./refB.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1667B.go").Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	input := genInput()
+	exp, err := runBin(ref, input)
+	if err != nil {
+		fmt.Println("reference failed:", err)
+		os.Exit(1)
+	}
+	out, err := runBin(user, input)
+	if err != nil {
+		fmt.Println("runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+		fmt.Printf("wrong answer\ninput:\n%s\nexpected:\n%s\nfound:\n%s\n", input, exp, out)
+		os.Exit(1)
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1660-1669/1667/verifierC.go
+++ b/1000-1999/1600-1699/1660-1669/1667/verifierC.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genTest() string {
+	n := rand.Intn(30) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func runBin(path, in string) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	user := os.Args[1]
+	ref := "./refC.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1667C.go").Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBin(ref, input)
+		if err != nil {
+			fmt.Println("reference failed on test", i+1)
+			os.Exit(1)
+		}
+		out, err := runBin(user, input)
+		if err != nil {
+			fmt.Println("runtime error on test", i+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+			fmt.Printf("wrong answer on test %d\ninput:%sexpected:%sfound:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1660-1669/1667/verifierD.go
+++ b/1000-1999/1600-1699/1660-1669/1667/verifierD.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func randTree(n int) []edge {
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, edge{i, p})
+	}
+	return edges
+}
+
+func genInput() string {
+	t := 100
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(7) + 2
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, e := range randTree(n) {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+		}
+	}
+	return sb.String()
+}
+
+func runBin(path, in string) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	user := os.Args[1]
+	ref := "./refD.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1667D.go").Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	input := genInput()
+	exp, err := runBin(ref, input)
+	if err != nil {
+		fmt.Println("reference failed:", err)
+		os.Exit(1)
+	}
+	out, err := runBin(user, input)
+	if err != nil {
+		fmt.Println("runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+		fmt.Printf("wrong answer\ninput:\n%s\nexpected:\n%s\nfound:\n%s\n", input, exp, out)
+		os.Exit(1)
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1660-1669/1667/verifierE.go
+++ b/1000-1999/1600-1699/1660-1669/1667/verifierE.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genInput() string {
+	n := rand.Intn(19) + 3
+	if n%2 == 0 {
+		n++
+	}
+	return fmt.Sprintf("%d\n", n)
+}
+
+func runBin(path, in string) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	user := os.Args[1]
+	ref := "./refE.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1667E.go").Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genInput()
+		exp, err := runBin(ref, input)
+		if err != nil {
+			fmt.Println("reference failed on test", i+1)
+			os.Exit(1)
+		}
+		out, err := runBin(user, input)
+		if err != nil {
+			fmt.Println("runtime error on test", i+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+			fmt.Printf("wrong answer on test %d\ninput:%sexpected:%sfound:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1660-1669/1667/verifierF.go
+++ b/1000-1999/1600-1699/1660-1669/1667/verifierF.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genInput() string {
+	t := 100
+	opts := []int{8, 12}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := opts[rand.Intn(len(opts))]
+		m := opts[rand.Intn(len(opts))]
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		line := strings.Repeat(".", m)
+		for r := 0; r < n; r++ {
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func runBin(path, in string) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	user := os.Args[1]
+	ref := "./refF.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1667F.go").Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	input := genInput()
+	exp, err := runBin(ref, input)
+	if err != nil {
+		fmt.Println("reference failed:", err)
+		os.Exit(1)
+	}
+	out, err := runBin(user, input)
+	if err != nil {
+		fmt.Println("runtime error:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(string(out)) != strings.TrimSpace(string(exp)) {
+		fmt.Printf("wrong answer\ninput:\n%s\nexpected:\n%s\nfound:\n%s\n", input, exp, out)
+		os.Exit(1)
+	}
+	fmt.Println("ok")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 1667 problems A–F
- each verifier builds the reference solution, generates ≥100 random test cases and compares output
- users run e.g. `go run verifierA.go ./my_solution` to check their binaries

## Testing
- `go build 1000-1999/1600-1699/1660-1669/1667/verifierA.go`
- `go build 1000-1999/1600-1699/1660-1669/1667/verifierB.go`
- `go build 1000-1999/1600-1699/1660-1669/1667/verifierC.go`
- `go build 1000-1999/1600-1699/1660-1669/1667/verifierD.go`
- `go build 1000-1999/1600-1699/1660-1669/1667/verifierE.go`
- `go build 1000-1999/1600-1699/1660-1669/1667/verifierF.go`
- `go run verifierA.go ./A.bin` (passed)
- `go run verifierB.go ./B.bin` (passed)
- `go run verifierF.go ./F.bin` (passed)


------
https://chatgpt.com/codex/tasks/task_e_6887426dd60083248a5337ca8d9bb3da