### PR TITLE
Add Go verifiers for CF 1699

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1699/verifierA.go
+++ b/1000-1999/1600-1699/1690-1699/1699/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func checkCase(n int64, out string) error {
+	out = strings.TrimSpace(out)
+	if out == "-1" {
+		if n%2 == 0 {
+			return fmt.Errorf("solution exists but got -1")
+		}
+		return nil
+	}
+	parts := strings.Fields(out)
+	if len(parts) != 3 {
+		return fmt.Errorf("expected 3 integers, got %d", len(parts))
+	}
+	vals := make([]int64, 3)
+	for i, p := range parts {
+		v, err := strconv.ParseInt(p, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", p)
+		}
+		if v < 0 || v > 1_000_000_000 {
+			return fmt.Errorf("value out of range: %d", v)
+		}
+		vals[i] = v
+	}
+	a, b, c := vals[0], vals[1], vals[2]
+	sum := (a ^ b) + (b ^ c) + (a ^ c)
+	if sum != n {
+		return fmt.Errorf("expected sum %d got %d", n, sum)
+	}
+	if n%2 == 1 {
+		// when n is odd there is no solution
+		return fmt.Errorf("n is odd, should output -1")
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Int63n(1_000_000_000) + 1
+	input := fmt.Sprintf("1\n%d\n", n)
+	return input, n
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if err := checkCase(n, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1699/verifierB.go
+++ b/1000-1999/1600-1699/1690-1699/1699/verifierB.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseMatrix(out string, n, m int) ([][]int, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != n {
+		return nil, fmt.Errorf("expected %d lines, got %d", n, len(lines))
+	}
+	mat := make([][]int, n)
+	for i := 0; i < n; i++ {
+		fields := strings.Fields(lines[i])
+		if len(fields) != m {
+			return nil, fmt.Errorf("line %d: expected %d values, got %d", i+1, m, len(fields))
+		}
+		row := make([]int, m)
+		for j, f := range fields {
+			if f != "0" && f != "1" {
+				return nil, fmt.Errorf("line %d: invalid value %q", i+1, f)
+			}
+			if f == "1" {
+				row[j] = 1
+			}
+		}
+		mat[i] = row
+	}
+	return mat, nil
+}
+
+func checkMatrix(mat [][]int) error {
+	n := len(mat)
+	m := len(mat[0])
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			diff := 0
+			v := mat[i][j]
+			if i > 0 && mat[i-1][j] != v {
+				diff++
+			}
+			if i+1 < n && mat[i+1][j] != v {
+				diff++
+			}
+			if j > 0 && mat[i][j-1] != v {
+				diff++
+			}
+			if j+1 < m && mat[i][j+1] != v {
+				diff++
+			}
+			if diff != 2 {
+				return fmt.Errorf("cell %d,%d diff %d", i+1, j+1, diff)
+			}
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, int, int) {
+	n := rng.Intn(10) + 2
+	if n%2 == 1 {
+		n++
+	}
+	m := rng.Intn(10) + 2
+	if m%2 == 1 {
+		m++
+	}
+	input := fmt.Sprintf("1\n%d %d\n", n, m)
+	return input, n, m
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n, m := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		mat, err := parseMatrix(out, n, m)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+		if err := checkMatrix(mat); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1699/verifierC.go
+++ b/1000-1999/1600-1699/1690-1699/1699/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const mod int64 = 1000000007
+
+func solveC(n int, arr []int) int64 {
+	pos := make([]int, n)
+	for i, v := range arr {
+		pos[v] = i
+	}
+	L, R := pos[0], pos[0]
+	ans := int64(1)
+	for x := 1; x < n; x++ {
+		p := pos[x]
+		if p < L {
+			L = p
+		} else if p > R {
+			R = p
+		} else {
+			choices := int64(R - L + 1 - x)
+			ans = (ans * choices) % mod
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(10) + 1
+	perm := rng.Perm(n)
+	input := fmt.Sprintf("1\n%d\n", n)
+	for i, v := range perm {
+		if i > 0 {
+			input += " "
+		}
+		input += strconv.Itoa(v)
+	}
+	input += "\n"
+	exp := solveC(n, perm)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output\ninput:\n%soutput:\n%s", i+1, in, out)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, val, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1699/verifierD.go
+++ b/1000-1999/1600-1699/1690-1699/1699/verifierD.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(arr []int) int {
+	n := len(arr) - 1
+	can := make([][]bool, n+2)
+	for i := range can {
+		can[i] = make([]bool, n+2)
+	}
+	for i := 1; i <= n+1; i++ {
+		can[i][i-1] = true
+	}
+	for l := 1; l <= n; l++ {
+		freq := make([]int, n+1)
+		maxf := 0
+		for r := l; r <= n; r++ {
+			x := arr[r]
+			freq[x]++
+			if freq[x] > maxf {
+				maxf = freq[x]
+			}
+			length := r - l + 1
+			if length%2 == 0 && maxf <= length/2 {
+				can[l][r] = true
+			}
+		}
+	}
+	dp := make([]int, n+1)
+	ans := 0
+	for i := 1; i <= n; i++ {
+		if can[1][i-1] {
+			dp[i] = 1
+		}
+		for j := 1; j < i; j++ {
+			if arr[i] == arr[j] && dp[j] > 0 && can[j+1][i-1] {
+				if dp[j]+1 > dp[i] {
+					dp[i] = dp[j] + 1
+				}
+			}
+		}
+		if can[i+1][n] && dp[i] > ans {
+			ans = dp[i]
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	input := fmt.Sprintf("1\n%d\n", n)
+	arr := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		arr[i] = rng.Intn(n) + 1
+		input += fmt.Sprintf("%d", arr[i])
+		if i < n {
+			input += " "
+		}
+	}
+	input += "\n"
+	exp := solveD(arr)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output\ninput:\n%soutput:\n%s", i+1, in, out)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, val, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1600-1699/1690-1699/1699/verifierE.go
+++ b/1000-1999/1600-1699/1690-1699/1699/verifierE.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const maxM = 1000000
+
+var spf [maxM + 1]int
+
+func init() {
+	for i := 2; i <= maxM; i++ {
+		if spf[i] == 0 {
+			spf[i] = i
+			if i <= maxM/i {
+				for j := i * i; j <= maxM; j += i {
+					if spf[j] == 0 {
+						spf[j] = i
+					}
+				}
+			}
+		}
+	}
+	spf[1] = 1
+}
+
+func maxPrimeFactor(x int) int {
+	res := 1
+	for x > 1 {
+		p := spf[x]
+		if p > res {
+			res = p
+		}
+		for x%p == 0 {
+			x /= p
+		}
+	}
+	return res
+}
+
+func solveE(n, m int, arr []int) int {
+	maxVal := 0
+	maxPF := 1
+	for _, v := range arr {
+		if v > maxVal {
+			maxVal = v
+		}
+		pf := maxPrimeFactor(v)
+		if pf > maxPF {
+			maxPF = pf
+		}
+	}
+	if maxVal == 1 {
+		return 0
+	}
+	freq := make([]int, maxVal+1)
+	for _, v := range arr {
+		freq[v]++
+	}
+	dp := make([]int, maxVal+1)
+	cnt := make([]int, maxVal+1)
+	for val, c := range freq {
+		if c > 0 {
+			if val == 1 {
+				dp[val] = 1
+			}
+			cnt[dp[val]] += c
+		}
+	}
+	curMin := 0
+	for curMin < len(cnt) && cnt[curMin] == 0 {
+		curMin++
+	}
+	best := int(1 << 60)
+	for r := 2; r <= maxVal; r++ {
+		if r > dp[r] {
+			old := dp[r]
+			dp[r] = r
+			if freq[r] > 0 {
+				cnt[old] -= freq[r]
+				cnt[r] += freq[r]
+				if old == curMin && cnt[old] == 0 {
+					for curMin < len(cnt) && cnt[curMin] == 0 {
+						curMin++
+					}
+				}
+			}
+		}
+		for j := r * 2; j <= maxVal; j += r {
+			cand := dp[j/r]
+			if cand == 0 {
+				continue
+			}
+			if cand > r {
+				cand = r
+			}
+			if cand > dp[j] {
+				old := dp[j]
+				dp[j] = cand
+				if freq[j] > 0 {
+					cnt[old] -= freq[j]
+					cnt[cand] += freq[j]
+					if old == curMin && cnt[old] == 0 {
+						for curMin < len(cnt) && cnt[curMin] == 0 {
+							curMin++
+						}
+					}
+				}
+			}
+		}
+		if r >= maxPF {
+			if curMin < len(cnt) {
+				diff := r - curMin
+				if diff < best {
+					best = diff
+					if best == 0 {
+						break
+					}
+				}
+			}
+		}
+	}
+	if best == int(1<<60) {
+		best = 0
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(1000) + 2
+	arr := make([]int, n)
+	input := fmt.Sprintf("1\n%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(m-1) + 1
+		if i > 0 {
+			input += " "
+		}
+		input += strconv.Itoa(arr[i])
+	}
+	input += "\n"
+	exp := solveE(n, m, arr)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output\ninput:\n%soutput:\n%s", i+1, in, out)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, val, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1699 problems A–E
- each verifier generates 100 random tests and checks a user binary

## Testing
- `go run verifierA.go ./1699A_bin`
- `go run verifierB.go ./1699B_bin`
- `go run verifierC.go ./1699C_bin`
- `go run verifierD.go ./1699D_bin`
- `go run verifierE.go ./1699E_bin`


------
https://chatgpt.com/codex/tasks/task_e_68874b2f0eb0832496790f07fb4ac2ef