### PR TITLE
Add Go verifiers for contest 1671

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1671/verifierA.go
+++ b/1000-1999/1600-1699/1670-1679/1671/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func check(s string) string {
+    for i := 0; i < len(s); {
+        j := i
+        for j < len(s) && s[j] == s[i] {
+            j++
+        }
+        if j-i == 1 {
+            return "NO"
+        }
+        i = j
+    }
+    return "YES"
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierA.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    r := rand.New(rand.NewSource(1))
+    tests := 100
+    for i := 0; i < tests; i++ {
+        l := r.Intn(50) + 1
+        sb := make([]byte, l)
+        for j := 0; j < l; j++ {
+            if r.Intn(2) == 0 {
+                sb[j] = 'a'
+            } else {
+                sb[j] = 'b'
+            }
+        }
+        s := string(sb)
+        input := fmt.Sprintf("1\n%s\n", s)
+        expected := check(s)
+        out, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        out = strings.ToUpper(strings.TrimSpace(out))
+        if out != expected {
+            fmt.Printf("test %d failed: input=%s expected=%s got=%s\n", i+1, s, expected, out)
+            return
+        }
+    }
+    fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1670-1679/1671/verifierB.go
+++ b/1000-1999/1600-1699/1670-1679/1671/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func solve(points []int) string {
+    L := -1<<60
+    R := 1<<60
+    for i, v := range points {
+        a := v - (i + 1)
+        if a > L {
+            L = a
+        }
+        if a+2 < R {
+            R = a + 2
+        }
+    }
+    if L <= R {
+        return "YES"
+    }
+    return "NO"
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierB.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    r := rand.New(rand.NewSource(2))
+    tests := 100
+    for i := 0; i < tests; i++ {
+        n := r.Intn(5) + 1
+        points := make([]int, n)
+        cur := r.Intn(5) + 1
+        for j := 0; j < n; j++ {
+            cur += r.Intn(5) + 1
+            points[j] = cur
+        }
+        input := fmt.Sprintf("1\n%d\n", n)
+        for j, v := range points {
+            if j > 0 {
+                input += " "
+            }
+            input += fmt.Sprintf("%d", v)
+        }
+        input += "\n"
+        expected := solve(points)
+        out, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        out = strings.ToUpper(strings.TrimSpace(out))
+        if out != expected {
+            fmt.Printf("test %d failed: input=%v expected=%s got=%s\n", i+1, points, expected, out)
+            return
+        }
+    }
+    fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1670-1679/1671/verifierC.go
+++ b/1000-1999/1600-1699/1670-1679/1671/verifierC.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+    "time"
+)
+
+func solve(n int, x int64, a []int64) int64 {
+    sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+    prefix := make([]int64, n+1)
+    for i := 1; i <= n; i++ {
+        prefix[i] = prefix[i-1] + a[i-1]
+    }
+    var ans, last int64
+    for k := 1; k <= n; k++ {
+        if prefix[k] > x {
+            break
+        }
+        days := (x-prefix[k])/int64(k) + 1
+        ans += days - last
+        last = days
+    }
+    return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierC.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    r := rand.New(rand.NewSource(3))
+    tests := 100
+    for i := 0; i < tests; i++ {
+        n := r.Intn(4) + 1
+        x := int64(r.Intn(20) + 1)
+        a := make([]int64, n)
+        for j := 0; j < n; j++ {
+            a[j] = int64(r.Intn(20) + 1)
+        }
+        input := fmt.Sprintf("1\n%d %d\n", n, x)
+        for j, v := range a {
+            if j > 0 {
+                input += " "
+            }
+            input += fmt.Sprintf("%d", v)
+        }
+        input += "\n"
+        expected := fmt.Sprintf("%d", solve(n, x, a))
+        out, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        out = strings.TrimSpace(out)
+        if out != expected {
+            fmt.Printf("test %d failed: n=%d x=%d a=%v expected=%s got=%s\n", i+1, n, x, a, expected, out)
+            return
+        }
+    }
+    fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1670-1679/1671/verifierD.go
+++ b/1000-1999/1600-1699/1670-1679/1671/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func abs(x int64) int64 {
+    if x < 0 {
+        return -x
+    }
+    return x
+}
+
+func min64(a, b int64) int64 {
+    if a < b {
+        return a
+    }
+    return b
+}
+
+func solve(n, x int, a []int64) int64 {
+    if n == 1 {
+        v1 := int64(a[0]-1)
+        v2 := int64(x-1)
+        if v1 < v2 {
+            return v2
+        }
+        return v1
+    }
+    base := int64(0)
+    for i := 0; i < n-1; i++ {
+        base += abs(a[i] - a[i+1])
+    }
+    costVal := func(val int64) int64 {
+        res := min64(abs(a[0]-val), abs(a[n-1]-val))
+        for i := 0; i < n-1; i++ {
+            c := abs(a[i]-val) + abs(a[i+1]-val) - abs(a[i]-a[i+1])
+            if c < res {
+                res = c
+            }
+        }
+        return res
+    }
+    ans := base + costVal(1)
+    if x > 1 {
+        ans += costVal(int64(x))
+    }
+    cand := base + int64(x-1) + min64(abs(a[0]-1), abs(a[0]-int64(x)))
+    if cand < ans {
+        ans = cand
+    }
+    cand = base + int64(x-1) + min64(abs(a[n-1]-1), abs(a[n-1]-int64(x)))
+    if cand < ans {
+        ans = cand
+    }
+    for i := 0; i < n-1; i++ {
+        cand = base - abs(a[i]-a[i+1]) + int64(x-1) +
+            min64(abs(a[i]-1)+abs(a[i+1]-int64(x)), abs(a[i]-int64(x))+abs(a[i+1]-1))
+        if cand < ans {
+            ans = cand
+        }
+    }
+    return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierD.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    r := rand.New(rand.NewSource(4))
+    tests := 100
+    for i := 0; i < tests; i++ {
+        n := r.Intn(3) + 1
+        x := r.Intn(7) + 1
+        a := make([]int64, n)
+        for j := 0; j < n; j++ {
+            a[j] = int64(r.Intn(7) + 1)
+        }
+        input := fmt.Sprintf("1\n%d %d\n", n, x)
+        for j, v := range a {
+            if j > 0 {
+                input += " "
+            }
+            input += fmt.Sprintf("%d", v)
+        }
+        input += "\n"
+        expected := fmt.Sprintf("%d", solve(n, x, a))
+        out, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        out = strings.TrimSpace(out)
+        if out != expected {
+            fmt.Printf("test %d failed: n=%d x=%d a=%v expected=%s got=%s\n", i+1, n, x, a, expected, out)
+            return
+        }
+    }
+    fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1670-1679/1671/verifierE.go
+++ b/1000-1999/1600-1699/1670-1679/1671/verifierE.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+const mod int64 = 998244353
+
+func dfs(idx int, letters []byte, N int) ([]byte, int64) {
+    if idx*2 > N {
+        return []byte{letters[idx]}, 1
+    }
+    ls, lc := dfs(idx*2, letters, N)
+    rs, rc := dfs(idx*2+1, letters, N)
+    if bytes.Compare(ls, rs) > 0 {
+        ls, rs = rs, ls
+        lc, rc = rc, lc
+    }
+    count := (lc * rc) % mod
+    if !bytes.Equal(ls, rs) {
+        count = (count * 2) % mod
+    }
+    res := make([]byte, 1+len(ls)+len(rs))
+    res[0] = letters[idx]
+    copy(res[1:], ls)
+    copy(res[1+len(ls):], rs)
+    return res, count
+}
+
+func solve(n int, s string) int64 {
+    N := (1 << n) - 1
+    letters := make([]byte, N+1)
+    for i := 1; i <= N; i++ {
+        letters[i] = s[i-1]
+    }
+    _, ans := dfs(1, letters, N)
+    return ans % mod
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierE.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    r := rand.New(rand.NewSource(5))
+    tests := 100
+    for i := 0; i < tests; i++ {
+        n := r.Intn(3) + 2 // 2..4
+        N := (1 << n) - 1
+        sb := make([]byte, N)
+        for j := 0; j < N; j++ {
+            if r.Intn(2) == 0 {
+                sb[j] = 'A'
+            } else {
+                sb[j] = 'B'
+            }
+        }
+        s := string(sb)
+        input := fmt.Sprintf("%d\n%s\n", n, s)
+        expected := fmt.Sprintf("%d", solve(n, s))
+        out, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        out = strings.TrimSpace(out)
+        if out != expected {
+            fmt.Printf("test %d failed: n=%d s=%s expected=%s got=%s\n", i+1, n, s, expected, out)
+            return
+        }
+    }
+    fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1670-1679/1671/verifierF.go
+++ b/1000-1999/1600-1699/1670-1679/1671/verifierF.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+const MOD int = 998244353
+const K int = 11
+const N int = 22
+
+func make2D() [][]int {
+    a := make([][]int, K+1)
+    for i := range a {
+        a[i] = make([]int, K+1)
+    }
+    return a
+}
+
+func computeDP(n int) [K + 1][K + 1]int {
+    dpPrev := make([][][]int, 1)
+    dpPrev[0] = make2D()
+    dpPrev[0][0][0] = 1
+    for pos := n - 1; pos >= 1; pos-- {
+        limit := n - pos
+        dpCurr := make([][][]int, limit+1)
+        for i := 0; i <= limit; i++ {
+            dpCurr[i] = make2D()
+        }
+        for last := 0; last < len(dpPrev); last++ {
+            table := dpPrev[last]
+            for inv := 0; inv <= K; inv++ {
+                row := table[inv]
+                for desc := 0; desc <= K; desc++ {
+                    val := row[desc]
+                    if val == 0 {
+                        continue
+                    }
+                    for valNew := 0; valNew <= limit; valNew++ {
+                        ni := inv + valNew
+                        if ni > K {
+                            continue
+                        }
+                        nd := desc
+                        if valNew > last {
+                            nd++
+                        }
+                        if nd > K {
+                            continue
+                        }
+                        dpCurr[valNew][ni][nd] = (dpCurr[valNew][ni][nd] + val) % MOD
+                    }
+                }
+            }
+        }
+        dpPrev = dpCurr
+    }
+    var res [K + 1][K + 1]int
+    for _, table := range dpPrev {
+        for inv := 0; inv <= K; inv++ {
+            for desc := 0; desc <= K; desc++ {
+                res[inv][desc] = (res[inv][desc] + table[inv][desc]) % MOD
+            }
+        }
+    }
+    return res
+}
+
+func modInverse(a int) int { return powMod(a, MOD-2) }
+
+func powMod(a, e int) int {
+    res := 1
+    base := a % MOD
+    for e > 0 {
+        if e&1 == 1 {
+            res = res * base % MOD
+        }
+        base = base * base % MOD
+        e >>= 1
+    }
+    return res
+}
+
+var dp [N + 1][K + 1][K + 1]int
+var bases [K + 1][K + 1]int
+var coeffs [K + 1][K + 1][]int
+var invFact [K + 1]int
+
+func precompute() {
+    fact := make([]int, K+1)
+    fact[0] = 1
+    for i := 1; i <= K; i++ {
+        fact[i] = fact[i-1] * i % MOD
+    }
+    invFact[K] = modInverse(fact[K])
+    for i := K; i >= 1; i-- {
+        invFact[i-1] = invFact[i] * i % MOD
+    }
+
+    for n := 1; n <= N; n++ {
+        res := computeDP(n)
+        for k := 0; k <= K; k++ {
+            for x := 0; x <= K; x++ {
+                dp[n][k][x] = res[k][x]
+            }
+        }
+    }
+    for k := 0; k <= K; k++ {
+        for x := 0; x <= K && x <= k; x++ {
+            base := N - x
+            bases[k][x] = base
+            y := make([]int, x+1)
+            for i := 0; i <= x; i++ {
+                y[i] = dp[base+i][k][x]
+            }
+            coeff := make([]int, x+1)
+            cur := make([]int, len(y))
+            copy(cur, y)
+            for i := 0; i <= x; i++ {
+                coeff[i] = (cur[0]%MOD + MOD) % MOD
+                if i == x {
+                    break
+                }
+                next := make([]int, len(cur)-1)
+                for j := 0; j < len(cur)-1; j++ {
+                    val := cur[j+1] - cur[j]
+                    if val < 0 {
+                        val += MOD
+                    }
+                    next[j] = val % MOD
+                }
+                cur = next
+            }
+            coeffs[k][x] = coeff
+        }
+    }
+}
+
+func choose(n, r int) int {
+    if r < 0 || r > n {
+        return 0
+    }
+    res := 1
+    for i := 0; i < r; i++ {
+        res = res * ((n - i) % MOD) % MOD
+    }
+    res = res * invFact[r] % MOD
+    return res
+}
+
+func getAnswer(n, k, x int) int {
+    if x > k {
+        return 0
+    }
+    if n <= N {
+        return dp[n][k][x] % MOD
+    }
+    base := bases[k][x]
+    diff := coeffs[k][x]
+    m := n - base
+    res := 0
+    for i, c := range diff {
+        res = (res + c*choose(m, i)%MOD) % MOD
+    }
+    return res
+}
+
+func runBinary(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierF.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    precompute()
+    r := rand.New(rand.NewSource(6))
+    tests := 100
+    for i := 0; i < tests; i++ {
+        n := r.Intn(30) + 1
+        k := r.Intn(11) + 1
+        x := r.Intn(11) + 1
+        input := fmt.Sprintf("1\n%d %d %d\n", n, k, x)
+        expected := fmt.Sprintf("%d", getAnswer(n, k, x))
+        out, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        out = strings.TrimSpace(out)
+        if out != expected {
+            fmt.Printf("test %d failed: n=%d k=%d x=%d expected=%s got=%s\n", i+1, n, k, x, expected, out)
+            return
+        }
+    }
+    fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for Codeforces contest 1671 problems A–F
- each verifier generates 100 deterministic test cases and checks any solution binary

## Testing
- `go run verifierA.go ./1671A`
- `go run verifierB.go ./1671B`
- `go run verifierC.go ./1671C`
- `go run verifierD.go ./1671D`
- `go run verifierE.go ./1671E`
- `go run verifierF.go ./1671F`


------
https://chatgpt.com/codex/tasks/task_e_68874385efd48324b361813d7f80b2a5