### PR TITLE
Add Go verifiers for Codeforces round 1689

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1689/verifierA.go
+++ b/1000-1999/1600-1699/1680-1689/1689/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n, m, k int
+	a, b    string
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("1\n%d %d %d\n%s\n%s\n", t.n, t.m, t.k, t.a, t.b)
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleA"
+	cmd := exec.Command("go", "build", "-o", ref, "1689A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	lettersA := []rune("abcdefghijklm")
+	lettersB := []rune("nopqrstuvwxyz")
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		k := rng.Intn(10) + 1
+		a := make([]rune, n)
+		b := make([]rune, m)
+		for j := 0; j < n; j++ {
+			a[j] = lettersA[rng.Intn(len(lettersA))]
+		}
+		for j := 0; j < m; j++ {
+			b[j] = lettersB[rng.Intn(len(lettersB))]
+		}
+		tests[i] = Test{n, m, k, string(a), string(b)}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1680-1689/1689/verifierB.go
+++ b/1000-1999/1600-1699/1680-1689/1689/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	p []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.p)))
+	for i, v := range t.p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleB"
+	cmd := exec.Command("go", "build", "-o", ref, "1689B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		arr := rand.Perm(n)
+		for j := range arr {
+			arr[j]++
+		}
+		tests[i] = Test{p: arr}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1680-1689/1689/verifierC.go
+++ b/1000-1999/1600-1699/1680-1689/1689/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n     int
+	edges [][2]int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", t.n))
+	for _, e := range t.edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleC"
+	cmd := exec.Command("go", "build", "-o", ref, "1689C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(9) + 2 // 2..10
+		edges := make([][2]int, n-1)
+		for v := 2; v <= n; v++ {
+			p := rng.Intn(v-1) + 1
+			edges[v-2] = [2]int{p, v}
+		}
+		tests[i] = Test{n: n, edges: edges}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1680-1689/1689/verifierD.go
+++ b/1000-1999/1600-1699/1680-1689/1689/verifierD.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n, m int
+	grid []string
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.m))
+	for _, row := range t.grid {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleD"
+	cmd := exec.Command("go", "build", "-o", ref, "1689D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 2 // 2..9
+		m := rng.Intn(8) + 2
+		grid := make([]string, n)
+		hasB := false
+		for r := 0; r < n; r++ {
+			row := make([]byte, m)
+			for c := 0; c < m; c++ {
+				if rng.Intn(3) == 0 { // 1/3 chance B
+					row[c] = 'B'
+					hasB = true
+				} else {
+					row[c] = 'W'
+				}
+			}
+			grid[r] = string(row)
+		}
+		if !hasB {
+			// ensure at least one B
+			grid[0] = "B" + grid[0][1:]
+		}
+		tests[i] = Test{n, m, grid}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1680-1689/1689/verifierE.go
+++ b/1000-1999/1600-1699/1680-1689/1689/verifierE.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	arr []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.arr)))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleE"
+	cmd := exec.Command("go", "build", "-o", ref, "1689E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 2 // 2..9
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(64) // 0..63
+		}
+		tests[i] = Test{arr: arr}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for problems A–E of contest 1689
- each verifier builds the official solution and runs 100 random tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_68874872a3e883248434265b0a418506