### PR TITLE
Add verifiers for contest 1712

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1712/verifierA.go
+++ b/1000-1999/1700-1799/1710-1719/1712/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, k int, p []int) int {
+	ans := 0
+	for i := 0; i < k; i++ {
+		if p[i] > k {
+			ans++
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(n) + 1
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	ans := solveCase(n, k, perm)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	return sb.String(), fmt.Sprint(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1712/verifierB.go
+++ b/1000-1999/1700-1799/1710-1719/1712/verifierB.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int) int {
+	return a / gcd(a, b) * b
+}
+
+func bruteMaxSum(n int) int {
+	used := make([]bool, n)
+	maxSum := 0
+	var dfs func(int, int)
+	dfs = func(pos, sum int) {
+		if pos == n {
+			if sum > maxSum {
+				maxSum = sum
+			}
+			return
+		}
+		for i := 1; i <= n; i++ {
+			if !used[i-1] {
+				used[i-1] = true
+				dfs(pos+1, sum+lcm(pos+1, i))
+				used[i-1] = false
+			}
+		}
+	}
+	dfs(0, 0)
+	return maxSum
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(7) + 1
+	maxSum := bruteMaxSum(n)
+	input := fmt.Sprintf("1\n%d\n", n)
+	return input, maxSum
+}
+
+func parsePermutation(out string, n int) ([]int, error) {
+	fields := strings.Fields(out)
+	if len(fields) != n {
+		return nil, fmt.Errorf("expected %d numbers got %d", n, len(fields))
+	}
+	perm := make([]int, n)
+	used := make([]bool, n)
+	for i, f := range fields {
+		val, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, fmt.Errorf("bad integer: %v", err)
+		}
+		if val < 1 || val > n {
+			return nil, fmt.Errorf("value out of range")
+		}
+		if used[val-1] {
+			return nil, fmt.Errorf("duplicate value")
+		}
+		used[val-1] = true
+		perm[i] = val
+	}
+	return perm, nil
+}
+
+func permSum(perm []int) int {
+	sum := 0
+	for i, v := range perm {
+		sum += lcm(i+1, v)
+	}
+	return sum
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expSum := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		nLines := strings.Split(strings.TrimSpace(in), "\n")
+		n, _ := strconv.Atoi(strings.TrimSpace(nLines[1]))
+		perm, err := parsePermutation(out, n)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if permSum(perm) != expSum {
+			fmt.Fprintf(os.Stderr, "case %d failed: wrong sum\ninput:\n%soutput:\n%s", i+1, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1712/verifierC.go
+++ b/1000-1999/1700-1799/1710-1719/1712/verifierC.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(arr []int) int {
+	n := len(arr)
+	last := make([]int, n+1)
+	for i, v := range arr {
+		last[v] = i
+	}
+	end := -1
+	for i := n - 2; i >= 0; i-- {
+		if arr[i] > arr[i+1] {
+			end = i
+			break
+		}
+	}
+	if end == -1 {
+		return 0
+	}
+	seen := make(map[int]struct{})
+	for i := 0; i <= end; i++ {
+		v := arr[i]
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			if last[v] > end {
+				end = last[v]
+			}
+		}
+	}
+	return len(seen)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(n) + 1
+	}
+	ans := solveCase(arr)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	return sb.String(), fmt.Sprint(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1712/verifierD.go
+++ b/1000-1999/1700-1799/1710-1719/1712/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func can(a []int, k int, D int) bool {
+	mNeeded := (D + 1) / 2
+	cnt := 0
+	for _, v := range a {
+		if v < mNeeded {
+			cnt++
+		}
+	}
+	if cnt > k {
+		return false
+	}
+	rem := k - cnt
+	l := 0
+	bad := 0
+	for r, v := range a {
+		if v >= mNeeded && v < D {
+			bad++
+		}
+		for bad > rem {
+			y := a[l]
+			if y >= mNeeded && y < D {
+				bad--
+			}
+			l++
+		}
+		if r-l+1 >= 2 {
+			return true
+		}
+	}
+	return false
+}
+
+func solve(a []int, k int) int {
+	lo, hi := 1, 1000000000
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if can(a, k, mid) {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return lo
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	k := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(50) + 1
+	}
+	ans := solve(arr, k)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	return sb.String(), fmt.Sprint(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1712/verifierE1.go
+++ b/1000-1999/1700-1799/1710-1719/1712/verifierE1.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm3(a, b, c int) int {
+	t := a / gcd(a, b) * b
+	return t / gcd(t, c) * c
+}
+
+func brute(l, r int) int {
+	count := 0
+	for i := l; i <= r; i++ {
+		for j := i + 1; j <= r; j++ {
+			for k := j + 1; k <= r; k++ {
+				if lcm3(i, j, k) >= i+j+k {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l := rng.Intn(20) + 1
+	r := l + rng.Intn(6) + 2
+	ans := brute(l, r)
+	input := fmt.Sprintf("1\n%d %d\n", l, r)
+	return input, fmt.Sprint(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1712/verifierE2.go
+++ b/1000-1999/1700-1799/1710-1719/1712/verifierE2.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm3(a, b, c int) int {
+	t := a / gcd(a, b) * b
+	return t / gcd(t, c) * c
+}
+
+func brute(l, r int) int {
+	count := 0
+	for i := l; i <= r; i++ {
+		for j := i + 1; j <= r; j++ {
+			for k := j + 1; k <= r; k++ {
+				if lcm3(i, j, k) >= i+j+k {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l := rng.Intn(20) + 1
+	r := l + rng.Intn(6) + 2
+	ans := brute(l, r)
+	input := fmt.Sprintf("1\n%d %d\n", l, r)
+	return input, fmt.Sprint(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1712/verifierF.go
+++ b/1000-1999/1700-1799/1710-1719/1712/verifierF.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(cmdPath string, input string, args ...string) (string, error) {
+	cmdArgs := append([]string{cmdPath}, args...)
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	if strings.HasSuffix(bin, ".go") {
+		return runBinary("go", input, "run", bin)
+	}
+	return runBinary(bin, input)
+}
+
+func runReference(input string) (string, error) {
+	return runBinary("go", input, "run", "1712F.go")
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(7) + 3
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		parent := rng.Intn(i-1) + 1
+		sb.WriteString(strconv.Itoa(parent))
+	}
+	sb.WriteString("\n")
+	q := rng.Intn(3) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	used := make(map[int]struct{})
+	for i := 0; i < q; i++ {
+		var x int
+		for {
+			x = rng.Intn(n) + 1
+			if _, ok := used[x]; !ok {
+				used[x] = struct{}{}
+				break
+			}
+		}
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(x))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp, err := runReference(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\ninput:\n%s", err, in)
+			os.Exit(1)
+		}
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for all problems of Codeforces contest 1712
- each verifier generates 100 random tests and checks a provided binary
- heavy problems reuse the reference solution or a brute force solver

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE1.go`
- `go build verifierE2.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68874ebd85a48324b594c17f1803619d