### PR TITLE
Add verifiers for contest 1685

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1685/verifierA.go
+++ b/1000-1999/1600-1699/1680-1689/1685/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]string, 0, 100)
+	for len(tests) < 100 {
+		n := r.Intn(8) + 3 // 3..10
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(r.Intn(20)))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refA")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1685A.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, input := range tests {
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\n", i+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\n", i+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sactual:%s", i+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1680-1689/1685/verifierB.go
+++ b/1000-1999/1600-1699/1680-1689/1685/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]string, 0, 100)
+	for len(tests) < 100 {
+		n := r.Intn(10) + 1 // length of string
+		c := r.Intn(n/2 + 1)
+		d := r.Intn((n-2*c)/2 + 1)
+		if 2*(c+d) > n {
+			continue
+		}
+		leftover := n - 2*(c+d)
+		a := r.Intn(leftover + 1)
+		b := leftover - a
+		numA := a + c + d
+		numB := b + c + d
+		arr := make([]byte, n)
+		for i := 0; i < numA; i++ {
+			arr[i] = 'A'
+		}
+		for i := 0; i < numB; i++ {
+			arr[numA+i] = 'B'
+		}
+		r.Shuffle(n, func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+		s := string(arr)
+		tests = append(tests, fmt.Sprintf("1\n%d %d %d %d\n%s\n", a, b, c, d, s))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refB")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1685B.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, input := range tests {
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\n", i+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\n", i+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sactual:%s", i+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1680-1689/1685/verifierC.go
+++ b/1000-1999/1600-1699/1680-1689/1685/verifierC.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(3))
+	tests := make([]string, 0, 100)
+	for len(tests) < 100 {
+		n := r.Intn(5) + 1 // 1..5
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for i := 0; i < 2*n; i++ {
+			if r.Intn(2) == 0 {
+				sb.WriteByte('(')
+			} else {
+				sb.WriteByte(')')
+			}
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refC")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1685C.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, input := range tests {
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\n", i+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\n", i+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sactual:%s", i+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1680-1689/1685/verifierD1.go
+++ b/1000-1999/1600-1699/1680-1689/1685/verifierD1.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(4))
+	tests := make([]string, 0, 100)
+	for len(tests) < 100 {
+		n := r.Intn(5) + 2 // 2..6
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		perm := r.Perm(n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(perm[i] + 1))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refD1")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1685D1.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, input := range tests {
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\n", i+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\n", i+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sactual:%s", i+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1680-1689/1685/verifierD2.go
+++ b/1000-1999/1600-1699/1680-1689/1685/verifierD2.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(5))
+	tests := make([]string, 0, 100)
+	for len(tests) < 100 {
+		n := r.Intn(6) + 1 // 1..6
+		perm := r.Perm(n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(perm[i] + 1))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refD2")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1685D2.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, input := range tests {
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\n", i+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\n", i+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sactual:%s", i+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1600-1699/1680-1689/1685/verifierE.go
+++ b/1000-1999/1600-1699/1680-1689/1685/verifierE.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(6))
+	tests := make([]string, 0, 100)
+	for len(tests) < 100 {
+		n := r.Intn(3) + 1 // 1..3
+		q := r.Intn(3) + 1 // 1..3
+		m := 2*n + 1
+		perm := r.Perm(m)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i := 0; i < m; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(perm[i] + 1))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < q; i++ {
+			u := r.Intn(m) + 1
+			v := r.Intn(m) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refE")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1685E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, input := range tests {
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\n", i+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\n", i+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sactual:%s", i+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- create Go verifiers for Codeforces contest 1685 problems A–E and D1/D2
- each verifier builds the provided Go solution, generates 100 random tests and checks the candidate binary against it

## Testing
- `go run verifierA.go ./testA`
- `go run verifierB.go ./testB`
- `go run verifierC.go ./testC`
- `timeout 5 go run verifierD1.go ./testD1`
- `go run verifierD2.go ./testD2`
- `go run verifierE.go ./testE`


------
https://chatgpt.com/codex/tasks/task_e_6887475a6f648324b397e901ab83a81e