### PR TITLE
Add verifiers for CF 1673

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1673/verifierA.go
+++ b/1000-1999/1600-1699/1670-1679/1673/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	s string
+}
+
+func generateTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	tests := []testCase{{"a"}, {"z"}, {"aa"}, {"ab"}, {"abc"}}
+	for len(tests) < 100 {
+		n := r.Intn(10) + 1
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b[i] = byte('a' + r.Intn(26))
+		}
+		tests = append(tests, testCase{s: string(b)})
+	}
+	return tests
+}
+
+func expected(s string) string {
+	n := len(s)
+	total := 0
+	for i := 0; i < n; i++ {
+		total += int(s[i]-'a') + 1
+	}
+	if n == 1 {
+		return fmt.Sprintf("Bob %d", total)
+	}
+	if n%2 == 0 {
+		return fmt.Sprintf("Alice %d", total)
+	}
+	first := int(s[0]-'a') + 1
+	last := int(s[n-1]-'a') + 1
+	bob := first
+	if last < bob {
+		bob = last
+	}
+	alice := total - bob
+	if alice > bob {
+		return fmt.Sprintf("Alice %d", alice-bob)
+	}
+	return fmt.Sprintf("Bob %d", bob-alice)
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("1\n%s\n", t.s)
+		want := expected(t.s)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.ToUpper(strings.TrimSpace(got)) != strings.ToUpper(want) {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, want, strings.TrimSpace(got))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1670-1679/1673/verifierB.go
+++ b/1000-1999/1600-1699/1670-1679/1673/verifierB.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	s string
+}
+
+func generateTests() []testCase {
+	r := rand.New(rand.NewSource(2))
+	tests := []testCase{{"a"}, {"ab"}, {"abb"}, {"abc"}, {"aabb"}}
+	for len(tests) < 100 {
+		n := r.Intn(8) + 1
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b[i] = byte('a' + r.Intn(3))
+		}
+		tests = append(tests, testCase{s: string(b)})
+	}
+	return tests
+}
+
+func expected(s string) string {
+	letters := make(map[byte]bool)
+	for i := 0; i < len(s); i++ {
+		letters[s[i]] = true
+	}
+	n := len(s)
+	pref := make([][26]int, n+1)
+	for i := 1; i <= n; i++ {
+		pref[i] = pref[i-1]
+		pref[i][s[i-1]-'a']++
+	}
+	pos := make(map[byte][]int)
+	for i := 0; i < n; i++ {
+		c := s[i]
+		pos[c] = append(pos[c], i+1)
+	}
+	balanced := true
+	for _, arr := range pos {
+		for j := 1; j < len(arr) && balanced; j++ {
+			l := arr[j-1]
+			r := arr[j]
+			for ch := range letters {
+				idx := ch - 'a'
+				if pref[r][idx]-pref[l-1][idx] == 0 {
+					balanced = false
+					break
+				}
+			}
+		}
+		if !balanced {
+			break
+		}
+	}
+	if balanced {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("1\n%s\n", t.s)
+		want := expected(t.s)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.ToUpper(strings.TrimSpace(got)) != want {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, want, strings.TrimSpace(got))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1670-1679/1673/verifierC.go
+++ b/1000-1999/1600-1699/1670-1679/1673/verifierC.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int = 1e9 + 7
+const MAXN int = 40000
+
+func generatePalindromes(limit int) []int {
+	res := make([]int, 0)
+	for i := 1; i <= limit; i++ {
+		if isPalindrome(i) {
+			res = append(res, i)
+		}
+	}
+	return res
+}
+
+func isPalindrome(x int) bool {
+	orig := x
+	rev := 0
+	for x > 0 {
+		rev = rev*10 + x%10
+		x /= 10
+	}
+	return orig == rev
+}
+
+func precompute() []int {
+	pals := generatePalindromes(MAXN)
+	dp := make([]int, MAXN+1)
+	dp[0] = 1
+	for _, v := range pals {
+		for i := v; i <= MAXN; i++ {
+			dp[i] += dp[i-v]
+			if dp[i] >= MOD {
+				dp[i] -= MOD
+			}
+		}
+	}
+	return dp
+}
+
+var dp = precompute()
+
+type testCase struct {
+	n int
+}
+
+func generateTests() []testCase {
+	r := rand.New(rand.NewSource(3))
+	tests := []testCase{{1}, {2}, {3}, {4}, {5}}
+	for len(tests) < 100 {
+		tests = append(tests, testCase{n: r.Intn(MAXN) + 1})
+	}
+	return tests
+}
+
+func expected(n int) string {
+	return fmt.Sprintf("%d", dp[n])
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("1\n%d\n", t.n)
+		want := expected(t.n)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, want, strings.TrimSpace(got))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1670-1679/1673/verifierD.go
+++ b/1000-1999/1600-1699/1670-1679/1673/verifierD.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1_000_000_007
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int64) int64 {
+	return a / gcd(a, b) * b
+}
+
+type testCase struct {
+	b, q, y int64
+	c, r, z int64
+}
+
+func generateTests() []testCase {
+	r := rand.New(rand.NewSource(4))
+	tests := []testCase{
+		{0, 1, 2, 0, 1, 2},
+		{1, 2, 3, 1, 2, 2},
+	}
+	for len(tests) < 100 {
+		b := int64(r.Intn(21) - 10)
+		q := int64(r.Intn(10) + 1)
+		y := int64(r.Intn(9) + 2)
+		c := int64(r.Intn(21) - 10)
+		r2 := int64(r.Intn(10) + 1)
+		z := int64(r.Intn(9) + 2)
+		tests = append(tests, testCase{b, q, y, c, r2, z})
+	}
+	return tests
+}
+
+func expected(t testCase) string {
+	b, q, y := t.b, t.q, t.y
+	c, rVal, z := t.c, t.r, t.z
+	lastB := b + (y-1)*q
+	lastC := c + (z-1)*rVal
+	if (c-b)%q != 0 || rVal%q != 0 || c < b || lastC > lastB {
+		return "0"
+	}
+	if c-rVal < b || c+z*rVal > lastB {
+		return "-1"
+	}
+	ans := int64(0)
+	for d := int64(1); d*d <= rVal; d++ {
+		if rVal%d == 0 {
+			if lcm(d, q) == rVal {
+				x := rVal / d
+				ans = (ans + x*x) % MOD
+			}
+			d2 := rVal / d
+			if d2 != d && lcm(d2, q) == rVal {
+				x := rVal / d2
+				ans = (ans + x*x) % MOD
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans%MOD)
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("1\n%d %d %d\n%d %d %d\n", t.b, t.q, t.y, t.c, t.r, t.z)
+		want := expected(t)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, want, strings.TrimSpace(got))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1670-1679/1673/verifierE.go
+++ b/1000-1999/1600-1699/1670-1679/1673/verifierE.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const LIM = 1 << 20
+
+type testCase struct {
+	n int
+	k int
+	b []int
+}
+
+func generateTests() []testCase {
+	r := rand.New(rand.NewSource(5))
+	tests := []testCase{{n: 1, k: 1, b: []int{1}}, {n: 2, k: 1, b: []int{1, 2}}}
+	for len(tests) < 100 {
+		n := r.Intn(5) + 1
+		k := r.Intn(n) + 1
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			b[i] = r.Intn(5) + 1
+		}
+		tests = append(tests, testCase{n, k, b})
+	}
+	return tests
+}
+
+func expected(t testCase) string {
+	n, k := t.n, t.k
+	B := t.b
+	if n > 20 {
+		return "0"
+	}
+	var ans uint64
+	var dfs func(pos, cnt int, curProd int, curVal uint64)
+	dfs = func(pos, cnt int, curProd int, curVal uint64) {
+		if pos == n-1 {
+			if curProd < LIM {
+				curVal ^= 1 << curProd
+			}
+			if cnt >= k {
+				ans ^= curVal
+			}
+			return
+		}
+		nextProd := curProd * B[pos+1]
+		dfs(pos+1, cnt, nextProd, curVal)
+		val := curVal
+		if curProd < LIM {
+			val ^= 1 << curProd
+		}
+		dfs(pos+1, cnt+1, B[pos+1], val)
+	}
+	dfs(0, 0, B[0], 0)
+	if ans == 0 {
+		return "0"
+	}
+	out := ""
+	for ans > 0 {
+		if ans&1 == 1 {
+			out = "1" + out
+		} else {
+			out = "0" + out
+		}
+		ans >>= 1
+	}
+	return out
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.n, t.k)
+		for j, v := range t.b {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		want := expected(t)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, want, strings.TrimSpace(got))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1670-1679/1673/verifierF.go
+++ b/1000-1999/1600-1699/1670-1679/1673/verifierF.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem F is interactive and cannot be automatically verified.")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1673 problems A‑F
- verifiers A‑E generate 100+ random tests each
- verifier F prints message that the problem is interactive

## Testing
- `go run verifierA.go ./solverA`
- `go run verifierB.go ./solverB`
- `go run verifierC.go ./solverC`
- `go run verifierD.go ./solverD`
- `go run verifierE.go ./solverE`


------
https://chatgpt.com/codex/tasks/task_e_6887441204d48324a0a41a7f333f5550