### PR TITLE
Add verifiers for contest 1670

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1670/verifierA.go
+++ b/1000-1999/1600-1699/1670-1679/1670/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(cmdPath string, input string) (string, error) {
+	cmd := exec.Command(cmdPath)
+	if strings.HasSuffix(cmdPath, ".go") {
+		cmd = exec.Command("go", "run", cmdPath)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1670A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n) + "\n")
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			v := rand.Intn(201) - 100
+			if v == 0 {
+				v = 1
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	// edge cases
+	tests = append(tests, "1\n1\n1\n")
+	tests = append(tests, "1\n2\n-1 2\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := run(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1670-1679/1670/verifierB.go
+++ b/1000-1999/1600-1699/1670-1679/1670/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(cmdPath string, input string) (string, error) {
+	cmd := exec.Command(cmdPath)
+	if strings.HasSuffix(cmdPath, ".go") {
+		cmd = exec.Command("go", "run", cmdPath)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1670B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(2)
+	tests := make([]string, 0, 100)
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 2
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n) + "\n")
+		for j := 0; j < n; j++ {
+			sb.WriteByte(letters[rand.Intn(26)])
+		}
+		sb.WriteByte('\n')
+		k := rand.Intn(26) + 1
+		sb.WriteString(strconv.Itoa(k))
+		sb.WriteByte(' ')
+		chosen := rand.Perm(26)[:k]
+		for j, idx := range chosen {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteByte(letters[idx])
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	// edge cases
+	sb := strings.Builder{}
+	sb.WriteString("1\n2\naa\n1 a\n")
+	tests = append(tests, sb.String())
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := run(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1670-1679/1670/verifierC.go
+++ b/1000-1999/1600-1699/1670-1679/1670/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(cmdPath string, input string) (string, error) {
+	cmd := exec.Command(cmdPath)
+	if strings.HasSuffix(cmdPath, ".go") {
+		cmd = exec.Command("go", "run", cmdPath)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1670C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(3)
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(7) + 1
+		a := rand.Perm(n)
+		b := rand.Perm(n)
+		for j := 0; j < n; j++ {
+			a[j]++
+			b[j]++
+		}
+		d := make([]int, n)
+		copy(d, a)
+		if rand.Intn(2) == 0 {
+			idx := rand.Intn(n)
+			d[idx] = 0
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n) + "\n")
+		for j, v := range a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		for j, v := range b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		for j, v := range d {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	// simple case n=1
+	tests = append(tests, "1\n1\n1\n1\n1\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := run(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1670-1679/1670/verifierD.go
+++ b/1000-1999/1600-1699/1670-1679/1670/verifierD.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(cmdPath string, input string) (string, error) {
+	cmd := exec.Command(cmdPath)
+	if strings.HasSuffix(cmdPath, ".go") {
+		cmd = exec.Command("go", "run", cmdPath)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1670D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(4)
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Int63n(1_000_000_000) + 1
+		tests = append(tests, fmt.Sprintf("1\n%d\n", n))
+	}
+	tests = append(tests, "1\n1\n")
+	tests = append(tests, "1\n1000000000\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := run(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s\ngot:%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1670-1679/1670/verifierE.go
+++ b/1000-1999/1600-1699/1670-1679/1670/verifierE.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(cmdPath string, input string) (string, error) {
+	cmd := exec.Command(cmdPath)
+	if strings.HasSuffix(cmdPath, ".go") {
+		cmd = exec.Command("go", "run", cmdPath)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1670E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTree(n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		edges = append(edges, [2]int{i, rand.Intn(i-1) + 1})
+	}
+	return edges
+}
+
+func genTests() []string {
+	rand.Seed(5)
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		x := rand.Intn(4) + 1
+		n := 1 << x
+		edges := genTree(n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(x) + "\n")
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		tests = append(tests, sb.String())
+	}
+	// minimal tree
+	tests = append(tests, "1\n1\n1 2\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := run(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1600-1699/1670-1679/1670/verifierF.go
+++ b/1000-1999/1600-1699/1670-1679/1670/verifierF.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(cmdPath string, input string) (string, error) {
+	cmd := exec.Command(cmdPath)
+	if strings.HasSuffix(cmdPath, ".go") {
+		cmd = exec.Command("go", "run", cmdPath)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1670F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(6)
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(5) + 1
+		l := rand.Int63n(50) + 1
+		r := l + rand.Int63n(50)
+		z := rand.Int63n(64)
+		tests = append(tests, fmt.Sprintf("1\n%d %d %d %d\n", n, l, r, z))
+	}
+	tests = append(tests, "1\n1 1 1 0\n")
+	tests = append(tests, "1\n2 1 3 1\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := run(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1670
- each verifier builds the reference solution and runs 100+ generated tests

## Testing
- `go build 1000-1999/1600-1699/1670-1679/1670/verifierA.go`
- `go build 1000-1999/1600-1699/1670-1679/1670/verifierB.go`
- `go build 1000-1999/1600-1699/1670-1679/1670/verifierC.go`
- `go build 1000-1999/1600-1699/1670-1679/1670/verifierD.go`
- `go build 1000-1999/1600-1699/1670-1679/1670/verifierE.go`
- `go build 1000-1999/1600-1699/1670-1679/1670/verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6887433fe9888324a941ad9ed0b498d7