### PR TITLE
Add verifiers for contest 1691

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1691/verifierA.go
+++ b/1000-1999/1600-1699/1690-1699/1691/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1691A.go")
+	refBin := filepath.Join(os.TempDir(), "1691A_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 3
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(1000)+1))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1691/verifierB.go
+++ b/1000-1999/1600-1699/1690-1699/1691/verifierB.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1691B.go")
+	refBin := filepath.Join(os.TempDir(), "1691B_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 1
+	arr := make([]int, n)
+	cur := rand.Intn(3) + 1
+	for i := 0; i < n; i++ {
+		cur += rand.Intn(3)
+		arr[i] = cur
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1691/verifierC.go
+++ b/1000-1999/1600-1699/1690-1699/1691/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1691C.go")
+	refBin := filepath.Join(os.TempDir(), "1691C_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 2
+	k := rand.Intn(n + 1)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if rand.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1691/verifierD.go
+++ b/1000-1999/1600-1699/1690-1699/1691/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1691D.go")
+	refBin := filepath.Join(os.TempDir(), "1691D_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(21)-10))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1691/verifierE.go
+++ b/1000-1999/1600-1699/1690-1699/1691/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1691E.go")
+	refBin := filepath.Join(os.TempDir(), "1691E_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(6) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		c := rand.Intn(2)
+		l := rand.Intn(20)
+		r := l + rand.Intn(5)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", c, l, r))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1691/verifierF.go
+++ b/1000-1999/1600-1699/1690-1699/1691/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1691F.go")
+	refBin := filepath.Join(os.TempDir(), "1691F_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 3
+	k := rand.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, i))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for contest 1691 problems A–F
- each verifier compiles the reference solution, generates random tests and checks candidate output

## Testing
- `gofmt -w 1000-1999/1600-1699/1690-1699/1691/verifier*.go`

------
https://chatgpt.com/codex/tasks/task_e_688748fed0508324a8ff17898d4547b0