### PR TITLE
Add Go verifiers for contest 1700

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1700/verifierA.go
+++ b/1000-1999/1700-1799/1700-1709/1700/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsA = 100
+
+func generateTestsA() []string {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]string, numTestsA)
+	for i := 0; i < numTestsA; i++ {
+		n := rng.Intn(1000) + 1
+		m := rng.Intn(1000) + 1
+		tests[i] = fmt.Sprintf("1\n%d %d\n", n, m)
+	}
+	return tests
+}
+
+func solveA(input string) string {
+	var t int
+	var n, m int64
+	fmt.Sscan(input, &t, &n, &m)
+	ans := m*(m+1)/2 + m*(n*(n+1)/2-1)
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsA()
+	for i, tc := range tests {
+		expected := solveA(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, tc, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1700-1799/1700-1709/1700/verifierB.go
+++ b/1000-1999/1700-1799/1700-1709/1700/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsB = 100
+
+func generateTestsB() []string {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]string, numTestsB)
+	for i := 0; i < numTestsB; i++ {
+		n := rng.Intn(18) + 2
+		digits := make([]byte, n)
+		digits[0] = byte(rng.Intn(9)+1) + '0'
+		for j := 1; j < n; j++ {
+			digits[j] = byte(rng.Intn(10)) + '0'
+		}
+		s := string(digits)
+		tests[i] = fmt.Sprintf("1\n%d\n%s\n", n, s)
+	}
+	return tests
+}
+
+func solveB(input string) string {
+	var t, n int
+	var s string
+	fmt.Sscan(input, &t, &n, &s)
+	v := make([]int, n)
+	for i := 0; i < n; i++ {
+		v[i] = int(s[i] - '0')
+	}
+	for i := 0; i < n; i++ {
+		v[i] = 9 - v[i]
+	}
+	if v[0] == 0 {
+		carry := 0
+		d := v[n-1] + 2
+		carry = d / 10
+		v[n-1] = d % 10
+		for i := n - 2; i >= 0; i-- {
+			d = v[i] + 3 + carry
+			carry = d / 10
+			v[i] = d % 10
+		}
+	}
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteByte(byte(v[i] + '0'))
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsB()
+	for i, tc := range tests {
+		expected := solveB(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, tc, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1700-1799/1700-1709/1700/verifierC.go
+++ b/1000-1999/1700-1799/1700-1709/1700/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsC = 100
+
+func generateTestsC() []string {
+	rng := rand.New(rand.NewSource(3))
+	tests := make([]string, numTestsC)
+	for i := 0; i < numTestsC; i++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int64, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Int63n(2001) - 1000
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[j]))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func solveC(input string) string {
+	var t, n int
+	reader := strings.NewReader(input)
+	fmt.Fscan(reader, &t)
+	fmt.Fscan(reader, &n)
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+	var pos, neg int64
+	for i := 1; i < n; i++ {
+		diff := arr[i] - arr[i-1]
+		if diff > 0 {
+			pos += diff
+		} else {
+			neg += -diff
+		}
+	}
+	ans := pos + neg + int64(math.Abs(float64(arr[0]-neg)))
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsC()
+	for i, tc := range tests {
+		expected := solveC(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, tc, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1700-1799/1700-1709/1700/verifierD.go
+++ b/1000-1999/1700-1799/1700-1709/1700/verifierD.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsD = 100
+
+func generateTestsD() []string {
+	rng := rand.New(rand.NewSource(4))
+	tests := make([]string, numTestsD)
+	for i := 0; i < numTestsD; i++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int64, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Int63n(100) + 1
+		}
+		tVal := rng.Int63n(50) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[j]))
+		}
+		sb.WriteString("\n1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tVal))
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func solveD(input string) string {
+	reader := strings.NewReader(input)
+	var n int
+	fmt.Fscan(reader, &n)
+	pref := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		var x int64
+		fmt.Fscan(reader, &x)
+		pref[i] = pref[i-1] + x
+	}
+	maxTime := int64(0)
+	for i := 1; i <= n; i++ {
+		t := (pref[i] + int64(i) - 1) / int64(i)
+		if t > maxTime {
+			maxTime = t
+		}
+	}
+	var q int
+	fmt.Fscan(reader, &q)
+	var results []string
+	for ; q > 0; q-- {
+		var t int64
+		fmt.Fscan(reader, &t)
+		if t < maxTime {
+			results = append(results, "-1")
+		} else {
+			k := (pref[n] + t - 1) / t
+			results = append(results, fmt.Sprintf("%d", k))
+		}
+	}
+	return strings.Join(results, "\n") + "\n"
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsD()
+	for i, tc := range tests {
+		expected := solveD(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, tc, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1700-1799/1700-1709/1700/verifierE.go
+++ b/1000-1999/1700-1799/1700-1709/1700/verifierE.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsE = 100
+
+type Grid struct {
+	n, m int
+	val  []int
+}
+
+func (g *Grid) good(idx int) bool {
+	v := g.val[idx]
+	if v == 1 {
+		return true
+	}
+	r := idx / g.m
+	c := idx % g.m
+	if r > 0 && g.val[idx-g.m] < v {
+		return true
+	}
+	if r+1 < g.n && g.val[idx+g.m] < v {
+		return true
+	}
+	if c > 0 && g.val[idx-1] < v {
+		return true
+	}
+	if c+1 < g.m && g.val[idx+1] < v {
+		return true
+	}
+	return false
+}
+
+func (g *Grid) goodAfter(idx, a, b, valA, valB int) bool {
+	v := g.val[idx]
+	if idx == a {
+		v = valB
+	} else if idx == b {
+		v = valA
+	}
+	if v == 1 {
+		return true
+	}
+	r := idx / g.m
+	c := idx % g.m
+	if r > 0 {
+		nv := g.val[idx-g.m]
+		if idx-g.m == a {
+			nv = valB
+		} else if idx-g.m == b {
+			nv = valA
+		}
+		if nv < v {
+			return true
+		}
+	}
+	if r+1 < g.n {
+		nv := g.val[idx+g.m]
+		if idx+g.m == a {
+			nv = valB
+		} else if idx+g.m == b {
+			nv = valA
+		}
+		if nv < v {
+			return true
+		}
+	}
+	if c > 0 {
+		nv := g.val[idx-1]
+		if idx-1 == a {
+			nv = valB
+		} else if idx-1 == b {
+			nv = valA
+		}
+		if nv < v {
+			return true
+		}
+	}
+	if c+1 < g.m {
+		nv := g.val[idx+1]
+		if idx+1 == a {
+			nv = valB
+		} else if idx+1 == b {
+			nv = valA
+		}
+		if nv < v {
+			return true
+		}
+	}
+	return false
+}
+
+func solveE(input string) string {
+	reader := strings.NewReader(input)
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return ""
+	}
+	g := Grid{n: n, m: m, val: make([]int, n*m)}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			idx := i*m + j
+			fmt.Fscan(reader, &g.val[idx])
+		}
+	}
+
+	good := make([]bool, n*m)
+	badList := make([]int, 0)
+	for i := 0; i < n*m; i++ {
+		if g.good(i) {
+			good[i] = true
+		} else {
+			badList = append(badList, i)
+		}
+	}
+	if len(badList) == 0 {
+		return "0\n"
+	}
+	if len(badList) > 10 {
+		return "2\n"
+	}
+
+	candidate := make([]bool, n*m)
+	addCand := func(x int) {
+		if x >= 0 && x < n*m {
+			candidate[x] = true
+		}
+	}
+	for _, idx := range badList {
+		addCand(idx)
+		r := idx / m
+		c := idx % m
+		if r > 0 {
+			addCand(idx - m)
+		}
+		if r+1 < n {
+			addCand(idx + m)
+		}
+		if c > 0 {
+			addCand(idx - 1)
+		}
+		if c+1 < m {
+			addCand(idx + 1)
+		}
+	}
+
+	candList := make([]int, 0)
+	for i := 0; i < n*m; i++ {
+		if candidate[i] {
+			candList = append(candList, i)
+		}
+	}
+
+	visited := make([]int, n*m)
+	cur := 0
+	count := 0
+
+	buildUnion := func(a, b int) []int {
+		cur++
+		res := make([]int, 0, 10)
+		var add func(int)
+		add = func(x int) {
+			if x >= 0 && x < n*m {
+				if visited[x] != cur {
+					visited[x] = cur
+					res = append(res, x)
+				}
+			}
+		}
+		add(a)
+		add(b)
+		ra := a / m
+		ca := a % m
+		if ra > 0 {
+			add(a - m)
+		}
+		if ra+1 < n {
+			add(a + m)
+		}
+		if ca > 0 {
+			add(a - 1)
+		}
+		if ca+1 < m {
+			add(a + 1)
+		}
+
+		rb := b / m
+		cb := b % m
+		if rb > 0 {
+			add(b - m)
+		}
+		if rb+1 < n {
+			add(b + m)
+		}
+		if cb > 0 {
+			add(b - 1)
+		}
+		if cb+1 < m {
+			add(b + 1)
+		}
+		return res
+	}
+
+	badCount := len(badList)
+
+	checkSwap := func(a, b int) bool {
+		if a == b {
+			return false
+		}
+		va := g.val[a]
+		vb := g.val[b]
+		cells := buildUnion(a, b)
+		nb := badCount
+		for _, p := range cells {
+			old := good[p]
+			nw := g.goodAfter(p, a, b, va, vb)
+			if old != nw {
+				if old {
+					nb++
+				} else {
+					nb--
+				}
+			}
+		}
+		return nb == 0
+	}
+
+	totalCells := n * m
+	for _, a := range candList {
+		for b := 0; b < totalCells; b++ {
+			if a >= b {
+				continue
+			}
+			if checkSwap(a, b) {
+				count++
+			}
+		}
+	}
+
+	if count > 0 {
+		return fmt.Sprintf("1 %d\n", count)
+	}
+	return "2\n"
+}
+
+func generateTestsE() []string {
+	rng := rand.New(rand.NewSource(5))
+	tests := make([]string, numTestsE)
+	for i := 0; i < numTestsE; i++ {
+		n := rng.Intn(3) + 2
+		m := rng.Intn(3) + 2
+		vals := rand.Perm(n * m)
+		for j := range vals {
+			vals[j]++
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		idx := 0
+		for r := 0; r < n; r++ {
+			for c := 0; c < m; c++ {
+				sb.WriteString(fmt.Sprintf("%d", vals[idx]))
+				idx++
+				if c+1 < m {
+					sb.WriteByte(' ')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsE()
+	for i, tc := range tests {
+		expected := solveE(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, tc, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1700-1799/1700-1709/1700/verifierF.go
+++ b/1000-1999/1700-1799/1700-1709/1700/verifierF.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const numTestsF = 100
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solveF(input string) string {
+	reader := strings.NewReader(input)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return ""
+	}
+	a := make([][]int, 2)
+	b := make([][]int, 2)
+	for i := 0; i < 2; i++ {
+		a[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Fscan(reader, &a[i][j])
+		}
+	}
+	for i := 0; i < 2; i++ {
+		b[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Fscan(reader, &b[i][j])
+		}
+	}
+	sumA, sumB := 0, 0
+	for i := 0; i < 2; i++ {
+		for j := 0; j < n; j++ {
+			sumA += a[i][j]
+			sumB += b[i][j]
+		}
+	}
+	if sumA != sumB {
+		return "-1\n"
+	}
+	c0, c1 := 0, 0
+	cost := 0
+	for i := 0; i < n; i++ {
+		u := c0 + a[0][i] - b[0][i]
+		v := c1 + a[1][i] - b[1][i]
+		arr := []int{0, u, -v}
+		sort.Ints(arr)
+		x := arr[1]
+		cost += abs(x) + abs(u-x) + abs(v+x)
+		c0 = u - x
+		c1 = v + x
+	}
+	if c0 != 0 || c1 != 0 {
+		return "-1\n"
+	}
+	return fmt.Sprintf("%d\n", cost)
+}
+
+func generateTestsF() []string {
+	rng := rand.New(rand.NewSource(6))
+	tests := make([]string, numTestsF)
+	for i := 0; i < numTestsF; i++ {
+		n := rng.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for r := 0; r < 2; r++ {
+			for c := 0; c < n; c++ {
+				sb.WriteString(fmt.Sprintf("%d", rng.Intn(2)))
+				if c+1 < n {
+					sb.WriteByte(' ')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		for r := 0; r < 2; r++ {
+			for c := 0; c < n; c++ {
+				sb.WriteString(fmt.Sprintf("%d", rng.Intn(2)))
+				if c+1 < n {
+					sb.WriteByte(' ')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsF()
+	for i, tc := range tests {
+		expected := solveF(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, tc, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for contest 1700 problems A–F
- each verifier generates 100 deterministic test cases and checks the provided binary

## Testing
- `go run verifierA.go ./1700A`
- `go run verifierB.go ./1700B`
- `go run verifierC.go ./1700C`
- `go run verifierD.go ./1700D`
- `go run verifierE.go ./1700E`
- `go run verifierF.go ./1700F`


------
https://chatgpt.com/codex/tasks/task_e_68874b75accc8324ba465a96edb9a7da