### PR TITLE
Add verifiers for Codeforces contest 1710

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1710/verifierA.go
+++ b/1000-1999/1700-1799/1710-1719/1710/verifierA.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1710A.go")
+	refBin := filepath.Join(os.TempDir(), "1710A_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(8) + 3
+	m := rand.Intn(8) + 3
+	k := rand.Intn(7) + 1
+	a := make([]int64, k)
+	for i := 0; i < k; i++ {
+		a[i] = rand.Int63n(50) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1710/verifierB.go
+++ b/1000-1999/1700-1799/1710-1719/1710/verifierB.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1710B.go")
+	refBin := filepath.Join(os.TempDir(), "1710B_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+type testCase struct {
+	n  int
+	m  int64
+	xs []int64
+	ps []int64
+}
+
+func genTest() []byte {
+	n := rand.Intn(8) + 1
+	m := rand.Int63n(100) + 1
+	xs := make([]int64, n)
+	ps := make([]int64, n)
+	for i := 0; i < n; i++ {
+		xs[i] = rand.Int63n(100) + 1
+		ps[i] = rand.Int63n(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", xs[i], ps[i]))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1710/verifierC.go
+++ b/1000-1999/1700-1799/1710-1719/1710/verifierC.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1710C.go")
+	refBin := filepath.Join(os.TempDir(), "1710C_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	length := rand.Intn(30) + 1
+	var sb strings.Builder
+	sb.WriteByte('1')
+	for i := 1; i < length; i++ {
+		if rand.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1710/verifierD.go
+++ b/1000-1999/1700-1799/1710-1719/1710/verifierD.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1710D.go")
+	refBin := filepath.Join(os.TempDir(), "1710D_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+type tree struct {
+	n     int
+	edges [][2]int
+	adj   [][]int
+}
+
+func randTree(n int) *tree {
+	edges := make([][2]int, 0, n-1)
+	adj := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+		adj[p] = append(adj[p], i)
+		adj[i] = append(adj[i], p)
+	}
+	return &tree{n: n, edges: edges, adj: adj}
+}
+
+func (t *tree) isGood(l, r int) bool {
+	visited := make([]bool, t.n+1)
+	stack := []int{l}
+	visited[l] = true
+	count := 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		count++
+		for _, to := range t.adj[v] {
+			if to < l || to > r {
+				return false
+			}
+			if !visited[to] {
+				visited[to] = true
+				stack = append(stack, to)
+			}
+		}
+	}
+	return count == r-l+1
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 1
+	tr := randTree(n)
+	lines := make([]string, n)
+	for i := 1; i <= n; i++ {
+		var sb strings.Builder
+		for j := i; j <= n; j++ {
+			if tr.isGood(i, j) {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('0')
+			}
+		}
+		lines[i-1] = sb.String()
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(lines[i])
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1710/verifierE.go
+++ b/1000-1999/1700-1799/1710-1719/1710/verifierE.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runProg(exe string, input []byte) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1710E.go")
+	refBin := filepath.Join(os.TempDir(), "1710E_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(8) + 1
+	m := rand.Intn(8) + 1
+	a := make([]int64, n)
+	b := make([]int64, m)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Int63n(100) + 1
+	}
+	for i := 0; i < m; i++ {
+		b[i] = rand.Int63n(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(b[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	exe, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n%s", i, err, expected)
+			os.Exit(1)
+		}
+		got, err := runProg(exe, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i, err, got)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E in contest 1710
- each verifier builds the provided reference solution, generates 100 random tests and compares outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68874e3165f083248ae9e2e8c9673afb