### PR TITLE
Add Go verifiers for Codeforces contest 1705

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1705/verifierA.go
+++ b/1000-1999/1700-1799/1700-1709/1705/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func expected(n, x int, h []int) string {
+	sort.Ints(h)
+	for i := 0; i < n; i++ {
+		if h[i+n]-h[i] < x {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	x := rng.Intn(1000) + 1
+	h := make([]int, 2*n)
+	for i := range h {
+		h[i] = rng.Intn(1000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, x)
+	for i, v := range h {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	exp := expected(n, x, append([]int(nil), h...))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1705))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1705/verifierB.go
+++ b/1000-1999/1700-1799/1700-1709/1705/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(n int, arr []int64) string {
+	last := n - 1
+	for last >= 0 && arr[last] == 0 {
+		last--
+	}
+	var ans int64
+	for i := 0; i < last; i++ {
+		ans += arr[i]
+		if arr[i] == 0 {
+			ans++
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(18) + 2
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = rng.Int63n(10)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	exp := expected(n, append([]int64(nil), a...))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1705))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1705/verifierC.go
+++ b/1000-1999/1700-1799/1700-1709/1705/verifierC.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Op struct {
+	l, r  int64
+	start int64
+	end   int64
+}
+
+func resolveChar(s string, ops []Op, k int64) byte {
+	origLen := int64(len(s))
+	for k > origLen {
+		for i := len(ops) - 1; i >= 0; i-- {
+			op := ops[i]
+			if k >= op.start && k <= op.end {
+				k = op.l + (k - op.start)
+				break
+			}
+		}
+	}
+	return s[k-1]
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	c := rng.Intn(3) + 1
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = byte('a' + rng.Intn(3))
+	}
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d %d\n", n, c, q)
+	sb.WriteString(string(s))
+	sb.WriteByte('\n')
+	ops := make([]Op, c)
+	currLen := int64(n)
+	for i := 0; i < c; i++ {
+		l := rng.Int63n(currLen) + 1
+		r := l + rng.Int63n(currLen-l+1)
+		ops[i] = Op{l: l, r: r, start: currLen + 1, end: currLen + (r - l + 1)}
+		currLen += r - l + 1
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+	}
+	queries := make([]int64, q)
+	for i := 0; i < q; i++ {
+		queries[i] = rng.Int63n(currLen) + 1
+	}
+	for _, k := range queries {
+		fmt.Fprintf(&sb, "%d\n", k)
+	}
+	var expSB strings.Builder
+	for _, k := range queries {
+		ch := resolveChar(string(s), ops, k)
+		expSB.WriteByte(ch)
+		expSB.WriteByte('\n')
+	}
+	return sb.String(), strings.TrimSpace(expSB.String())
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1705))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1705/verifierD.go
+++ b/1000-1999/1700-1799/1700-1709/1705/verifierD.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func expected(n int, s, t string) string {
+	if s[0] != t[0] || s[n-1] != t[n-1] {
+		return "-1"
+	}
+	a := make([]int, 0)
+	b := make([]int, 0)
+	for i := 0; i < n-1; i++ {
+		if s[i] != s[i+1] {
+			a = append(a, i+1)
+		}
+		if t[i] != t[i+1] {
+			b = append(b, i+1)
+		}
+	}
+	if len(a) != len(b) {
+		return "-1"
+	}
+	res := 0
+	for i := range a {
+		res += abs(a[i] - b[i])
+	}
+	return fmt.Sprint(res)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 3
+	s := make([]byte, n)
+	t := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			s[i] = '0'
+		} else {
+			s[i] = '1'
+		}
+		if rng.Intn(2) == 0 {
+			t[i] = '0'
+		} else {
+			t[i] = '1'
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	sb.WriteString(string(s))
+	sb.WriteByte('\n')
+	sb.WriteString(string(t))
+	sb.WriteByte('\n')
+	exp := expected(n, string(s), string(t))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1705))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1705/verifierE.go
+++ b/1000-1999/1700-1799/1700-1709/1705/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1705E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1705))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(4) + 2
+		q := rng.Intn(4) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(6) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, q)
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		for t := 0; t < q; t++ {
+			k := rng.Intn(n) + 1
+			l := rng.Intn(6) + 1
+			fmt.Fprintf(&sb, "%d %d\n", k, l)
+			arr[k-1] = l
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1705/verifierF.go
+++ b/1000-1999/1700-1799/1700-1709/1705/verifierF.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem F is interactive and cannot be automatically verified.")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 1705 problems A-E
- add notice for interactive problem F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68874cd33bd88324809677f15c3626dc