### PR TITLE
Add Go verifiers for contest 1715

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1715/verifierA.go
+++ b/1000-1999/1700-1799/1710-1719/1715/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n int64
+	m int64
+}
+
+func expectedA(n, m int64) int64 {
+	if n == 1 && m == 1 {
+		return 0
+	}
+	if n-1 < m-1 {
+		return n + m - 1 + (n - 1)
+	}
+	return n + m - 1 + (m - 1)
+}
+
+func genCaseA(rng *rand.Rand) []testCaseA {
+	t := rng.Intn(5) + 1
+	cases := make([]testCaseA, t)
+	for i := 0; i < t; i++ {
+		cases[i].n = rng.Int63n(1e5) + 1
+		cases[i].m = rng.Int63n(1e5) + 1
+	}
+	return cases
+}
+
+func runCaseA(bin string, tc []testCaseA) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", len(tc)))
+	for _, c := range tc {
+		input.WriteString(fmt.Sprintf("%d %d\n", c.n, c.m))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != len(tc) {
+		return fmt.Errorf("expected %d numbers got %d", len(tc), len(fields))
+	}
+	for i, f := range fields {
+		val, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", f)
+		}
+		if val != expectedA(tc[i].n, tc[i].m) {
+			return fmt.Errorf("case %d expected %d got %d", i+1, expectedA(tc[i].n, tc[i].m), val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		tc := genCaseA(rng)
+		if err := runCaseA(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n", t+1, err)
+			var input strings.Builder
+			input.WriteString(fmt.Sprintf("%d\n", len(tc)))
+			for _, c := range tc {
+				input.WriteString(fmt.Sprintf("%d %d\n", c.n, c.m))
+			}
+			fmt.Fprint(os.Stderr, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1715/verifierB.go
+++ b/1000-1999/1700-1799/1710-1719/1715/verifierB.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n int
+	k int64
+	b int64
+	s int64
+}
+
+func expectedB(tc testCaseB) ([]int64, bool) {
+	base := tc.b * tc.k
+	minSum := base
+	maxSum := base + int64(tc.n)*(tc.k-1)
+	if tc.s < minSum || tc.s > maxSum {
+		return nil, false
+	}
+	rem := tc.s - base
+	a := make([]int64, tc.n)
+	a[0] = base
+	for i := 1; i < tc.n && rem > 0; i++ {
+		add := tc.k - 1
+		if rem < add {
+			add = rem
+		}
+		a[i] = add
+		rem -= add
+	}
+	a[0] += rem
+	return a, true
+}
+
+func genCaseB(rng *rand.Rand) []testCaseB {
+	t := rng.Intn(5) + 1
+	cases := make([]testCaseB, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(5) + 1
+		k := int64(rng.Intn(10) + 1)
+		b := int64(rng.Intn(10))
+		base := b * k
+		maxS := base + int64(n)*(k-1)
+		var s int64
+		if rng.Intn(2) == 0 {
+			s = base + int64(rng.Intn(int(maxS-base+1)))
+		} else {
+			s = maxS + int64(rng.Intn(10)+1) // invalid
+		}
+		cases[i] = testCaseB{n: n, k: k, b: b, s: s}
+	}
+	return cases
+}
+
+func runCaseB(bin string, tcs []testCaseB) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", len(tcs)))
+	for _, tc := range tcs {
+		input.WriteString(fmt.Sprintf("%d %d %d %d\n", tc.n, tc.k, tc.b, tc.s))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(tcs) {
+		return fmt.Errorf("expected %d lines got %d", len(tcs), len(lines))
+	}
+	for i, line := range lines {
+		a, ok := expectedB(tcs[i])
+		if !ok {
+			if strings.TrimSpace(line) != "-1" {
+				return fmt.Errorf("case %d expected -1 got %s", i+1, strings.TrimSpace(line))
+			}
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != tcs[i].n {
+			return fmt.Errorf("case %d expected %d numbers got %d", i+1, tcs[i].n, len(fields))
+		}
+		for j, f := range fields {
+			val, err := strconv.ParseInt(f, 10, 64)
+			if err != nil {
+				return fmt.Errorf("case %d invalid int %q", i+1, f)
+			}
+			if val != a[j] {
+				return fmt.Errorf("case %d mismatch expected %v got %v", i+1, a, fields)
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		tc := genCaseB(rng)
+		if err := runCaseB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n", t+1, err)
+			var inp strings.Builder
+			inp.WriteString(fmt.Sprintf("%d\n", len(tc)))
+			for _, c := range tc {
+				inp.WriteString(fmt.Sprintf("%d %d %d %d\n", c.n, c.k, c.b, c.s))
+			}
+			fmt.Fprint(os.Stderr, inp.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1715/verifierC.go
+++ b/1000-1999/1700-1799/1710-1719/1715/verifierC.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	n       int
+	m       int
+	arr     []int64
+	queries [][2]int64
+}
+
+func expectedC(tc testCaseC) []int64 {
+	n := tc.n
+	a := append([]int64(nil), tc.arr...)
+	total := int64(n) * int64(n+1) / 2
+	for i := 0; i+1 < n; i++ {
+		if a[i] != a[i+1] {
+			total += int64(i+1) * int64(n-i-1)
+		}
+	}
+	res := make([]int64, tc.m)
+	for qi, q := range tc.queries {
+		idx := int(q[0]) - 1
+		x := q[1]
+		if a[idx] != x {
+			if idx-1 >= 0 {
+				oldDiff := a[idx-1] != a[idx]
+				newDiff := a[idx-1] != x
+				if oldDiff != newDiff {
+					weight := int64(idx) * int64(n-idx)
+					if newDiff {
+						total += weight
+					} else {
+						total -= weight
+					}
+				}
+			}
+			if idx+1 < n {
+				oldDiff := a[idx] != a[idx+1]
+				newDiff := x != a[idx+1]
+				if oldDiff != newDiff {
+					weight := int64(idx+1) * int64(n-idx-1)
+					if newDiff {
+						total += weight
+					} else {
+						total -= weight
+					}
+				}
+			}
+			a[idx] = x
+		}
+		res[qi] = total
+	}
+	return res
+}
+
+func genCaseC(rng *rand.Rand) testCaseC {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(8) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rng.Intn(5) + 1)
+	}
+	queries := make([][2]int64, m)
+	for i := 0; i < m; i++ {
+		queries[i][0] = int64(rng.Intn(n) + 1)
+		queries[i][1] = int64(rng.Intn(5) + 1)
+	}
+	return testCaseC{n: n, m: m, arr: arr, queries: queries}
+}
+
+func runCaseC(bin string, tc testCaseC) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for i, v := range tc.arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprintf("%d", v))
+	}
+	input.WriteByte('\n')
+	for _, q := range tc.queries {
+		input.WriteString(fmt.Sprintf("%d %d\n", q[0], q[1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != tc.m {
+		return fmt.Errorf("expected %d lines got %d", tc.m, len(lines))
+	}
+	expect := expectedC(tc)
+	for i, line := range lines {
+		val, err := strconv.ParseInt(strings.TrimSpace(line), 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid int %q", line)
+		}
+		if val != expect[i] {
+			return fmt.Errorf("line %d expected %d got %d", i+1, expect[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		tc := genCaseC(rng)
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n", t+1, err)
+			var inp strings.Builder
+			inp.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+			for i, v := range tc.arr {
+				if i > 0 {
+					inp.WriteByte(' ')
+				}
+				inp.WriteString(fmt.Sprintf("%d", v))
+			}
+			inp.WriteByte('\n')
+			for _, q := range tc.queries {
+				inp.WriteString(fmt.Sprintf("%d %d\n", q[0], q[1]))
+			}
+			fmt.Fprint(os.Stderr, inp.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1715/verifierD.go
+++ b/1000-1999/1700-1799/1710-1719/1715/verifierD.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type EdgeD struct {
+	u int
+	v int
+	x int
+}
+
+type DSUD struct {
+	parent []int
+	size   []int
+	mx     []int
+	need   []bool
+	hasOne []bool
+}
+
+func NewDSUD(n int) *DSUD {
+	d := &DSUD{parent: make([]int, n), size: make([]int, n), mx: make([]int, n), need: make([]bool, n), hasOne: make([]bool, n)}
+	for i := 0; i < n; i++ {
+		d.parent[i] = i
+		d.size[i] = 1
+		d.mx[i] = i
+	}
+	return d
+}
+
+func (d *DSUD) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSUD) union(a, b int) int {
+	ra := d.find(a)
+	rb := d.find(b)
+	if ra == rb {
+		return ra
+	}
+	if d.size[ra] < d.size[rb] {
+		ra, rb = rb, ra
+	}
+	d.parent[rb] = ra
+	d.size[ra] += d.size[rb]
+	if d.mx[rb] > d.mx[ra] {
+		d.mx[ra] = d.mx[rb]
+	}
+	d.need[ra] = d.need[ra] || d.need[rb]
+	d.hasOne[ra] = d.hasOne[ra] || d.hasOne[rb]
+	return ra
+}
+
+func solveD(n int, edges []EdgeD) []int {
+	ans := make([]int, n)
+	for bit := 0; bit < 30; bit++ {
+		forced0 := make([]bool, n)
+		for _, e := range edges {
+			if ((e.x >> bit) & 1) == 0 {
+				forced0[e.u] = true
+				forced0[e.v] = true
+			}
+		}
+		dsu := NewDSUD(n)
+		forced1 := make([]bool, n)
+		for _, e := range edges {
+			if ((e.x >> bit) & 1) == 1 {
+				fu := forced0[e.u]
+				fv := forced0[e.v]
+				if fu && fv {
+				} else if fu && !fv {
+					forced1[e.v] = true
+				} else if fv && !fu {
+					forced1[e.u] = true
+				} else {
+					root := dsu.union(e.u, e.v)
+					dsu.need[root] = true
+				}
+			}
+		}
+		for i := 0; i < n; i++ {
+			if forced0[i] {
+				continue
+			}
+			r := dsu.find(i)
+			if dsu.mx[r] < i {
+				dsu.mx[r] = i
+			}
+		}
+		for i := 0; i < n; i++ {
+			if forced1[i] {
+				r := dsu.find(i)
+				dsu.hasOne[r] = true
+			}
+		}
+		seen := make(map[int]bool)
+		for i := 0; i < n; i++ {
+			if forced0[i] {
+				continue
+			}
+			r := dsu.find(i)
+			if seen[r] {
+				continue
+			}
+			seen[r] = true
+			if dsu.need[r] && !dsu.hasOne[r] {
+				idx := dsu.mx[r]
+				forced1[idx] = true
+				dsu.hasOne[r] = true
+			}
+		}
+		for i := 0; i < n; i++ {
+			if forced1[i] {
+				ans[i] |= (1 << bit)
+			}
+		}
+	}
+	return ans
+}
+
+type testCaseD struct {
+	n     int
+	q     int
+	edges []EdgeD
+}
+
+func genCaseD(rng *rand.Rand) testCaseD {
+	n := rng.Intn(5) + 1
+	q := rng.Intn(7) + 1
+	edges := make([]EdgeD, q)
+	for i := 0; i < q; i++ {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		x := rng.Intn(16)
+		edges[i] = EdgeD{u, v, x}
+	}
+	return testCaseD{n: n, q: q, edges: edges}
+}
+
+func runCaseD(bin string, tc testCaseD) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.q))
+	for _, e := range tc.edges {
+		input.WriteString(fmt.Sprintf("%d %d %d\n", e.u+1, e.v+1, e.x))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != tc.n {
+		return fmt.Errorf("expected %d numbers got %d", tc.n, len(fields))
+	}
+	expect := solveD(tc.n, tc.edges)
+	for i, f := range fields {
+		val, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("invalid int %q", f)
+		}
+		if val != expect[i] {
+			return fmt.Errorf("mismatch expected %v got %v", expect, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		tc := genCaseD(rng)
+		if err := runCaseD(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n", t+1, err)
+			var inp strings.Builder
+			inp.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.q))
+			for _, e := range tc.edges {
+				inp.WriteString(fmt.Sprintf("%d %d %d\n", e.u+1, e.v+1, e.x))
+			}
+			fmt.Fprint(os.Stderr, inp.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1715/verifierE.go
+++ b/1000-1999/1700-1799/1710-1719/1715/verifierE.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type EdgeE struct {
+	to int
+	w  int64
+}
+
+type item struct {
+	node int
+	dist int64
+}
+
+type priorityQueue []*item
+
+func (pq priorityQueue) Len() int            { return len(pq) }
+func (pq priorityQueue) Less(i, j int) bool  { return pq[i].dist < pq[j].dist }
+func (pq priorityQueue) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *priorityQueue) Push(x interface{}) { *pq = append(*pq, x.(*item)) }
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	it := old[n-1]
+	*pq = old[:n-1]
+	return it
+}
+
+type Line struct {
+	m, b int64
+}
+
+func (ln Line) value(x int64) int64 { return ln.m*x + ln.b }
+
+type Node struct {
+	ln          Line
+	left, right *Node
+}
+
+func insert(node *Node, l, r int64, ln Line) *Node {
+	if node == nil {
+		return &Node{ln: ln}
+	}
+	mid := (l + r) >> 1
+	leftBetter := ln.value(l) < node.ln.value(l)
+	midBetter := ln.value(mid) < node.ln.value(mid)
+	if midBetter {
+		node.ln, ln = ln, node.ln
+	}
+	if l == r {
+		return node
+	}
+	if leftBetter != midBetter {
+		node.left = insert(node.left, l, mid, ln)
+	} else {
+		node.right = insert(node.right, mid+1, r, ln)
+	}
+	return node
+}
+
+func query(node *Node, l, r, x int64) int64 {
+	if node == nil {
+		return 1<<63 - 1
+	}
+	res := node.ln.value(x)
+	if l == r {
+		return res
+	}
+	mid := (l + r) >> 1
+	if x <= mid {
+		val := query(node.left, l, mid, x)
+		if val < res {
+			res = val
+		}
+	} else {
+		val := query(node.right, mid+1, r, x)
+		if val < res {
+			res = val
+		}
+	}
+	return res
+}
+
+type LiChao struct {
+	root        *Node
+	left, right int64
+}
+
+func NewLiChao(l, r int64) *LiChao     { return &LiChao{left: l, right: r} }
+func (lc *LiChao) Insert(ln Line)      { lc.root = insert(lc.root, lc.left, lc.right, ln) }
+func (lc *LiChao) Query(x int64) int64 { return query(lc.root, lc.left, lc.right, x) }
+
+func dijkstra(start []int64, g [][]EdgeE) []int64 {
+	n := len(g) - 1
+	dist := make([]int64, n+1)
+	copy(dist, start)
+	pq := &priorityQueue{}
+	heap.Init(pq)
+	for i := 1; i <= n; i++ {
+		if dist[i] < (1<<63 - 1) {
+			heap.Push(pq, &item{node: i, dist: dist[i]})
+		}
+	}
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(*item)
+		if it.dist != dist[it.node] {
+			continue
+		}
+		u := it.node
+		d := it.dist
+		for _, e := range g[u] {
+			nd := d + e.w
+			if nd < dist[e.to] {
+				dist[e.to] = nd
+				heap.Push(pq, &item{node: e.to, dist: nd})
+			}
+		}
+	}
+	return dist
+}
+
+func solveE(n, m, k int, edges [][3]int) []int64 {
+	g := make([][]EdgeE, n+1)
+	for _, e := range edges {
+		u := e[0]
+		v := e[1]
+		w := int64(e[2])
+		g[u] = append(g[u], EdgeE{v, w})
+		g[v] = append(g[v], EdgeE{u, w})
+	}
+	const inf int64 = 1<<63 - 1
+	dist := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = inf
+	}
+	dist[1] = 0
+	dist = dijkstra(dist, g)
+	for iter := 0; iter < k; iter++ {
+		tree := NewLiChao(1, int64(n))
+		for i := 1; i <= n; i++ {
+			if dist[i] < inf {
+				x := int64(i)
+				tree.Insert(Line{m: -2 * x, b: dist[i] + x*x})
+			}
+		}
+		newDist := make([]int64, n+1)
+		for i := 1; i <= n; i++ {
+			x := int64(i)
+			newDist[i] = x*x + tree.Query(x)
+		}
+		dist = dijkstra(newDist, g)
+	}
+	return dist[1:]
+}
+
+type testCaseE struct {
+	n, m, k int
+	edges   [][3]int
+}
+
+func genCaseE(rng *rand.Rand) testCaseE {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(6) + 1
+	k := rng.Intn(3) + 1
+	edges := make([][3]int, m)
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		for v == u {
+			v = rng.Intn(n) + 1
+		}
+		w := rng.Intn(10) + 1
+		edges[i] = [3]int{u, v, w}
+	}
+	return testCaseE{n: n, m: m, k: k, edges: edges}
+}
+
+func runCaseE(bin string, tc testCaseE) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.m, tc.k))
+	for _, e := range tc.edges {
+		input.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != tc.n {
+		return fmt.Errorf("expected %d numbers got %d", tc.n, len(fields))
+	}
+	expect := solveE(tc.n, tc.m, tc.k, tc.edges)
+	for i, f := range fields {
+		val, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid int %q", f)
+		}
+		if val != expect[i] {
+			return fmt.Errorf("mismatch expected %v got %v", expect, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		tc := genCaseE(rng)
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n", t+1, err)
+			var inp strings.Builder
+			inp.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.m, tc.k))
+			for _, e := range tc.edges {
+				inp.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+			}
+			fmt.Fprint(os.Stderr, inp.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1715/verifierF.go
+++ b/1000-1999/1700-1799/1710-1719/1715/verifierF.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem F is interactive and cannot be automatically verified.")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1715 (problems A–F)
- verifiers generate random cases and compare output with expected results
- interactive problem F prints a helpful notice

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68874f8f9fc88324a842e8a903563b24