### PR TITLE
Add verifiers for contest 1674

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1674/verifierA.go
+++ b/1000-1999/1600-1699/1670-1679/1674/verifierA.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(x, y int) string {
+	if y%x != 0 {
+		return "0 0"
+	}
+	return fmt.Sprintf("1 %d", y/x)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		x := rng.Intn(100) + 1
+		y := rng.Intn(100) + 1
+		input := fmt.Sprintf("1\n%d %d\n", x, y)
+		exp := expected(x, y)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1670-1679/1674/verifierB.go
+++ b/1000-1999/1600-1699/1670-1679/1674/verifierB.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(s string) string {
+	i := int(s[0] - 'a' + 1)
+	j := int(s[1] - 'a' + 1)
+	ans := (i-1)*25 + j
+	if j > i {
+		ans--
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(43))
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	for t := 0; t < 100; t++ {
+		var a, b byte
+		for {
+			a = letters[rng.Intn(26)]
+			b = letters[rng.Intn(26)]
+			if a != b {
+				break
+			}
+		}
+		s := string([]byte{a, b})
+		input := fmt.Sprintf("1\n%s\n", s)
+		exp := expected(s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\n", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1670-1679/1674/verifierC.go
+++ b/1000-1999/1600-1699/1670-1679/1674/verifierC.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(s, t string) string {
+	if t == "a" {
+		return "1"
+	}
+	if strings.Contains(t, "a") {
+		return "-1"
+	}
+	ans := int64(1)
+	for i := 0; i < len(s); i++ {
+		ans *= 2
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(44))
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	for i := 0; i < 100; i++ {
+		sLen := rng.Intn(20) + 1
+		s := strings.Repeat("a", sLen)
+		tLen := rng.Intn(20) + 1
+		var sb strings.Builder
+		for j := 0; j < tLen; j++ {
+			sb.WriteByte(letters[rng.Intn(26)])
+		}
+		t := sb.String()
+		input := fmt.Sprintf("1\n%s\n%s\n", s, t)
+		exp := expected(s, t)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1670-1679/1674/verifierD.go
+++ b/1000-1999/1600-1699/1670-1679/1674/verifierD.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(a []int) string {
+	n := len(a)
+	b := make([]int, n)
+	copy(b, a)
+	start := n % 2
+	for i := start; i+1 < n; i += 2 {
+		if b[i] > b[i+1] {
+			b[i], b[i+1] = b[i+1], b[i]
+		}
+	}
+	for i := 1; i < n; i++ {
+		if b[i-1] > b[i] {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(45))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(100)
+			sb.WriteString(fmt.Sprintf("%d ", arr[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(arr)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\n", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(strings.ToUpper(got)) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1670-1679/1674/verifierE.go
+++ b/1000-1999/1600-1699/1670-1679/1674/verifierE.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expected(arr []int) string {
+	n := len(arr)
+	vals := make([]int, n)
+	for i, v := range arr {
+		vals[i] = (v + 1) / 2
+	}
+	min1, min2 := 1<<60, 1<<60
+	for _, v := range vals {
+		if v < min1 {
+			min2 = min1
+			min1 = v
+		} else if v < min2 {
+			min2 = v
+		}
+	}
+	ans := min1 + min2
+	for i := 0; i+1 < n; i++ {
+		x, y := arr[i], arr[i+1]
+		cand := max((x+y+2)/3, max((x+1)/2, (y+1)/2))
+		if cand < ans {
+			ans = cand
+		}
+	}
+	for i := 0; i+2 < n; i++ {
+		x, z := arr[i], arr[i+2]
+		cand := max((x+z+1)/2, max((x+1)/2, (z+1)/2))
+		if cand < ans {
+			ans = cand
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(46))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(8) + 2
+		arr := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(30) + 1
+			sb.WriteString(fmt.Sprintf("%d ", arr[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(arr)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\n", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1670-1679/1674/verifierF.go
+++ b/1000-1999/1600-1699/1670-1679/1674/verifierF.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Fenwick struct{ tree []int }
+
+func NewFenwick(n int) *Fenwick { return &Fenwick{make([]int, n+2)} }
+func (f *Fenwick) Add(i, delta int) {
+	for ; i < len(f.tree); i += i & -i {
+		f.tree[i] += delta
+	}
+}
+func (f *Fenwick) Sum(i int) int {
+	s := 0
+	for ; i > 0; i -= i & -i {
+		s += f.tree[i]
+	}
+	return s
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m int, grid []string, queries [][2]int) string {
+	total := n * m
+	fw := NewFenwick(total)
+	state := make([]byte, total+1)
+	stars := 0
+	for j := 0; j < m; j++ {
+		for i := 0; i < n; i++ {
+			if grid[i][j] == '*' {
+				pos := j*n + i + 1
+				state[pos] = 1
+				fw.Add(pos, 1)
+				stars++
+			}
+		}
+	}
+	var out strings.Builder
+	for _, q := range queries {
+		x, y := q[0]-1, q[1]-1
+		pos := y*n + x + 1
+		if state[pos] == 1 {
+			state[pos] = 0
+			fw.Add(pos, -1)
+			stars--
+		} else {
+			state[pos] = 1
+			fw.Add(pos, 1)
+			stars++
+		}
+		good := fw.Sum(stars)
+		out.WriteString(fmt.Sprintf("%d\n", stars-good))
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(47))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		q := rng.Intn(8) + 1
+		grid := make([]string, n)
+		for i := 0; i < n; i++ {
+			row := make([]byte, m)
+			for j := 0; j < m; j++ {
+				if rng.Intn(2) == 0 {
+					row[j] = '.'
+				} else {
+					row[j] = '*'
+				}
+			}
+			grid[i] = string(row)
+		}
+		queries := make([][2]int, q)
+		for i := 0; i < q; i++ {
+			queries[i][0] = rng.Intn(n) + 1
+			queries[i][1] = rng.Intn(m) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+		for i := 0; i < n; i++ {
+			sb.WriteString(grid[i] + "\n")
+		}
+		for i := 0; i < q; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", queries[i][0], queries[i][1]))
+		}
+		input := sb.String()
+		exp := expected(n, m, grid, queries)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\n", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1670-1679/1674/verifierG.go
+++ b/1000-1999/1600-1699/1670-1679/1674/verifierG.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, edges [][2]int) string {
+	adj := make([][]int, n+1)
+	indeg := make([]int, n+1)
+	outdeg := make([]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		indeg[v]++
+		outdeg[u]++
+	}
+	indeg2 := make([]int, n+1)
+	copy(indeg2, indeg)
+	queue := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		if indeg2[i] == 0 {
+			queue = append(queue, i)
+		}
+	}
+	order := make([]int, 0, n)
+	for len(queue) > 0 {
+		v := queue[0]
+		queue = queue[1:]
+		order = append(order, v)
+		for _, to := range adj[v] {
+			indeg2[to]--
+			if indeg2[to] == 0 {
+				queue = append(queue, to)
+			}
+		}
+	}
+	dp := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		dp[i] = 1
+	}
+	ans := 1
+	for _, v := range order {
+		for _, to := range adj[v] {
+			if outdeg[v] > 1 && indeg[to] > 1 {
+				if dp[v]+1 > dp[to] {
+					dp[to] = dp[v] + 1
+					if dp[to] > ans {
+						ans = dp[to]
+					}
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(48))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(n*(n-1)/2 + 1)
+		edgeSet := make(map[[2]int]bool)
+		edges := make([][2]int, 0, m)
+		for len(edges) < m {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			// ensure acyclicity by only adding if u < v randomly
+			if rng.Intn(2) == 0 {
+				if u > v {
+					u, v = v, u
+				}
+			} else {
+				if v > u {
+					u, v = v, u
+				}
+			}
+			e := [2]int{u, v}
+			if !edgeSet[e] {
+				edgeSet[e] = true
+				edges = append(edges, e)
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input := sb.String()
+		exp := expected(n, edges)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\n", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1674 problems A–G
- each verifier generates at least 100 random tests and checks a candidate binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_6887445810908324abafa67875bb2117