### PR TITLE
Add verifiers for CF contest 1706

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1706/verifierA.go
+++ b/1000-1999/1700-1799/1700-1709/1706/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseA struct {
+	n, m int
+	arr  []int
+}
+
+func solveA(n, m int, arr []int) string {
+	res := make([]byte, m)
+	for i := range res {
+		res[i] = 'B'
+	}
+	for _, v := range arr {
+		left := v
+		right := m + 1 - v
+		if left > right {
+			left, right = right, left
+		}
+		if res[left-1] == 'B' {
+			res[left-1] = 'A'
+		} else {
+			res[right-1] = 'A'
+		}
+	}
+	return string(res)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const T = 100
+	tests := make([]caseA, T)
+	expected := make([]string, T)
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(50) + 1
+		m := rng.Intn(50) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(m) + 1
+		}
+		tests[i] = caseA{n: n, m: m, arr: arr}
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		for j, v := range arr {
+			if j+1 == len(arr) {
+				fmt.Fprintf(&input, "%d\n", v)
+			} else {
+				fmt.Fprintf(&input, "%d ", v)
+			}
+		}
+		expected[i] = solveA(n, m, arr)
+	}
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	for i := 0; i < T; i++ {
+		if !scanner.Scan() {
+			fmt.Fprintln(os.Stderr, "insufficient output")
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(scanner.Text())
+		if got != expected[i] {
+			fmt.Printf("mismatch on test %d: expected %s got %s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output after", T, "tests")
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1706/verifierB.go
+++ b/1000-1999/1700-1799/1700-1709/1706/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+type caseB struct {
+	n      int
+	colors []int
+}
+
+func solveB(n int, arr []int) []int {
+	cnt := make([]int, n+1)
+	last := make([]int, n+1)
+	for i := range last {
+		last[i] = -1
+	}
+	for i, c := range arr {
+		p := (i + 1) % 2
+		if last[c] == -1 || last[c] != p {
+			cnt[c]++
+			last[c] = p
+		}
+	}
+	return cnt[1:]
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const T = 100
+	tests := make([]caseB, T)
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	expected := make([][]int, T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(n) + 1
+		}
+		tests[i] = caseB{n: n, colors: arr}
+		fmt.Fprintln(&input, n)
+		for j, v := range arr {
+			if j+1 == len(arr) {
+				fmt.Fprintf(&input, "%d\n", v)
+			} else {
+				fmt.Fprintf(&input, "%d ", v)
+			}
+		}
+		expected[i] = solveB(n, arr)
+	}
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i := 0; i < T; i++ {
+		for j := 0; j < tests[i].n; j++ {
+			if !scanner.Scan() {
+				fmt.Fprintln(os.Stderr, "insufficient output")
+				os.Exit(1)
+			}
+			var got int
+			fmt.Sscan(scanner.Text(), &got)
+			if got != expected[i][j] {
+				fmt.Fprintf(os.Stderr, "mismatch on test %d color %d: expected %d got %d\n", i+1, j+1, expected[i][j], got)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output after", T, "tests")
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1706/verifierC.go
+++ b/1000-1999/1700-1799/1700-1709/1706/verifierC.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+type caseC struct {
+	n int
+	h []int64
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveC(n int, h []int64) int64 {
+	if n%2 == 1 {
+		var ans int64
+		for i := 1; i < n-1; i += 2 {
+			need := max64(h[i-1], h[i+1]) + 1
+			if need > h[i] {
+				ans += need - h[i]
+			}
+		}
+		return ans
+	}
+	m := n - 2
+	pairs := m / 2
+	if pairs == 0 {
+		return 0
+	}
+	cost := make([]int64, m+1)
+	for k := 1; k <= m; k++ {
+		idx := k
+		need := max64(h[idx-1], h[idx+1]) + 1
+		if need > h[idx] {
+			cost[k] = need - h[idx]
+		}
+	}
+	dp0 := make([]int64, pairs+1)
+	dp1 := make([]int64, pairs+1)
+	dp0[1] = cost[1]
+	dp1[1] = cost[2]
+	for j := 2; j <= pairs; j++ {
+		dp0[j] = cost[2*j-1] + dp0[j-1]
+		prev := dp0[j-1]
+		if dp1[j-1] < prev {
+			prev = dp1[j-1]
+		}
+		dp1[j] = cost[2*j] + prev
+	}
+	ans := dp0[pairs]
+	if dp1[pairs] < ans {
+		ans = dp1[pairs]
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const T = 100
+	tests := make([]caseC, T)
+	expected := make([]int64, T)
+	var input bytes.Buffer
+	fmt.Fprintln(&input, T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(8) + 3
+		h := make([]int64, n)
+		for j := range h {
+			h[j] = rand.Int63n(10) + 1
+		}
+		tests[i] = caseC{n: n, h: h}
+		fmt.Fprintln(&input, n)
+		for j, v := range h {
+			if j+1 == len(h) {
+				fmt.Fprintf(&input, "%d\n", v)
+			} else {
+				fmt.Fprintf(&input, "%d ", v)
+			}
+		}
+		expected[i] = solveC(n, h)
+	}
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i := 0; i < T; i++ {
+		if !scanner.Scan() {
+			fmt.Fprintln(os.Stderr, "insufficient output")
+			os.Exit(1)
+		}
+		var got int64
+		fmt.Sscan(scanner.Text(), &got)
+		if got != expected[i] {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %d got %d\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output after", T, "tests")
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1706/verifierD1.go
+++ b/1000-1999/1700-1799/1700-1709/1706/verifierD1.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1706D1.go")
+	return runProg(ref, input)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	arr := make([]int, n)
+	val := rng.Intn(5) + 1
+	for i := 0; i < n; i++ {
+		arr[i] = val
+		val += rng.Intn(5)
+		if val > 3000 {
+			val = 3000
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i, v := range arr {
+		if i+1 == n {
+			fmt.Fprintf(&sb, "%d\n", v)
+		} else {
+			fmt.Fprintf(&sb, "%d ", v)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const T = 100
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", T)
+	cases := make([]string, T)
+	for i := 0; i < T; i++ {
+		c := genCase(rng)
+		cases[i] = c
+		input.WriteString(c)
+	}
+	expect, err := runRef(input.String())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "reference solver failed:", err)
+		os.Exit(1)
+	}
+	got, err := runProg(bin, input.String())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "candidate failed:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		fmt.Printf("output mismatch\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", input.String(), expect, got)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1706/verifierD2.go
+++ b/1000-1999/1700-1799/1700-1709/1706/verifierD2.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1706D2.go")
+	return runProg(ref, input)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(8) + 1
+	arr := make([]int, n)
+	val := rng.Intn(10) + 1
+	for i := 0; i < n; i++ {
+		arr[i] = val
+		val += rng.Intn(10)
+		if val > 100000 {
+			val = 100000
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i, v := range arr {
+		if i+1 == n {
+			fmt.Fprintf(&sb, "%d\n", v)
+		} else {
+			fmt.Fprintf(&sb, "%d ", v)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const T = 100
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", T)
+	for i := 0; i < T; i++ {
+		input.WriteString(genCase(rng))
+	}
+	expect, err := runRef(input.String())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "reference solver failed:", err)
+		os.Exit(1)
+	}
+	got, err := runProg(bin, input.String())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "candidate failed:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		fmt.Printf("output mismatch\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", input.String(), expect, got)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1706/verifierE.go
+++ b/1000-1999/1700-1799/1700-1709/1706/verifierE.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "1706E.go")
+	return runProg(ref, input)
+}
+
+type edge struct{ u, v int }
+
+func genGraph(rng *rand.Rand) (int, [][2]int) {
+	n := rng.Intn(4) + 2 // 2..5
+	// start with a tree for connectivity
+	edges := make([][2]int, 0)
+	parent := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+		parent[i] = p
+	}
+	maxE := n * (n - 1) / 2
+	extra := rng.Intn(maxE - (n - 1) + 1)
+	used := make(map[[2]int]bool)
+	for _, e := range edges {
+		if e[0] > e[1] {
+			e[0], e[1] = e[1], e[0]
+		}
+		used[e] = true
+	}
+	for len(edges) < (n-1)+extra {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		e := [2]int{u, v}
+		if used[e] {
+			continue
+		}
+		used[e] = true
+		edges = append(edges, e)
+	}
+	return n, edges
+}
+
+func genCase(rng *rand.Rand) string {
+	n, edges := genGraph(rng)
+	m := len(edges)
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, q)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const T = 100
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", T)
+	for i := 0; i < T; i++ {
+		input.WriteString(genCase(rng))
+	}
+	expect, err := runRef(input.String())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "reference solver failed:", err)
+		os.Exit(1)
+	}
+	got, err := runProg(bin, input.String())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "candidate failed:", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		fmt.Printf("output mismatch\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", input.String(), expect, got)
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces Round 1706 problems A–E
- each verifier generates 100 random tests and checks a candidate binary against the provided reference solutions

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD1.go`
- `go build verifierD2.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68874d1950748324a786e14d71277ecb