### PR TITLE
Add verifiers for CF contest 1697

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1697/verifierA.go
+++ b/1000-1999/1600-1699/1690-1699/1697/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(20)
+	arr := make([]int, n)
+	sum := 0
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(20)
+		sum += arr[i]
+	}
+	need := sum - m
+	if need < 0 {
+		need = 0
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: fmt.Sprintf("%d", need)}
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		// deterministic cases
+		{input: "1\n1 0\n5\n", expected: "5"},
+		{input: "1\n3 10\n1 2 3\n", expected: "0"},
+		{input: "1\n2 1\n1 1\n", expected: "1"},
+	}
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d error: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if out != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1697/verifierB.go
+++ b/1000-1999/1600-1699/1690-1699/1697/verifierB.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(n, q int, prices []int, queries [][2]int) []int64 {
+	arr := append([]int(nil), prices...)
+	sort.Slice(arr, func(i, j int) bool { return arr[i] > arr[j] })
+	prefix := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] + int64(arr[i])
+	}
+	res := make([]int64, q)
+	for idx, qu := range queries {
+		x := qu[0]
+		y := qu[1]
+		res[idx] = prefix[x] - prefix[x-y]
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	q := rng.Intn(10) + 1
+	prices := make([]int, n)
+	for i := range prices {
+		prices[i] = rng.Intn(100) + 1
+	}
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(x) + 1
+		queries[i] = [2]int{x, y}
+	}
+	ans := solveCase(n, q, prices, queries)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", prices[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", queries[i][0], queries[i][1]))
+	}
+	var out strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(fmt.Sprintf("%d", v))
+	}
+	return testCase{input: sb.String(), expected: out.String()}
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{}
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d error: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(tc.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\n----got----\n%s\ninput:\n%s", i+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1697/verifierC.go
+++ b/1000-1999/1600-1699/1690-1699/1697/verifierC.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func canTransform(s, t string) bool {
+	n := len(s)
+	sNoB := make([]byte, 0, n)
+	tNoB := make([]byte, 0, n)
+	posAS := make([]int, 0)
+	posAT := make([]int, 0)
+	posCS := make([]int, 0)
+	posCT := make([]int, 0)
+
+	for i := 0; i < n; i++ {
+		if s[i] != 'b' {
+			sNoB = append(sNoB, s[i])
+			if s[i] == 'a' {
+				posAS = append(posAS, i)
+			} else {
+				posCS = append(posCS, i)
+			}
+		}
+		if t[i] != 'b' {
+			tNoB = append(tNoB, t[i])
+			if t[i] == 'a' {
+				posAT = append(posAT, i)
+			} else {
+				posCT = append(posCT, i)
+			}
+		}
+	}
+	if string(sNoB) != string(tNoB) {
+		return false
+	}
+	for i := range posAS {
+		if posAS[i] > posAT[i] {
+			return false
+		}
+	}
+	for i := range posCS {
+		if posCS[i] < posCT[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	b := make([]byte, n)
+	c := make([]byte, n)
+	letters := []byte{'a', 'b', 'c'}
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(3)]
+		c[i] = letters[rng.Intn(3)]
+	}
+	s := string(b)
+	t := string(c)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	sb.WriteString(fmt.Sprintf("%s\n%s\n", s, t))
+	expected := "NO"
+	if canTransform(s, t) {
+		expected = "YES"
+	}
+	return testCase{input: sb.String(), expected: expected}
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{}
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d error: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, strings.TrimSpace(out), tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1697/verifierD.go
+++ b/1000-1999/1600-1699/1690-1699/1697/verifierD.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem D is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1600-1699/1690-1699/1697/verifierE.go
+++ b/1000-1999/1600-1699/1690-1699/1697/verifierE.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1697E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	coords := make(map[[2]int]struct{})
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for len(coords) < n {
+		x := rng.Intn(11) - 5
+		y := rng.Intn(11) - 5
+		key := [2]int{x, y}
+		if _, ok := coords[key]; ok {
+			continue
+		}
+		coords[key] = struct{}{}
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return testCase{input: sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	expected, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, tc.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = genCase(rng)
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1697/verifierF.go
+++ b/1000-1999/1600-1699/1690-1699/1697/verifierF.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1697F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	K := rng.Intn(3) + 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, K))
+	for i := 0; i < m; i++ {
+		typ := rng.Intn(3) + 1
+		if typ == 1 {
+			idx := rng.Intn(n) + 1
+			v := rng.Intn(K) + 1
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", idx, v))
+		} else if typ == 2 {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			v := rng.Intn(2*K) + 1
+			sb.WriteString(fmt.Sprintf("2 %d %d %d\n", a, b, v))
+		} else {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			v := rng.Intn(2*K) + 1
+			sb.WriteString(fmt.Sprintf("3 %d %d %d\n", a, b, v))
+		}
+	}
+	return testCase{input: sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	expected, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, tc.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = genCase(rng)
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` – runs 100+ random tests and checks output
- implement `verifierB.go` – generates random cases with sorted prefix logic
- implement `verifierC.go` – verifies string transform rules
- add placeholder verifier for interactive problem D
- implement reference-based verifiers for problems E and F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68874aa2efc083248b7ba120286b4a17