### PR TITLE
Add verifiers for Codeforces 1690

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1690/verifierA.go
+++ b/1000-1999/1600-1699/1690-1699/1690/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func expected(n int) (int, int, int) {
+	a := (n + 1) / 3
+	b := (n+2)/3 + 1
+	c := n/3 - 1
+	return a, b, c
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	cases := []int{6, 7, 8, 9, 10, 11}
+	for i := 0; i < 94; i++ {
+		cases = append(cases, rng.Intn(100000-6+1)+6)
+	}
+	for i, n := range cases {
+		input := fmt.Sprintf("1\n%d\n", n)
+		expA, expB, expC := expected(n)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) < 3 {
+			fmt.Fprintf(os.Stderr, "case %d: expected three numbers, got %q\n", i+1, out)
+			os.Exit(1)
+		}
+		var a, b, c int
+		fmt.Sscanf(strings.Join(fields[:3], " "), "%d %d %d", &a, &b, &c)
+		if a != expA || b != expB || c != expC {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d %d %d got %d %d %d\n", i+1, expA, expB, expC, a, b, c)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1690/verifierB.go
+++ b/1000-1999/1600-1699/1690-1699/1690/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveCase(a, b []int) string {
+	diff := -1
+	for i := range a {
+		if b[i] > a[i] {
+			return "NO"
+		}
+		if b[i] > 0 {
+			d := a[i] - b[i]
+			if diff == -1 {
+				diff = d
+			} else if diff != d {
+				return "NO"
+			}
+		}
+	}
+	if diff != -1 {
+		for i := range a {
+			if b[i] == 0 && a[i] > diff {
+				return "NO"
+			}
+		}
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(43))
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(10) + 1
+		a := make([]int, n)
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(20)
+		}
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 0 {
+				b[i] = 0
+			} else {
+				val := rng.Intn(a[i] + 1)
+				b[i] = val
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "1\n%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", a[i])
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", b[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveCase(a, b)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", tc+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", tc+1, expected, strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1690/verifierC.go
+++ b/1000-1999/1600-1699/1690-1699/1690/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveCase(s, f []int) []int {
+	n := len(s)
+	ans := make([]int, n)
+	prev := 0
+	for i := 0; i < n; i++ {
+		start := s[i]
+		if prev > start {
+			start = prev
+		}
+		ans[i] = f[i] - start
+		prev = f[i]
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(44))
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(10) + 1
+		s := make([]int, n)
+		f := make([]int, n)
+		cur := rng.Intn(5)
+		for i := 0; i < n; i++ {
+			cur += rng.Intn(5) + 1
+			s[i] = cur
+		}
+		cur = s[0] + rng.Intn(5) + 1
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				if cur < s[i] {
+					cur = s[i]
+				}
+				cur += rng.Intn(5) + 1
+			}
+			f[i] = cur
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "1\n%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", s[i])
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", f[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := solveCase(s, f)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", tc+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) < n {
+			fmt.Fprintf(os.Stderr, "case %d wrong output size: got %q\n", tc+1, out)
+			os.Exit(1)
+		}
+		for i := 0; i < n; i++ {
+			var v int
+			fmt.Sscanf(fields[i], "%d", &v)
+			if v != exp[i] {
+				fmt.Fprintf(os.Stderr, "case %d failed at index %d: expected %d got %d\ninput:\n%s", tc+1, i, exp[i], v, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1690/verifierD.go
+++ b/1000-1999/1600-1699/1690-1699/1690/verifierD.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveCase(n, k int, s string) int {
+	cnt := 0
+	for i := 0; i < k; i++ {
+		if s[i] == 'W' {
+			cnt++
+		}
+	}
+	best := cnt
+	for i := k; i < n; i++ {
+		if s[i-k] == 'W' {
+			cnt--
+		}
+		if s[i] == 'W' {
+			cnt++
+		}
+		if cnt < best {
+			best = cnt
+		}
+	}
+	return best
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(45))
+	letters := []byte{'W', 'B'}
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(n) + 1
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = letters[rng.Intn(2)]
+		}
+		s := string(b)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "1\n%d %d\n%s\n", n, k, s)
+		input := sb.String()
+		expected := solveCase(n, k, s)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", tc+1, err)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscanf(strings.TrimSpace(out), "%d", &got)
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", tc+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1690/verifierE.go
+++ b/1000-1999/1600-1699/1690-1699/1690/verifierE.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveCase(n int, k int64, arr []int64) int64 {
+	var res int64
+	rems := make([]int64, n)
+	for i, v := range arr {
+		res += v / k
+		rems[i] = v % k
+	}
+	sort.Slice(rems, func(i, j int) bool { return rems[i] < rems[j] })
+	i, j := 0, n-1
+	for i < j {
+		if rems[i]+rems[j] >= k {
+			res++
+			i++
+			j--
+		} else {
+			i++
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(46))
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(10) + 2
+		k := int64(rng.Intn(10) + 1)
+		arr := make([]int64, n)
+		for i := range arr {
+			arr[i] = int64(rng.Intn(50))
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "1\n%d %d\n", n, k)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", arr[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveCase(n, k, arr)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", tc+1, err)
+			os.Exit(1)
+		}
+		var got int64
+		fmt.Sscanf(strings.TrimSpace(out), "%d", &got)
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", tc+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1690/verifierF.go
+++ b/1000-1999/1600-1699/1690-1699/1690/verifierF.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int64) int64 {
+	return a / gcd(a, b) * b
+}
+
+func minimalShift(chars []byte) int {
+	m := len(chars)
+	for d := 1; d <= m; d++ {
+		if m%d != 0 {
+			continue
+		}
+		ok := true
+		for i := 0; i < m; i++ {
+			if chars[i] != chars[(i+d)%m] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return d
+		}
+	}
+	return m
+}
+
+func solveCase(n int, s string, p []int) int64 {
+	visited := make([]bool, n)
+	ans := int64(1)
+	for i := 0; i < n; i++ {
+		if visited[i] {
+			continue
+		}
+		cycle := []int{}
+		j := i
+		for !visited[j] {
+			visited[j] = true
+			cycle = append(cycle, j)
+			j = p[j]
+		}
+		chars := make([]byte, len(cycle))
+		for idx, v := range cycle {
+			chars[idx] = s[v]
+		}
+		d := minimalShift(chars)
+		ans = lcm(ans, int64(d))
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(47))
+	letters := []byte("abc")
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(8) + 1
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = letters[rng.Intn(len(letters))]
+		}
+		perm := rng.Perm(n)
+		p := make([]int, n)
+		for i, v := range perm {
+			p[i] = v
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "1\n%d\n%s\n", n, string(b))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", p[i]+1)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveCase(n, string(b), p)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", tc+1, err)
+			os.Exit(1)
+		}
+		var got int64
+		fmt.Sscanf(strings.TrimSpace(out), "%d", &got)
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", tc+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1690/verifierG.go
+++ b/1000-1999/1600-1699/1690-1699/1690/verifierG.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func computeTrains(a []int) int {
+	n := len(a)
+	speeds := make([]int, n)
+	speeds[0] = a[0]
+	trains := 1
+	for i := 1; i < n; i++ {
+		if a[i] < speeds[i-1] {
+			speeds[i] = a[i]
+			trains++
+		} else {
+			speeds[i] = speeds[i-1]
+		}
+	}
+	return trains
+}
+
+func processCase(n, m int, a []int, ops [][2]int) []int {
+	res := make([]int, m)
+	cur := append([]int(nil), a...)
+	for i, op := range ops {
+		k := op[0] - 1
+		d := op[1]
+		cur[k] -= d
+		res[i] = computeTrains(cur)
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(48))
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(6) + 1
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rng.Intn(10) + 1
+		}
+		ops := make([][2]int, m)
+		for i := 0; i < m; i++ {
+			k := rng.Intn(n) + 1
+			d := rng.Intn(a[k-1] + 1)
+			a[k-1] -= d
+			ops[i] = [2]int{k, d}
+		}
+		// rebuild original a for expected computation
+		orig := make([]int, n)
+		for i := range orig {
+			orig[i] = a[i]
+		}
+		for i := 0; i < m; i++ {
+			orig[ops[i][0]-1] += ops[i][1]
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "1\n%d %d\n", n, m)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", orig[i])
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", ops[i][0], ops[i][1])
+		}
+		input := sb.String()
+		expected := processCase(n, m, orig, ops)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", tc+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) < m {
+			fmt.Fprintf(os.Stderr, "case %d wrong output size: got %q\n", tc+1, out)
+			os.Exit(1)
+		}
+		for i := 0; i < m; i++ {
+			var v int
+			fmt.Sscanf(fields[i], "%d", &v)
+			if v != expected[i] {
+				fmt.Fprintf(os.Stderr, "case %d failed at op %d: expected %d got %d\ninput:\n%s", tc+1, i+1, expected[i], v, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G of contest 1690
- each verifier runs 100 randomised test cases against a binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_688748b8a80c8324a643b5d07607d9aa