### PR TITLE
Add verifiers for contest 1692

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1692/verifierA.go
+++ b/1000-1999/1600-1699/1690-1699/1692/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	t := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		a := rand.Intn(10001)
+		used := map[int]bool{a: true}
+		var nums [3]int
+		for j := 0; j < 3; j++ {
+			for {
+				x := rand.Intn(10001)
+				if !used[x] {
+					nums[j] = x
+					used[x] = true
+					break
+				}
+			}
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", a, nums[0], nums[1], nums[2]))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refA.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1692A.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1690-1699/1692/verifierB.go
+++ b/1000-1999/1600-1699/1690-1699/1692/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	t := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(50) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(rand.Intn(100) + 1))
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refB.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1692B.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1690-1699/1692/verifierC.go
+++ b/1000-1999/1600-1699/1690-1699/1692/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genBoard() []string {
+	board := make([]string, 8)
+	for i := range board {
+		row := make([]byte, 8)
+		for j := range row {
+			row[j] = '.'
+		}
+		board[i] = string(row)
+	}
+	r := rand.Intn(6) + 1
+	c := rand.Intn(6) + 1
+	rows := []byte(board[r])
+	rows[c] = '#'
+	board[r] = string(rows)
+	rows = []byte(board[r-1])
+	rows[c-1] = '#'
+	board[r-1] = string(rows)
+	rows = []byte(board[r-1])
+	rows[c+1] = '#'
+	board[r-1] = string(rows)
+	rows = []byte(board[r+1])
+	rows[c-1] = '#'
+	board[r+1] = string(rows)
+	rows = []byte(board[r+1])
+	rows[c+1] = '#'
+	board[r+1] = string(rows)
+	return board
+}
+
+func genTest() []byte {
+	t := rand.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		b := genBoard()
+		for _, row := range b {
+			sb.WriteString(row)
+			sb.WriteByte('\n')
+		}
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refC.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1692C.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1690-1699/1692/verifierD.go
+++ b/1000-1999/1600-1699/1690-1699/1692/verifierD.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	t := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		h := rand.Intn(24)
+		m := rand.Intn(60)
+		x := rand.Intn(1439) + 1
+		sb.WriteString(fmt.Sprintf("%02d:%02d %d\n", h, m, x))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refD.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1692D.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1690-1699/1692/verifierE.go
+++ b/1000-1999/1600-1699/1690-1699/1692/verifierE.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 1
+		s := rand.Intn(n + 1)
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, s))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := 0
+			if rand.Intn(2) == 1 {
+				val = 1
+			}
+			sb.WriteString(fmt.Sprint(val))
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refE.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1692E.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1690-1699/1692/verifierF.go
+++ b/1000-1999/1600-1699/1690-1699/1692/verifierF.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	t := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(10) + 3
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(rand.Intn(1000) + 1))
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refF.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1692F.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1690-1699/1692/verifierG.go
+++ b/1000-1999/1600-1699/1690-1699/1692/verifierG.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(15) + 3
+		k := rand.Intn(n-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(rand.Intn(100) + 1))
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refG.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1692G.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1600-1699/1690-1699/1692/verifierH.go
+++ b/1000-1999/1600-1699/1690-1699/1692/verifierH.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(rand.Intn(50) + 1))
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refH.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1692H.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–H in contest 1692
- each verifier compiles the reference solution and runs 100 randomized tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_68874944bf6883249ee09291aa93d9c3