### PR TITLE
Add verifier for 1428D

### DIFF
--- a/1000-1999/1400-1499/1420-1429/1428/verifierD.go
+++ b/1000-1999/1400-1499/1420-1429/1428/verifierD.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTestsD() []string {
+	rand.Seed(1)
+	tests := make([]string, 0, 110)
+	// some fixed edge cases
+	tests = append(tests,
+		"1\n0\n",
+		"1\n1\n",
+		"1\n2\n",
+		"1\n3\n",
+		"2\n0 0\n",
+		"2\n3 0\n",
+		"2\n0 3\n",
+		"3\n3 2 1\n",
+		"4\n1 0 2 3\n",
+		"5\n1 2 3 0 1\n",
+	)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rand.Intn(4))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "1428D.go"
+	tests := genTestsD()
+	for i, input := range tests {
+		expect, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d: expected %q got %q\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- implement `verifierD.go` for contest 1428 problem D
- include more than 100 deterministic and random tests
- verified `1428D.go` passes all tests without runtime errors

## Testing
- `go build verifierD.go`
- `./verifierD 1428D.go`

------
https://chatgpt.com/codex/tasks/task_e_688743894344832488fc81bdaaf5c65c