### PR TITLE
Add Go solution verifiers for CF 1693

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1693/verifierA.go
+++ b/1000-1999/1600-1699/1690-1699/1693/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(a []int) string {
+	sum := 0
+	zeroReached := false
+	ok := true
+	for _, x := range a {
+		sum += x
+		if sum < 0 {
+			ok = false
+		}
+		if zeroReached && sum != 0 {
+			ok = false
+		}
+		if sum == 0 {
+			zeroReached = true
+		}
+	}
+	if sum != 0 {
+		ok = false
+	}
+	if ok {
+		return "Yes"
+	}
+	return "No"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	const t = 100
+	var input strings.Builder
+	var expected strings.Builder
+	input.WriteString(fmt.Sprintln(t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(10) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rand.Intn(7) - 3
+		}
+		input.WriteString(fmt.Sprintln(n))
+		for j, x := range arr {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", x))
+		}
+		input.WriteByte('\n')
+		expected.WriteString(solveCase(arr))
+		expected.WriteByte('\n')
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error running binary: %v\noutput:\n%s", err, out.String())
+		os.Exit(1)
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(expected.String())
+	if normalize(got) != normalize(want) {
+		fmt.Fprintf(os.Stderr, "wrong answer\nexpected:\n%s\ngot:\n%s\n", want, got)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}
+
+func normalize(s string) string {
+	var res []string
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		res = append(res, strings.ToLower(strings.TrimSpace(scanner.Text())))
+	}
+	return strings.Join(res, "\n")
+}

--- a/1000-1999/1600-1699/1690-1699/1693/verifierB.go
+++ b/1000-1999/1600-1699/1690-1699/1693/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestB struct {
+	n       int
+	parents []int
+	l       []int64
+	r       []int64
+}
+
+func solveB(t TestB) int {
+	g := make([][]int, t.n)
+	for i := 1; i < t.n; i++ {
+		p := t.parents[i-1] - 1
+		g[p] = append(g[p], i)
+	}
+	var dfs func(int) int64
+	res := 0
+	dfs = func(v int) int64 {
+		sum := int64(0)
+		for _, to := range g[v] {
+			sum += dfs(to)
+		}
+		if sum < t.l[v] {
+			res++
+			return t.r[v]
+		}
+		if sum > t.r[v] {
+			return t.r[v]
+		}
+		return sum
+	}
+	dfs(0)
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(43)
+	const tCases = 100
+	var sb strings.Builder
+	var exp strings.Builder
+	sb.WriteString(fmt.Sprintln(tCases))
+	for i := 0; i < tCases; i++ {
+		n := rand.Intn(9) + 2
+		parents := make([]int, n-1)
+		for j := 1; j < n; j++ {
+			parents[j-1] = rand.Intn(j) + 1
+		}
+		l := make([]int64, n)
+		r := make([]int64, n)
+		for j := 0; j < n; j++ {
+			low := rand.Intn(10) + 1
+			high := low + rand.Intn(5)
+			l[j] = int64(low)
+			r[j] = int64(high)
+		}
+		sb.WriteString(fmt.Sprintln(n))
+		for j, p := range parents {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", p))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", l[j], r[j]))
+		}
+		exp.WriteString(fmt.Sprintf("%d\n", solveB(TestB{n, parents, l, r})))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error running binary: %v\noutput:\n%s", err, out.String())
+		os.Exit(1)
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(exp.String())
+	if got != want {
+		fmt.Fprintf(os.Stderr, "wrong answer\nexpected:\n%s\ngot:\n%s\n", want, got)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1693/verifierC.go
+++ b/1000-1999/1600-1699/1690-1699/1693/verifierC.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type item struct {
+	node int
+	dist int
+}
+
+type priorityQueue []item
+
+func (pq priorityQueue) Len() int            { return len(pq) }
+func (pq priorityQueue) Less(i, j int) bool  { return pq[i].dist < pq[j].dist }
+func (pq priorityQueue) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *priorityQueue) Push(x interface{}) { *pq = append(*pq, x.(item)) }
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	x := old[n-1]
+	*pq = old[:n-1]
+	return x
+}
+
+func solveC(n int, edges [][2]int) int {
+	rev := make([][]int, n+1)
+	outDeg := make([]int, n+1)
+	for _, e := range edges {
+		v, u := e[0], e[1]
+		rev[u] = append(rev[u], v)
+		outDeg[v]++
+	}
+	const inf = math.MaxInt32
+	dist := make([]int, n+1)
+	for i := range dist {
+		dist[i] = inf
+	}
+	processed := make([]int, n+1)
+	pq := &priorityQueue{}
+	heap.Init(pq)
+	dist[n] = 0
+	heap.Push(pq, item{n, 0})
+	for pq.Len() > 0 {
+		cur := heap.Pop(pq).(item)
+		u := cur.node
+		if cur.dist != dist[u] {
+			continue
+		}
+		for _, v := range rev[u] {
+			processed[v]++
+			cand := dist[u] + 1 + outDeg[v] - processed[v]
+			if cand < dist[v] {
+				dist[v] = cand
+				heap.Push(pq, item{v, cand})
+			}
+		}
+	}
+	return dist[1]
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(44)
+	const t = 100
+	var sb strings.Builder
+	var exp strings.Builder
+	for i := 0; i < t; i++ {
+		n := rand.Intn(5) + 2
+		// create path edges
+		edges := make([][2]int, 0)
+		for j := 1; j < n; j++ {
+			edges = append(edges, [2]int{j, j + 1})
+		}
+		// add random extra edges
+		extra := rand.Intn(n)
+		for k := 0; k < extra; k++ {
+			v := rand.Intn(n-1) + 1
+			u := rand.Intn(n-v) + v + 1
+			edges = append(edges, [2]int{v, u})
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		exp.WriteString(fmt.Sprintf("%d\n", solveC(n, edges)))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error running binary: %v\noutput:\n%s", err, out.String())
+		os.Exit(1)
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(exp.String())
+	if got != want {
+		fmt.Fprintf(os.Stderr, "wrong answer\nexpected:\n%s\ngot:\n%s\n", want, got)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1693/verifierD.go
+++ b/1000-1999/1600-1699/1690-1699/1693/verifierD.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func extend(states [][2]int, x int) [][2]int {
+	next := make([][2]int, 0, len(states)*2)
+	for _, st := range states {
+		if x > st[0] {
+			next = append(next, [2]int{x, st[1]})
+		}
+		if x < st[1] {
+			next = append(next, [2]int{st[0], x})
+		}
+	}
+	res := make([][2]int, 0, 2)
+	for _, st := range next {
+		dominated := false
+		for i := 0; i < len(res); {
+			ot := res[i]
+			if st[0] >= ot[0] && st[1] <= ot[1] {
+				dominated = true
+				break
+			}
+			if st[0] <= ot[0] && st[1] >= ot[1] {
+				res[i] = res[len(res)-1]
+				res = res[:len(res)-1]
+			} else {
+				i++
+			}
+		}
+		if !dominated {
+			res = append(res, st)
+		}
+	}
+	return res
+}
+
+func isDecinc(arr []int) bool {
+	states := [][2]int{{math.MinInt64, math.MaxInt64}}
+	for _, x := range arr {
+		states = extend(states, x)
+		if len(states) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func solveD(p []int) int64 {
+	n := len(p)
+	var ans int64
+	for l := 0; l < n; l++ {
+		states := [][2]int{{math.MinInt64, math.MaxInt64}}
+		for r := l; r < n; r++ {
+			states = extend(states, p[r])
+			if len(states) == 0 {
+				break
+			}
+			ans++
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(45)
+	const t = 100
+	var sb strings.Builder
+	var exp strings.Builder
+	for i := 0; i < t; i++ {
+		n := rand.Intn(6) + 1
+		perm := rand.Perm(n)
+		for j := range perm {
+			perm[j]++
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range perm {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		exp.WriteString(fmt.Sprintf("%d\n", solveD(perm)))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error running binary: %v\noutput:\n%s", err, out.String())
+		os.Exit(1)
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(exp.String())
+	if got != want {
+		fmt.Fprintf(os.Stderr, "wrong answer\nexpected:\n%s\ngot:\n%s\n", want, got)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1693/verifierE.go
+++ b/1000-1999/1600-1699/1690-1699/1693/verifierE.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type state struct {
+	arr  []int
+	dist int
+}
+
+func allZero(a []int) bool {
+	for _, v := range a[1 : len(a)-1] {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func serialize(a []int) string {
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String()
+}
+
+func minOps(a []int) int {
+	start := append([]int(nil), a...)
+	q := list.New()
+	q.PushBack(state{start, 0})
+	seen := map[string]bool{}
+	for q.Len() > 0 {
+		e := q.Remove(q.Front()).(state)
+		key := serialize(e.arr)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		if allZero(e.arr) {
+			return e.dist
+		}
+		maxVal := -1
+		for _, v := range e.arr {
+			if v > maxVal {
+				maxVal = v
+			}
+		}
+		left := -1
+		for i, v := range e.arr {
+			if v == maxVal {
+				left = i
+				break
+			}
+		}
+		if left > 0 && left < len(e.arr)-1 {
+			nb := append([]int(nil), e.arr...)
+			m := 0
+			for j := 0; j < left; j++ {
+				if nb[j] > m {
+					m = nb[j]
+				}
+			}
+			nb[left] = m
+			q.PushBack(state{nb, e.dist + 1})
+		}
+		right := -1
+		for i := len(e.arr) - 1; i >= 0; i-- {
+			if e.arr[i] == maxVal {
+				right = i
+				break
+			}
+		}
+		if right > 0 && right < len(e.arr)-1 {
+			nb := append([]int(nil), e.arr...)
+			m := 0
+			for j := right + 1; j < len(nb); j++ {
+				if nb[j] > m {
+					m = nb[j]
+				}
+			}
+			nb[right] = m
+			q.PushBack(state{nb, e.dist + 1})
+		}
+	}
+	return -1
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(46)
+	const t = 100
+	var sb strings.Builder
+	var exp strings.Builder
+	for i := 0; i < t; i++ {
+		n := rand.Intn(3) + 1
+		a := make([]int, n+2)
+		for j := 1; j <= n; j++ {
+			a[j] = rand.Intn(4)
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 1; j <= n; j++ {
+			if j > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[j]))
+		}
+		sb.WriteByte('\n')
+		exp.WriteString(fmt.Sprintf("%d\n", minOps(a)))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error running binary: %v\noutput:\n%s", err, out.String())
+		os.Exit(1)
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(exp.String())
+	if got != want {
+		fmt.Fprintf(os.Stderr, "wrong answer\nexpected:\n%s\ngot:\n%s\n", want, got)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1693/verifierF.go
+++ b/1000-1999/1600-1699/1690-1699/1693/verifierF.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func minCost(s string) int {
+	n := len(s)
+	first := -1
+	for i := 0; i < n; i++ {
+		if s[i] == '1' {
+			first = i
+			break
+		}
+	}
+	if first == -1 {
+		return 0
+	}
+	last := -1
+	for i := n - 1; i >= 0; i-- {
+		if s[i] == '0' {
+			last = i
+			break
+		}
+	}
+	if last == -1 || first > last {
+		return 0
+	}
+	zerosBefore := first
+	onesAfter := n - 1 - last
+	zerosInside := 0
+	onesInside := 0
+	for i := first; i <= last; i++ {
+		if s[i] == '0' {
+			zerosInside++
+		} else {
+			onesInside++
+		}
+	}
+	delta := onesInside - zerosInside
+	diff := 0
+	if delta > zerosBefore {
+		diff = delta - zerosBefore
+	} else if -delta > onesAfter {
+		diff = -delta - onesAfter
+	}
+	return diff + 1
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(47)
+	const t = 100
+	var sb strings.Builder
+	var exp strings.Builder
+	sb.WriteString(fmt.Sprintln(t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(10) + 1
+		var b strings.Builder
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				b.WriteByte('0')
+			} else {
+				b.WriteByte('1')
+			}
+		}
+		s := b.String()
+		sb.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+		exp.WriteString(fmt.Sprintf("%d\n", minCost(s)))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error running binary: %v\noutput:\n%s", err, out.String())
+		os.Exit(1)
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(exp.String())
+	if got != want {
+		fmt.Fprintf(os.Stderr, "wrong answer\nexpected:\n%s\ngot:\n%s\n", want, got)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1693 problems A–F
- each verifier generates 100 random tests and compares output of a user binary
- includes reference solutions for each problem

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6887498ad1bc8324ab3a97a1d16ebb89