### PR TITLE
Add Go verifiers for CF contest 1669

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1669/verifierA.go
+++ b/1000-1999/1600-1699/1660-1669/1669/verifierA.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	rating int
+}
+
+func solveCase(tc testCase) string {
+	switch {
+	case tc.rating >= 1900:
+		return "Division 1"
+	case tc.rating >= 1600:
+		return "Division 2"
+	case tc.rating >= 1400:
+		return "Division 3"
+	default:
+		return "Division 4"
+	}
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	tc := testCase{rating: rng.Intn(10001) - 5000}
+	input := fmt.Sprintf("1\n%d\n", tc.rating)
+	output := solveCase(tc) + "\n"
+	return input, output
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1669/verifierB.go
+++ b/1000-1999/1600-1699/1660-1669/1669/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func solveCase(tc testCase) string {
+	count := make(map[int]int)
+	ans := -1
+	for _, v := range tc.arr {
+		if ans == -1 {
+			count[v]++
+			if count[v] >= 3 {
+				ans = v
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n) + 1
+	}
+	tc := testCase{arr: arr}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	output := solveCase(tc) + "\n"
+	return input, output
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1669/verifierC.go
+++ b/1000-1999/1600-1699/1660-1669/1669/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func solveCase(tc testCase) string {
+	if len(tc.arr) == 0 {
+		return "YES"
+	}
+	oddParity := tc.arr[0] % 2
+	evenParity := 0
+	if len(tc.arr) > 1 {
+		evenParity = tc.arr[1] % 2
+	}
+	for i, v := range tc.arr {
+		if i%2 == 0 {
+			if v%2 != oddParity {
+				return "NO"
+			}
+		} else {
+			if v%2 != evenParity {
+				return "NO"
+			}
+		}
+	}
+	return "YES"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100)
+	}
+	tc := testCase{arr: arr}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	output := solveCase(tc) + "\n"
+	return input, output
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1669/verifierD.go
+++ b/1000-1999/1600-1699/1660-1669/1669/verifierD.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	s string
+}
+
+func solveCase(tc testCase) string {
+	n := len(tc.s)
+	i := 0
+	for i < n {
+		if tc.s[i] == 'W' {
+			i++
+			continue
+		}
+		j := i
+		hasR := false
+		hasB := false
+		for j < n && tc.s[j] != 'W' {
+			if tc.s[j] == 'R' {
+				hasR = true
+			}
+			if tc.s[j] == 'B' {
+				hasB = true
+			}
+			j++
+		}
+		if !(hasR && hasB) {
+			return "NO"
+		}
+		i = j
+	}
+	return "YES"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	letters := []byte{'R', 'B', 'W'}
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(3)]
+	}
+	tc := testCase{s: string(b)}
+	input := fmt.Sprintf("1\n%d\n%s\n", n, tc.s)
+	output := solveCase(tc) + "\n"
+	return input, output
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1669/verifierE.go
+++ b/1000-1999/1600-1699/1660-1669/1669/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	words []string
+}
+
+func countPairs(words []string) int64 {
+	cnt := make(map[string]int)
+	var ans int64
+	for _, s := range words {
+		for pos := 0; pos < 2; pos++ {
+			b := []byte(s)
+			orig := b[pos]
+			for ch := 'a'; ch <= 'k'; ch++ {
+				if byte(ch) == orig {
+					continue
+				}
+				b[pos] = byte(ch)
+				ans += int64(cnt[string(b)])
+			}
+			b[pos] = orig
+		}
+		cnt[s]++
+	}
+	return ans
+}
+
+func solveCase(tc testCase) string {
+	return fmt.Sprintf("%d", countPairs(tc.words))
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	letters := []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'}
+	words := make([]string, n)
+	for i := 0; i < n; i++ {
+		w := []byte{letters[rng.Intn(len(letters))], letters[rng.Intn(len(letters))]}
+		words[i] = string(w)
+	}
+	tc := testCase{words: words}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, w := range words {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(w)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	output := solveCase(tc) + "\n"
+	return input, output
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1669/verifierF.go
+++ b/1000-1999/1600-1699/1660-1669/1669/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func solveCase(tc testCase) string {
+	i, j := 0, len(tc.arr)-1
+	left, right := 0, 0
+	ans := 0
+	for i <= j {
+		if left <= right {
+			left += tc.arr[i]
+			i++
+		} else {
+			right += tc.arr[j]
+			j--
+		}
+		if left == right {
+			cand := i + (len(tc.arr) - j - 1)
+			if cand > ans {
+				ans = cand
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(10) + 1
+	}
+	tc := testCase{arr: arr}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	output := solveCase(tc) + "\n"
+	return input, output
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1669/verifierG.go
+++ b/1000-1999/1600-1699/1660-1669/1669/verifierG.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	grid [][]byte
+}
+
+func simulate(grid [][]byte) []string {
+	n := len(grid)
+	if n == 0 {
+		return []string{}
+	}
+	m := len(grid[0])
+	result := make([][]byte, n)
+	for i := range result {
+		result[i] = make([]byte, m)
+		for j := range result[i] {
+			result[i][j] = '.'
+		}
+	}
+	for c := 0; c < m; c++ {
+		pos := n - 1
+		for r := n - 1; r >= 0; r-- {
+			switch grid[r][c] {
+			case 'o':
+				result[r][c] = 'o'
+				pos = r - 1
+			case '*':
+				result[pos][c] = '*'
+				pos--
+			}
+		}
+	}
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = string(result[i])
+	}
+	return out
+}
+
+func solveCase(tc testCase) string {
+	res := simulate(tc.grid)
+	return strings.Join(res, "\n")
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	letters := []byte{'.', '*', 'o'}
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			row[j] = letters[rng.Intn(3)]
+		}
+		grid[i] = row
+	}
+	tc := testCase{grid: grid}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	output := solveCase(tc) + "\n"
+	return input, output
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\n\ngot \n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1660-1669/1669/verifierH.go
+++ b/1000-1999/1600-1699/1660-1669/1669/verifierH.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	k   int
+	arr []int
+}
+
+func solveCase(tc testCase) string {
+	k := tc.k
+	result := 0
+	for b := 30; b >= 0; b-- {
+		count := 0
+		for _, v := range tc.arr {
+			if (v>>uint(b))&1 == 1 {
+				count++
+			}
+		}
+		need := tc.n - count
+		if need <= k {
+			k -= need
+			result |= 1 << uint(b)
+		}
+	}
+	return fmt.Sprintf("%d", result)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(50)
+	}
+	k := rng.Intn(5*n + 1)
+	tc := testCase{n: n, k: k, arr: arr}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	output := solveCase(tc) + "\n"
+	return input, output
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go-based verifiers for contest 1669 problems A–H
- each verifier generates 100 random tests and executes a given binary
- verifiers can be run with `go run verifierX.go /path/to/binary`

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go run verifierA.go ./solA` (built from 1669A.go)

------
https://chatgpt.com/codex/tasks/task_e_688742f9d7c88324a8c175bf402d7b31