### PR TITLE
Add Go verifiers for Codeforces contest 1678

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1678/verifierA.go
+++ b/1000-1999/1600-1699/1670-1679/1678/verifierA.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func solveCase(n int, arr []int) int {
+	zeros := 0
+	freq := make(map[int]int)
+	dup := false
+	for _, v := range arr {
+		if v == 0 {
+			zeros++
+		}
+		freq[v]++
+		if freq[v] > 1 {
+			dup = true
+		}
+	}
+	if zeros > 0 {
+		return n - zeros
+	}
+	if dup {
+		return n
+	}
+	return n + 1
+}
+
+func buildCase(arr []int) testCase {
+	var sb strings.Builder
+	n := len(arr)
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: solveCase(n, arr)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(99) + 2
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(101)
+	}
+	return buildCase(arr)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != 1 {
+		return fmt.Errorf("expected 1 number got %d", len(fields))
+	}
+	var val int
+	if _, err := fmt.Sscan(fields[0], &val); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if val != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	var cases []testCase
+
+	// deterministic edge cases
+	cases = append(cases, buildCase([]int{0, 0}))
+	cases = append(cases, buildCase([]int{1, 2}))
+	cases = append(cases, buildCase([]int{1, 1}))
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1670-1679/1678/verifierB1.go
+++ b/1000-1999/1600-1699/1670-1679/1678/verifierB1.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func solveCase(n int, s string) int {
+	ops := 0
+	for i := 0; i < n; i += 2 {
+		if s[i] != s[i+1] {
+			ops++
+		}
+	}
+	return ops
+}
+
+func buildCase(s string) testCase {
+	var sb strings.Builder
+	n := len(s)
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+	return testCase{input: sb.String(), expected: solveCase(n, s)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100)*2 + 2
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return buildCase(string(b))
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != 1 {
+		return fmt.Errorf("expected 1 number got %d", len(fields))
+	}
+	var val int
+	if _, err := fmt.Sscan(fields[0], &val); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if val != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(2))
+	var cases []testCase
+
+	// edge cases
+	cases = append(cases, buildCase("00"))
+	cases = append(cases, buildCase("01"))
+	cases = append(cases, buildCase("10"))
+	cases = append(cases, buildCase("11"))
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1670-1679/1678/verifierB2.go
+++ b/1000-1999/1600-1699/1670-1679/1678/verifierB2.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input       string
+	expectedOps int
+	expectedSeg int
+}
+
+func solveCase(n int, s string) (int, int) {
+	k := n / 2
+	ops := 0
+	pred := make([]byte, 0, k)
+	for i := 0; i < k; i++ {
+		a := s[2*i]
+		b := s[2*i+1]
+		if a != b {
+			ops++
+		} else {
+			pred = append(pred, a)
+		}
+	}
+	seg := 1
+	if len(pred) > 0 {
+		seg = 1
+		for i := 1; i < len(pred); i++ {
+			if pred[i] != pred[i-1] {
+				seg++
+			}
+		}
+	}
+	return ops, seg
+}
+
+func buildCase(s string) testCase {
+	var sb strings.Builder
+	n := len(s)
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+	ops, seg := solveCase(n, s)
+	return testCase{input: sb.String(), expectedOps: ops, expectedSeg: seg}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100)*2 + 2
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return buildCase(string(b))
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != 2 {
+		return fmt.Errorf("expected 2 numbers got %d", len(fields))
+	}
+	var gotOps, gotSeg int
+	if _, err := fmt.Sscan(fields[0], &gotOps); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if _, err := fmt.Sscan(fields[1], &gotSeg); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if gotOps != tc.expectedOps || gotSeg != tc.expectedSeg {
+		return fmt.Errorf("expected %d %d got %d %d", tc.expectedOps, tc.expectedSeg, gotOps, gotSeg)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(3))
+	var cases []testCase
+
+	// edge cases
+	cases = append(cases, buildCase("00"))
+	cases = append(cases, buildCase("01"))
+	cases = append(cases, buildCase("10"))
+	cases = append(cases, buildCase("11"))
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`, `verifierB1.go`, and `verifierB2.go` in contest 1678 directory
- each verifier generates 100+ test cases and checks a provided binary

## Testing
- `go run verifierA.go ./1678A.bin`
- `go run verifierB1.go ./1678B1.bin`
- `go run verifierB2.go ./1678B2.bin`

------
https://chatgpt.com/codex/tasks/task_e_6887457033f08324bf937baa7313447f