### PR TITLE
Fix 1009G verifier random mask generation

### DIFF
--- a/1000-1999/1000-1099/1000-1009/1009/verifierG.go
+++ b/1000-1999/1000-1099/1000-1009/1009/verifierG.go
@@ -48,10 +48,8 @@ func genCaseG(rng *rand.Rand) (string, int, [][2]interface{}) {
 	ops := make([][2]interface{}, m)
 	for i := 0; i < m; i++ {
 		pos := rng.Intn(n) + 1
-		mask := 0
-		letters := rng.Intn(1 << 6)
-		// ensure some letters chosen
-		mask = letters
+		// pick a non-empty subset of letters [a-f]
+		mask := rng.Intn((1<<6)-1) + 1
 		ops[i][0] = pos
 		ops[i][1] = mask
 	}


### PR DESCRIPTION
## Summary
- ensure verifier for problem 1009G never generates an empty letter mask

## Testing
- `go run verifierG.go /tmp/1009G_bin`

------
https://chatgpt.com/codex/tasks/task_e_6887462ad0a48324a46bc0a4cf6a2e24