### PR TITLE
Add Go verifiers for contest 1680

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1680/verifierA.go
+++ b/1000-1999/1600-1699/1680-1689/1680/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1680A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	l1 := rng.Intn(50) + 1
+	r1 := l1 + rng.Intn(50-l1+1)
+	l2 := rng.Intn(50) + 1
+	r2 := l2 + rng.Intn(50-l2+1)
+	return fmt.Sprintf("1\n%d %d %d %d\n", l1, r1, l2, r2)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1600-1699/1680-1689/1680/verifierB.go
+++ b/1000-1999/1600-1699/1680-1689/1680/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1680B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	grid := make([]string, n)
+	hasR := false
+	for i := 0; i < n; i++ {
+		var b strings.Builder
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				b.WriteByte('E')
+			} else {
+				b.WriteByte('R')
+				hasR = true
+			}
+		}
+		grid[i] = b.String()
+	}
+	if !hasR {
+		i := rng.Intn(n)
+		j := rng.Intn(m)
+		row := []byte(grid[i])
+		row[j] = 'R'
+		grid[i] = string(row)
+	}
+	var input strings.Builder
+	input.WriteString("1\n")
+	fmt.Fprintf(&input, "%d %d\n", n, m)
+	for _, g := range grid {
+		input.WriteString(g)
+		input.WriteByte('\n')
+	}
+	return input.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1600-1699/1680-1689/1680/verifierC.go
+++ b/1000-1999/1600-1699/1680-1689/1680/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1680C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(50) + 1
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b.WriteByte('0')
+		} else {
+			b.WriteByte('1')
+		}
+	}
+	return fmt.Sprintf("1\n%s\n", b.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1600-1699/1680-1689/1680/verifierD.go
+++ b/1000-1999/1600-1699/1680-1689/1680/verifierD.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1680D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Intn(21) - 10
+		sb.WriteString(strconv.Itoa(val))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1600-1699/1680-1689/1680/verifierE.go
+++ b/1000-1999/1600-1699/1680-1689/1680/verifierE.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1680E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var s1, s2 strings.Builder
+	has := false
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			s1.WriteByte('.')
+		} else {
+			s1.WriteByte('*')
+			has = true
+		}
+	}
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			s2.WriteByte('.')
+		} else {
+			s2.WriteByte('*')
+			has = true
+		}
+	}
+	if !has {
+		if rng.Intn(2) == 0 {
+			pos := rng.Intn(n)
+			b := []byte(s1.String())
+			b[pos] = '*'
+			s1.Reset()
+			s1.WriteString(string(b))
+		} else {
+			pos := rng.Intn(n)
+			b := []byte(s2.String())
+			b[pos] = '*'
+			s2.Reset()
+			s2.WriteString(string(b))
+		}
+	}
+	return fmt.Sprintf("1\n%d\n%s\n%s\n", n, s1.String(), s2.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/1000-1999/1600-1699/1680-1689/1680/verifierF.go
+++ b/1000-1999/1600-1699/1680-1689/1680/verifierF.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1680F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type edge struct{ u, v int }
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	maxEdges := n * (n - 1) / 2
+	m := n - 1 + rng.Intn(maxEdges-(n-1)+1)
+	edges := make([]edge, 0, m)
+	seen := make(map[[2]int]bool)
+	for i := 2; i <= n; i++ {
+		v := rng.Intn(i-1) + 1
+		edges = append(edges, edge{i, v})
+		seen[[2]int{i, v}] = true
+		seen[[2]int{v, i}] = true
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if seen[[2]int{u, v}] {
+			continue
+		}
+		edges = append(edges, edge{u, v})
+		seen[[2]int{u, v}] = true
+		seen[[2]int{v, u}] = true
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for problems A–F of contest 1680
- each verifier compiles the official solution as an oracle
- generate at least 100 random test cases per problem and compare outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688745fc520483248010765131d3da04