### PR TITLE
Add verifiers for CF Round 1709

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1709/verifierA.go
+++ b/1000-1999/1700-1799/1700-1709/1709/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(x int, doors [4]int) string {
+	first := doors[x]
+	if first == 0 {
+		return "NO"
+	}
+	second := doors[first]
+	if second == 0 {
+		return "NO"
+	}
+	return "YES"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	perm := []int{1, 2, 3}
+	rng.Shuffle(3, func(i, j int) { perm[i], perm[j] = perm[j], perm[i] })
+	x := perm[0]
+	vals := []int{perm[1], perm[2], 0}
+	rng.Shuffle(3, func(i, j int) { vals[i], vals[j] = vals[j], vals[i] })
+	doors := [4]int{0, vals[0], vals[1], vals[2]}
+	input := fmt.Sprintf("1\n%d\n%d %d %d\n", x, doors[1], doors[2], doors[3])
+	expect := solveCase(x, doors)
+	return input, expect
+}
+
+func main() {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1709/verifierB.go
+++ b/1000-1999/1700-1799/1700-1709/1709/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, m int, a []int64, qs [][2]int) []int64 {
+	prefixRight := make([]int64, n)
+	for i := 1; i < n; i++ {
+		diff := a[i-1] - a[i]
+		if diff > 0 {
+			prefixRight[i] = prefixRight[i-1] + diff
+		} else {
+			prefixRight[i] = prefixRight[i-1]
+		}
+	}
+	prefixLeft := make([]int64, n)
+	for i := n - 2; i >= 0; i-- {
+		diff := a[i+1] - a[i]
+		if diff > 0 {
+			prefixLeft[i] = prefixLeft[i+1] + diff
+		} else {
+			prefixLeft[i] = prefixLeft[i+1]
+		}
+	}
+	ans := make([]int64, m)
+	for idx, q := range qs {
+		s, t := q[0], q[1]
+		if s < t {
+			ans[idx] = prefixRight[t-1] - prefixRight[s-1]
+		} else {
+			ans[idx] = prefixLeft[t-1] - prefixLeft[s-1]
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(9) + 2 // 2..10
+	m := rng.Intn(5) + 1 // 1..5
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = rng.Int63n(20) + 1
+	}
+	qs := make([][2]int, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		s := rng.Intn(n) + 1
+		t := rng.Intn(n) + 1
+		for s == t {
+			t = rng.Intn(n) + 1
+		}
+		qs[i] = [2]int{s, t}
+		sb.WriteString(fmt.Sprintf("%d %d\n", s, t))
+	}
+	expect := solveCase(n, m, a, qs)
+	return sb.String(), expect
+}
+
+func main() {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		outFields := strings.Fields(out)
+		if len(outFields) != len(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\ninput:\n%s", i+1, len(expect), len(outFields), in)
+			os.Exit(1)
+		}
+		for j, val := range expect {
+			if outFields[j] != fmt.Sprintf("%d", val) {
+				fmt.Fprintf(os.Stderr, "case %d failed on query %d: expected %d got %s\ninput:\n%s", i+1, j+1, val, outFields[j], in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1709/verifierC.go
+++ b/1000-1999/1700-1799/1700-1709/1709/verifierC.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isValid(s []byte) bool {
+	bal := 0
+	for _, c := range s {
+		if c == '(' {
+			bal++
+		} else {
+			bal--
+		}
+		if bal < 0 {
+			return false
+		}
+	}
+	return bal == 0
+}
+
+func solveCase(str string) string {
+	n := len(str)
+	openCnt, closeCnt := 0, 0
+	for i := 0; i < n; i++ {
+		if str[i] == '(' {
+			openCnt++
+		} else if str[i] == ')' {
+			closeCnt++
+		}
+	}
+	openNeed := n/2 - openCnt
+	closeNeed := n/2 - closeCnt
+	bytesArr := []byte(str)
+	openPos := []int{}
+	closePos := []int{}
+	for i := 0; i < n; i++ {
+		if bytesArr[i] == '?' {
+			if openNeed > 0 {
+				bytesArr[i] = '('
+				openNeed--
+				openPos = append(openPos, i)
+			} else {
+				bytesArr[i] = ')'
+				closeNeed--
+				closePos = append(closePos, i)
+			}
+		}
+	}
+	if len(openPos) == 0 || len(closePos) == 0 {
+		if isValid(bytesArr) {
+			return "YES"
+		}
+		return "NO"
+	}
+	i := openPos[len(openPos)-1]
+	j := closePos[0]
+	bytesArr[i] = ')'
+	bytesArr[j] = '('
+	if isValid(bytesArr) {
+		return "NO"
+	}
+	return "YES"
+}
+
+func randRBS(rng *rand.Rand, n int) string {
+	open := n / 2
+	close := n / 2
+	bal := 0
+	b := make([]byte, 0, n)
+	for i := 0; i < n; i++ {
+		if open == 0 {
+			b = append(b, ')')
+			close--
+			bal--
+		} else if bal == 0 {
+			b = append(b, '(')
+			open--
+			bal++
+		} else {
+			if rng.Intn(open+close) < open {
+				b = append(b, '(')
+				open--
+				bal++
+			} else {
+				b = append(b, ')')
+				close--
+				bal--
+			}
+		}
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9)*2 + 2 // even between 2 and 20
+	base := randRBS(rng, n)
+	bytesArr := []byte(base)
+	hasQ := false
+	for i := 0; i < n; i++ {
+		if rng.Intn(3) == 0 { // replace with ?
+			bytesArr[i] = '?'
+			hasQ = true
+		}
+	}
+	if !hasQ {
+		bytesArr[rng.Intn(n)] = '?'
+	}
+	s := string(bytesArr)
+	input := fmt.Sprintf("1\n%s\n", s)
+	expect := solveCase(s)
+	return input, expect
+}
+
+func main() {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1709/verifierD.go
+++ b/1000-1999/1700-1799/1700-1709/1709/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, a []int, queries [][5]int) []string {
+	res := make([]string, len(queries))
+	for idx, q := range queries {
+		xs, ys, xf, yf, k := q[0], q[1], q[2], q[3], q[4]
+		ys--
+		yf--
+		if (xs-xf)%k != 0 || (ys-yf)%k != 0 {
+			res[idx] = "NO"
+			continue
+		}
+		high := xs + (n-xs)/k*k
+		l := ys
+		r := yf
+		if l > r {
+			l, r = r, l
+		}
+		maxA := 0
+		for i := l; i <= r; i++ {
+			if a[i] > maxA {
+				maxA = a[i]
+			}
+		}
+		if maxA < high {
+			res[idx] = "YES"
+		} else {
+			res[idx] = "NO"
+		}
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(50) + 10 // 10..59
+	m := rng.Intn(10) + 1  // 1..10 columns
+	a := make([]int, m)
+	for i := range a {
+		a[i] = rng.Intn(n)
+	}
+	q := rng.Intn(5) + 1 // 1..5 queries
+	queries := make([][5]int, q)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		ys := rng.Intn(m) + 1
+		yf := rng.Intn(m) + 1
+		xs := rng.Intn(n-a[ys-1]) + a[ys-1] + 1
+		xf := rng.Intn(n-a[yf-1]) + a[yf-1] + 1
+		k := rng.Intn(10) + 1
+		queries[i] = [5]int{xs, ys, xf, yf, k}
+		sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", xs, ys, xf, yf, k))
+	}
+	expect := solveCase(n, a, queries)
+	return sb.String(), expect
+}
+
+func main() {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		outFields := strings.Fields(out)
+		if len(outFields) != len(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, len(expect), len(outFields), in)
+			os.Exit(1)
+		}
+		for j, val := range expect {
+			if outFields[j] != val {
+				fmt.Fprintf(os.Stderr, "case %d failed on query %d: expected %s got %s\ninput:\n%s", i+1, j+1, val, outFields[j], in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1709/verifierE.go
+++ b/1000-1999/1700-1799/1700-1709/1709/verifierE.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type pair struct{ a, b int }
+
+func solveCase(n int, vals []int, edges []pair) int {
+	g := make([][]int, n)
+	for _, e := range edges {
+		u, v := e.a, e.b
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	px := make([]int, n)
+	var dfsPX func(v, p int)
+	dfsPX = func(v, p int) {
+		for _, to := range g[v] {
+			if to == p {
+				continue
+			}
+			px[to] = px[v] ^ vals[to]
+			dfsPX(to, v)
+		}
+	}
+	px[0] = vals[0]
+	dfsPX(0, -1)
+	ans := 0
+	var dfs func(v, p int) map[int]struct{}
+	dfs = func(v, p int) map[int]struct{} {
+		set := map[int]struct{}{px[v]: {}}
+		for _, to := range g[v] {
+			if to == p {
+				continue
+			}
+			child := dfs(to, v)
+			if len(set) < len(child) {
+				set, child = child, set
+			}
+			intersect := false
+			for val := range child {
+				if _, ok := set[val]; ok {
+					intersect = true
+					break
+				}
+			}
+			if intersect {
+				ans++
+			} else {
+				for val := range child {
+					set[val] = struct{}{}
+				}
+			}
+		}
+		return set
+	}
+	dfs(0, -1)
+	return ans
+}
+
+func genTree(rng *rand.Rand, n int) []pair {
+	edges := make([]pair, 0, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges = append(edges, pair{p, i})
+	}
+	return edges
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(7) + 1 // 1..7
+	vals := make([]int, n)
+	for i := range vals {
+		vals[i] = rng.Intn(16) + 1
+	}
+	edges := genTree(rng, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", vals[i]))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.a+1, e.b+1))
+	}
+	expect := solveCase(n, vals, edges)
+	return sb.String(), expect
+}
+
+func main() {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != fmt.Sprintf("%d", expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i+1, expect, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1700-1709/1709/verifierF.go
+++ b/1000-1999/1700-1799/1700-1709/1709/verifierF.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const mod = 998244353
+
+func modAdd(a, b int) int {
+	a += b
+	if a >= mod {
+		a -= mod
+	}
+	return a
+}
+func modSub(a, b int) int {
+	a -= b
+	if a < 0 {
+		a += mod
+	}
+	return a
+}
+func modMul(a, b int) int { return int(int64(a) * int64(b) % int64(mod)) }
+func modPow(a, e int) int {
+	res := 1
+	for e > 0 {
+		if e&1 != 0 {
+			res = modMul(res, a)
+		}
+		a = modMul(a, a)
+		e >>= 1
+	}
+	return res
+}
+func modInv(a int) int { return modPow(a, mod-2) }
+
+func ntt(a []int, invert bool) {
+	n := len(a)
+	for i, j := 1, 0; i < n; i++ {
+		bit := n >> 1
+		for ; j&bit != 0; bit >>= 1 {
+			j ^= bit
+		}
+		j |= bit
+		if i < j {
+			a[i], a[j] = a[j], a[i]
+		}
+	}
+	for length := 2; length <= n; length <<= 1 {
+		wlen := modPow(3, (mod-1)/length)
+		if invert {
+			wlen = modInv(wlen)
+		}
+		for i := 0; i < n; i += length {
+			w := 1
+			half := length >> 1
+			for j := 0; j < half; j++ {
+				u := a[i+j]
+				v := modMul(a[i+j+half], w)
+				a[i+j] = modAdd(u, v)
+				a[i+j+half] = modSub(u, v)
+				w = modMul(w, wlen)
+			}
+		}
+	}
+	if invert {
+		invN := modInv(n)
+		for i := range a {
+			a[i] = modMul(a[i], invN)
+		}
+	}
+}
+
+func multiply(a, b []int) []int {
+	need := len(a) + len(b) - 1
+	n := 1
+	for n < need {
+		n <<= 1
+	}
+	fa := make([]int, n)
+	fb := make([]int, n)
+	copy(fa, a)
+	copy(fb, b)
+	ntt(fa, false)
+	ntt(fb, false)
+	for i := 0; i < n; i++ {
+		fa[i] = modMul(fa[i], fb[i])
+	}
+	ntt(fa, true)
+	return fa[:need]
+}
+
+func solveCase(n, k, f int) int {
+	if f > 2*k {
+		return 0
+	}
+	g := make([][]int, n+1)
+	g[1] = make([]int, k+1)
+	for i := 0; i <= k; i++ {
+		g[1][i] = 1
+	}
+	for depth := 2; depth <= n; depth++ {
+		s := multiply(g[depth-1], g[depth-1])
+		big := 0
+		for i := k + 1; i < len(s); i++ {
+			big = modAdd(big, s[i])
+		}
+		prefix := make([]int, k+2)
+		sum := 0
+		for i := k; i >= 0; i-- {
+			sum = modAdd(sum, s[i])
+			prefix[i] = sum
+		}
+		arr := make([]int, k+1)
+		for x := 0; x <= k; x++ {
+			val := big
+			if x+1 <= k {
+				val = modAdd(val, prefix[x+1])
+			}
+			contrib := modMul(s[x], (k-x+1)%mod)
+			val = modAdd(val, contrib)
+			arr[x] = val
+		}
+		g[depth] = arr
+	}
+	rootConv := multiply(g[n], g[n])
+	if f >= len(rootConv) {
+		return 0
+	}
+	return rootConv[f] % mod
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(4) + 1 // 1..4
+	k := rng.Intn(8) + 1 // 1..8
+	f := rng.Intn(2*k + 1)
+	input := fmt.Sprintf("%d %d %d\n", n, k, f)
+	expect := solveCase(n, k, f)
+	return input, expect
+}
+
+func main() {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != fmt.Sprintf("%d", expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i+1, expect, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces Round 1709 problems A–F
- each verifier generates 100 random tests and compares a candidate program's output to expected results

## Testing
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68874deb65fc8324a0221fd2f9e28680