### PR TITLE
Add verifiers for Codeforces contest 1702

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1702/verifierA.go
+++ b/1000-1999/1700-1799/1700-1709/1702/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(m int64) int64 {
+	pow := int64(1)
+	for x := m; x >= 10; x /= 10 {
+		pow *= 10
+	}
+	return m - pow
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	rand.Seed(1)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	expected := make([]string, T)
+	for i := 0; i < T; i++ {
+		m := rand.Int63n(1_000_000_000) + 1
+		fmt.Fprintln(&input, m)
+		expected[i] = fmt.Sprintf("%d", solve(m))
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	i := 0
+	for scanner.Scan() {
+		if i >= T {
+			fmt.Println("binary produced extra output")
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(scanner.Text())
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+		i++
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println("reading output failed:", err)
+		os.Exit(1)
+	}
+	if i < T {
+		fmt.Println("binary produced insufficient output")
+		os.Exit(1)
+	}
+
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1702/verifierB.go
+++ b/1000-1999/1700-1799/1700-1709/1702/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveB(s string) int {
+	days := 1
+	present := make(map[byte]bool)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !present[c] {
+			if len(present) == 3 {
+				days++
+				for k := range present {
+					delete(present, k)
+				}
+			}
+			present[c] = true
+		}
+	}
+	return days
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	rand.Seed(1)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	expected := make([]string, T)
+	for i := 0; i < T; i++ {
+		length := rand.Intn(20) + 1
+		b := make([]byte, length)
+		for j := 0; j < length; j++ {
+			b[j] = byte('a' + rand.Intn(26))
+		}
+		s := string(b)
+		fmt.Fprintln(&input, s)
+		expected[i] = fmt.Sprintf("%d", solveB(s))
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	i := 0
+	for scanner.Scan() {
+		if i >= T {
+			fmt.Println("binary produced extra output")
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(scanner.Text())
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+		i++
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println("reading output failed:", err)
+		os.Exit(1)
+	}
+	if i < T {
+		fmt.Println("binary produced insufficient output")
+		os.Exit(1)
+	}
+
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1702/verifierC.go
+++ b/1000-1999/1700-1799/1700-1709/1702/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveC(n, k int, arr []int, queries [][2]int) []string {
+	first := make(map[int]int)
+	last := make(map[int]int)
+	for i, u := range arr {
+		if _, ok := first[u]; !ok {
+			first[u] = i
+		}
+		last[u] = i
+	}
+	res := make([]string, len(queries))
+	for i, q := range queries {
+		a, b := q[0], q[1]
+		fa, okA := first[a]
+		lb, okB := last[b]
+		if okA && okB && fa <= lb {
+			res[i] = "YES"
+		} else {
+			res[i] = "NO"
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	rand.Seed(1)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	expected := []string{}
+
+	for t := 0; t < T; t++ {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(10) + 1
+		fmt.Fprintf(&input, "%d %d\n", n, k)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(10) + 1
+			fmt.Fprintf(&input, "%d ", arr[i])
+		}
+		fmt.Fprintln(&input)
+		queries := make([][2]int, k)
+		for i := 0; i < k; i++ {
+			a := rand.Intn(10) + 1
+			b := rand.Intn(10) + 1
+			queries[i] = [2]int{a, b}
+			fmt.Fprintf(&input, "%d %d\n", a, b)
+		}
+		out := solveC(n, k, arr, queries)
+		expected = append(expected, out...)
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	i := 0
+	for scanner.Scan() {
+		if i >= len(expected) {
+			fmt.Println("binary produced extra output")
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(scanner.Text())
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+		i++
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println("reading output failed:", err)
+		os.Exit(1)
+	}
+	if i < len(expected) {
+		fmt.Println("binary produced insufficient output")
+		os.Exit(1)
+	}
+
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1702/verifierD.go
+++ b/1000-1999/1700-1799/1700-1709/1702/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveD(w string, p int) string {
+	freq := make([]int, 26)
+	total := 0
+	for _, ch := range w {
+		idx := int(ch - 'a')
+		freq[idx]++
+		total += idx + 1
+	}
+	keep := make([]int, 26)
+	copy(keep, freq)
+	for c := 25; c >= 0 && total > p; c-- {
+		for keep[c] > 0 && total > p {
+			keep[c]--
+			total -= c + 1
+		}
+	}
+	var res []byte
+	for _, ch := range w {
+		idx := int(ch - 'a')
+		if keep[idx] > 0 {
+			res = append(res, byte(ch))
+			keep[idx]--
+		}
+	}
+	return string(res)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	rand.Seed(1)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	expected := make([]string, T)
+	for i := 0; i < T; i++ {
+		length := rand.Intn(20) + 1
+		b := make([]byte, length)
+		for j := 0; j < length; j++ {
+			b[j] = byte('a' + rand.Intn(26))
+		}
+		w := string(b)
+		p := rand.Intn(26*length + 1)
+		fmt.Fprintf(&input, "%s\n%d\n", w, p)
+		expected[i] = solveD(w, p)
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	i := 0
+	for scanner.Scan() {
+		if i >= T {
+			fmt.Println("binary produced extra output")
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(scanner.Text())
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+		i++
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println("reading output failed:", err)
+		os.Exit(1)
+	}
+	if i < T {
+		fmt.Println("binary produced insufficient output")
+		os.Exit(1)
+	}
+
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1702/verifierE.go
+++ b/1000-1999/1700-1799/1700-1709/1702/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveE(n int, dom [][2]int) string {
+	adj := make([][]int, n+1)
+	deg := make([]int, n+1)
+	ok := true
+	for _, d := range dom {
+		a, b := d[0], d[1]
+		if a == b {
+			ok = false
+		}
+		deg[a]++
+		deg[b]++
+		adj[a] = append(adj[a], b)
+		adj[b] = append(adj[b], a)
+	}
+	if ok {
+		for i := 1; i <= n; i++ {
+			if deg[i] > 2 {
+				ok = false
+				break
+			}
+		}
+	}
+	if ok {
+		vis := make([]bool, n+1)
+		for i := 1; i <= n && ok; i++ {
+			if vis[i] || deg[i] == 0 {
+				continue
+			}
+			stack := []int{i}
+			vis[i] = true
+			nodes, edges := 0, 0
+			for len(stack) > 0 {
+				v := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				nodes++
+				edges += len(adj[v])
+				for _, to := range adj[v] {
+					if !vis[to] {
+						vis[to] = true
+						stack = append(stack, to)
+					}
+				}
+			}
+			edges /= 2
+			if edges == nodes && nodes%2 == 1 {
+				ok = false
+				break
+			}
+		}
+	}
+	if ok {
+		return "YES"
+	}
+	return "NO"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	rand.Seed(1)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	expected := make([]string, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(10)/2*2 + 2 // even and at least 2
+		fmt.Fprintln(&input, n)
+		dom := make([][2]int, n)
+		for j := 0; j < n; j++ {
+			a := rand.Intn(n) + 1
+			b := rand.Intn(n) + 1
+			dom[j] = [2]int{a, b}
+			fmt.Fprintf(&input, "%d %d\n", a, b)
+		}
+		expected[i] = solveE(n, dom)
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	i := 0
+	for scanner.Scan() {
+		if i >= T {
+			fmt.Println("binary produced extra output")
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(scanner.Text())
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+		i++
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println("reading output failed:", err)
+		os.Exit(1)
+	}
+	if i < T {
+		fmt.Println("binary produced insufficient output")
+		os.Exit(1)
+	}
+
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1702/verifierF.go
+++ b/1000-1999/1700-1799/1700-1709/1702/verifierF.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveF(a, b []int) string {
+	freq := make(map[int]int)
+	for _, x := range a {
+		for x%2 == 0 {
+			x /= 2
+		}
+		freq[x]++
+	}
+	for _, y := range b {
+		for y%2 == 0 {
+			y /= 2
+		}
+		for y > 0 && freq[y] == 0 {
+			y /= 2
+		}
+		if y == 0 {
+			return "NO"
+		}
+		freq[y]--
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	rand.Seed(1)
+	const T = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	expected := make([]string, T)
+
+	for i := 0; i < T; i++ {
+		n := rand.Intn(10) + 1
+		fmt.Fprintln(&input, n)
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rand.Intn(100) + 1
+			fmt.Fprintf(&input, "%d ", a[j])
+		}
+		fmt.Fprintln(&input)
+		b := make([]int, n)
+		for j := 0; j < n; j++ {
+			b[j] = rand.Intn(100) + 1
+			fmt.Fprintf(&input, "%d ", b[j])
+		}
+		fmt.Fprintln(&input)
+		expected[i] = solveF(a, b)
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	i := 0
+	for scanner.Scan() {
+		if i >= T {
+			fmt.Println("binary produced extra output")
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(scanner.Text())
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+		i++
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println("reading output failed:", err)
+		os.Exit(1)
+	}
+	if i < T {
+		fmt.Println("binary produced insufficient output")
+		os.Exit(1)
+	}
+
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1702/verifierG1.go
+++ b/1000-1999/1700-1799/1700-1709/1702/verifierG1.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	ref := "refG1.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1702G1.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG1.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	var input bytes.Buffer
+	n := 10
+	fmt.Fprintln(&input, n)
+	for i := 0; i < n-1; i++ {
+		fmt.Fprintf(&input, "%d %d\n", i+1, i+2)
+	}
+	q := 100
+	fmt.Fprintln(&input, q)
+	for i := 0; i < q; i++ {
+		k := rand.Intn(n) + 1
+		fmt.Fprint(&input, k)
+		for j := 0; j < k; j++ {
+			fmt.Fprintf(&input, " %d", rand.Intn(n)+1)
+		}
+		fmt.Fprintln(&input)
+	}
+
+	expOut, err := exec.Command("./" + ref).CombinedOutput()
+	if err != nil {
+		fmt.Println("failed to run reference solution:", err)
+		os.Exit(1)
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+
+	expLines := strings.Fields(string(expOut))
+	gotLines := strings.Fields(string(out))
+	if len(expLines) != len(gotLines) {
+		fmt.Println("output line count mismatch")
+		os.Exit(1)
+	}
+	for i := range expLines {
+		if expLines[i] != gotLines[i] {
+			fmt.Printf("test line %d failed: expected %s got %s\n", i+1, expLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1702/verifierG2.go
+++ b/1000-1999/1700-1799/1700-1709/1702/verifierG2.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	ref := "refG2.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1702G2.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG2.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	var input bytes.Buffer
+	n := 15
+	fmt.Fprintln(&input, n)
+	for i := 0; i < n-1; i++ {
+		fmt.Fprintf(&input, "%d %d\n", i+1, i+2)
+	}
+	q := 100
+	fmt.Fprintln(&input, q)
+	for i := 0; i < q; i++ {
+		k := rand.Intn(n) + 1
+		fmt.Fprint(&input, k)
+		for j := 0; j < k; j++ {
+			fmt.Fprintf(&input, " %d", rand.Intn(n)+1)
+		}
+		fmt.Fprintln(&input)
+	}
+
+	expOut, err := exec.Command("./" + ref).CombinedOutput()
+	if err != nil {
+		fmt.Println("failed to run reference solution:", err)
+		os.Exit(1)
+	}
+
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+
+	expLines := strings.Fields(string(expOut))
+	gotLines := strings.Fields(string(out))
+	if len(expLines) != len(gotLines) {
+		fmt.Println("output line count mismatch")
+		os.Exit(1)
+	}
+	for i := range expLines {
+		if expLines[i] != gotLines[i] {
+			fmt.Printf("test line %d failed: expected %s got %s\n", i+1, expLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier scripts for contest 1702 problems A–G2
- verifiers generate 100 random tests and check a provided binary
- G1 and G2 verifiers build the reference solutions and compare outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG1.go`
- `go build verifierG2.go`


------
https://chatgpt.com/codex/tasks/task_e_68874c012adc8324b10bfecfc3508aec