### PR TITLE
Add Go verifiers for Codeforces 1714

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1714/verifierA.go
+++ b/1000-1999/1700-1799/1710-1719/1714/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type alarm struct{ h, m int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n, H, M int, al []alarm) (int, int) {
+	start := H*60 + M
+	best := 24 * 60
+	for _, a := range al {
+		cur := a.h*60 + a.m
+		diff := cur - start
+		if diff < 0 {
+			diff += 24 * 60
+		}
+		if diff < best {
+			best = diff
+		}
+	}
+	return best / 60, best % 60
+}
+
+func generateCase(rng *rand.Rand) (string, int, int, []alarm) {
+	n := rng.Intn(10) + 1
+	H := rng.Intn(24)
+	M := rng.Intn(60)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, H, M))
+	alarms := make([]alarm, n)
+	for i := 0; i < n; i++ {
+		h := rng.Intn(24)
+		m := rng.Intn(60)
+		sb.WriteString(fmt.Sprintf("%d %d\n", h, m))
+		alarms[i] = alarm{h, m}
+	}
+	return sb.String(), H, M, alarms
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, H, M, alarms := generateCase(rng)
+		expH, expM := solve(len(alarms), H, M, alarms)
+		expected := fmt.Sprintf("%d %d", expH, expM)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1714/verifierB.go
+++ b/1000-1999/1700-1799/1710-1719/1714/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(arr []int) int {
+	seen := make(map[int]bool)
+	ans := 0
+	for i := len(arr) - 1; i >= 0; i-- {
+		if seen[arr[i]] {
+			ans = i + 1
+			break
+		}
+		seen[arr[i]] = true
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solve(arr)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, ans := genCase(rng)
+		expected := fmt.Sprintf("%d", ans)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1714/verifierC.go
+++ b/1000-1999/1700-1799/1710-1719/1714/verifierC.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(s int) string {
+	digits := []int{}
+	for d := 9; d >= 1; d-- {
+		if s >= d {
+			digits = append(digits, d)
+			s -= d
+		}
+	}
+	var sb strings.Builder
+	for i := len(digits) - 1; i >= 0; i-- {
+		sb.WriteString(fmt.Sprintf("%d", digits[i]))
+	}
+	if sb.Len() == 0 {
+		sb.WriteByte('0')
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	s := rng.Intn(45) + 1
+	input := fmt.Sprintf("1\n%d\n", s)
+	return input, solve(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1714/verifierD.go
+++ b/1000-1999/1700-1799/1710-1719/1714/verifierD.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func minOps(t string, arr []string) int {
+	const INF = int(1e9)
+	L := len(t)
+	ss := make([][2]int, L)
+	for i := 0; i < L; i++ {
+		ss[i][0], ss[i][1] = INF, INF
+	}
+	for i, pat := range arr {
+		plen := len(pat)
+		for j := 0; j+plen <= L; j++ {
+			if t[j:j+plen] == pat {
+				end := j + plen - 1
+				if ss[end][1] > j {
+					ss[end][0] = i
+					ss[end][1] = j
+				}
+			}
+		}
+	}
+	rpos := L - 1
+	ans := 0
+	for rpos >= 0 {
+		mv := rpos
+		for i := rpos; i < L; i++ {
+			if ss[i][1] <= rpos && ss[i][1]-1 < mv {
+				mv = ss[i][1] - 1
+			}
+		}
+		if mv >= rpos {
+			return -1
+		}
+		ans++
+		rpos = mv
+	}
+	return ans
+}
+
+func verifyOutput(out string, t string, arr []string, exp int) error {
+	fields := strings.Fields(out)
+	if exp == -1 {
+		if len(fields) != 1 || fields[0] != "-1" {
+			return fmt.Errorf("expected -1, got %s", out)
+		}
+		return nil
+	}
+	if len(fields) != 1+2*exp {
+		return fmt.Errorf("expected %d numbers, got %d", 1+2*exp, len(fields))
+	}
+	m, err := strconv.Atoi(fields[0])
+	if err != nil || m != exp {
+		return fmt.Errorf("expected first number %d", exp)
+	}
+	colored := make([]bool, len(t))
+	for i := 0; i < m; i++ {
+		idx, err1 := strconv.Atoi(fields[1+2*i])
+		pos, err2 := strconv.Atoi(fields[2+2*i])
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("bad integers")
+		}
+		if idx < 1 || idx > len(arr) {
+			return fmt.Errorf("bad index")
+		}
+		pos--
+		pat := arr[idx-1]
+		if pos < 0 || pos+len(pat) > len(t) {
+			return fmt.Errorf("bad position")
+		}
+		if t[pos:pos+len(pat)] != pat {
+			return fmt.Errorf("substring mismatch")
+		}
+		for j := 0; j < len(pat); j++ {
+			colored[pos+j] = true
+		}
+	}
+	for _, c := range colored {
+		if !c {
+			return fmt.Errorf("not fully covered")
+		}
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (string, string, []string, int) {
+	L := rng.Intn(8) + 1
+	alphabet := []rune("abc")
+	var sb strings.Builder
+	for i := 0; i < L; i++ {
+		sb.WriteRune(alphabet[rng.Intn(len(alphabet))])
+	}
+	t := sb.String()
+	n := rng.Intn(3) + 1
+	arr := make([]string, n)
+	for i := 0; i < n; i++ {
+		ln := rng.Intn(3) + 1
+		var tb strings.Builder
+		for j := 0; j < ln; j++ {
+			tb.WriteRune(alphabet[rng.Intn(len(alphabet))])
+		}
+		arr[i] = tb.String()
+	}
+	var input strings.Builder
+	input.WriteString("1\n")
+	input.WriteString(fmt.Sprintf("%s\n", t))
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for _, s := range arr {
+		input.WriteString(fmt.Sprintf("%s\n", s))
+	}
+	exp := minOps(t, arr)
+	return input.String(), t, arr, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, t, arr, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := verifyOutput(out, t, arr, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1714/verifierE.go
+++ b/1000-1999/1700-1799/1710-1719/1714/verifierE.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(arr []int) string {
+	hasZero := false
+	for i, v := range arr {
+		if v%10 == 5 {
+			v += 5
+		}
+		if v%10 == 0 {
+			hasZero = true
+		}
+		arr[i] = v
+	}
+	if hasZero {
+		first := arr[0]
+		for _, v := range arr {
+			if v != first {
+				return "NO"
+			}
+		}
+		return "YES"
+	}
+	parity := -1
+	for i, v := range arr {
+		for v%10 != 2 {
+			v += v % 10
+		}
+		arr[i] = v
+		p := (v / 10) % 2
+		if parity == -1 {
+			parity = p
+		} else if parity != p {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solve(arr)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1714/verifierF.go
+++ b/1000-1999/1700-1799/1710-1719/1714/verifierF.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func construct(n, d12, d23, d13 int) (bool, [][2]int) {
+	edges := make([][2]int, 0)
+	if d23 == d12+d13 {
+		if d12+d13+1 > n {
+			return false, nil
+		}
+		node := 4
+		second := 1
+		for i := 1; i <= d12-1; i++ {
+			first := second
+			second = node
+			edges = append(edges, [2]int{first, second})
+			node++
+		}
+		edges = append(edges, [2]int{second, 2})
+		second = 1
+		for i := 1; i <= d13-1; i++ {
+			first := second
+			second = node
+			edges = append(edges, [2]int{first, second})
+			node++
+		}
+		edges = append(edges, [2]int{second, 3})
+		for node <= n {
+			edges = append(edges, [2]int{1, node})
+			node++
+		}
+		return true, edges
+	}
+	if d12 == d23+d13 {
+		if d23+d13+1 > n {
+			return false, nil
+		}
+		node := 4
+		second := 3
+		for i := 1; i <= d13-1; i++ {
+			first := second
+			second = node
+			edges = append(edges, [2]int{first, second})
+			node++
+		}
+		edges = append(edges, [2]int{second, 1})
+		second = 3
+		for i := 1; i <= d23-1; i++ {
+			first := second
+			second = node
+			edges = append(edges, [2]int{first, second})
+			node++
+		}
+		edges = append(edges, [2]int{second, 2})
+		for node <= n {
+			edges = append(edges, [2]int{1, node})
+			node++
+		}
+		return true, edges
+	}
+	if d13 == d12+d23 {
+		if d12+d23+1 > n {
+			return false, nil
+		}
+		node := 4
+		second := 2
+		for i := 1; i <= d12-1; i++ {
+			first := second
+			second = node
+			edges = append(edges, [2]int{first, second})
+			node++
+		}
+		edges = append(edges, [2]int{second, 1})
+		second = 2
+		for i := 1; i <= d23-1; i++ {
+			first := second
+			second = node
+			edges = append(edges, [2]int{first, second})
+			node++
+		}
+		edges = append(edges, [2]int{second, 3})
+		for node <= n {
+			edges = append(edges, [2]int{1, node})
+			node++
+		}
+		return true, edges
+	}
+	for j := 1; j < d12; j++ {
+		d41 := j
+		d42 := d12 - j
+		d43 := d13 - j
+		if d43 <= 0 || d42 <= 0 || d42+d43 != d23 || d41+d42+d43+1 > n {
+			continue
+		}
+		node := 5
+		second := 4
+		edges = edges[:0]
+		for i := 1; i <= d41-1; i++ {
+			first := second
+			second = node
+			edges = append(edges, [2]int{first, second})
+			node++
+		}
+		edges = append(edges, [2]int{second, 1})
+		second = 4
+		for i := 1; i <= d43-1; i++ {
+			first := second
+			second = node
+			edges = append(edges, [2]int{first, second})
+			node++
+		}
+		edges = append(edges, [2]int{second, 3})
+		second = 4
+		for i := 1; i <= d42-1; i++ {
+			first := second
+			second = node
+			edges = append(edges, [2]int{first, second})
+			node++
+		}
+		edges = append(edges, [2]int{second, 2})
+		for node <= n {
+			edges = append(edges, [2]int{4, node})
+			node++
+		}
+		return true, edges
+	}
+	return false, nil
+}
+
+func bfs(n int, adj [][]int, start int) []int {
+	dist := make([]int, n+1)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := []int{start}
+	dist[start] = 0
+	for len(q) > 0 {
+		v := q[0]
+		q = q[1:]
+		for _, to := range adj[v] {
+			if dist[to] == -1 {
+				dist[to] = dist[v] + 1
+				q = append(q, to)
+			}
+		}
+	}
+	return dist
+}
+
+func verify(out string, n, d12, d23, d13 int, possible bool) error {
+	fields := strings.Fields(out)
+	if !possible {
+		if len(fields) != 1 || strings.ToUpper(fields[0]) != "NO" {
+			return fmt.Errorf("expected NO")
+		}
+		return nil
+	}
+	if len(fields) != 1+2*(n-1) {
+		return fmt.Errorf("expected %d numbers", 1+2*(n-1))
+	}
+	if strings.ToUpper(fields[0]) != "YES" {
+		return fmt.Errorf("expected YES")
+	}
+	edges := make([][2]int, n-1)
+	idx := 1
+	for i := 0; i < n-1; i++ {
+		u, err1 := strconv.Atoi(fields[idx])
+		v, err2 := strconv.Atoi(fields[idx+1])
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("bad integers")
+		}
+		if u < 1 || u > n || v < 1 || v > n {
+			return fmt.Errorf("bad node")
+		}
+		edges[i] = [2]int{u, v}
+		idx += 2
+	}
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		adj[e[0]] = append(adj[e[0]], e[1])
+		adj[e[1]] = append(adj[e[1]], e[0])
+	}
+	// check tree property
+	visited := make([]bool, n+1)
+	q := []int{1}
+	visited[1] = true
+	for len(q) > 0 {
+		v := q[0]
+		q = q[1:]
+		for _, to := range adj[v] {
+			if !visited[to] {
+				visited[to] = true
+				q = append(q, to)
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if !visited[i] {
+			return fmt.Errorf("graph not connected")
+		}
+	}
+	// check distances
+	d1 := bfs(n, adj, 1)
+	d2 := bfs(n, adj, 2)
+	if d1[2] != d12 || d2[3] != d23 || d1[3] != d13 {
+		return fmt.Errorf("wrong distances")
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (string, int, int, int, int, bool) {
+	n := rng.Intn(7) + 3
+	d12 := rng.Intn(n-1) + 1
+	d23 := rng.Intn(n-1) + 1
+	d13 := rng.Intn(n-1) + 1
+	possible, _ := construct(n, d12, d23, d13)
+	input := fmt.Sprintf("1\n%d %d %d %d\n", n, d12, d23, d13)
+	return input, n, d12, d23, d13, possible
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, n, d12, d23, d13, possible := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := verify(out, n, d12, d23, d13, possible); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1714/verifierG.go
+++ b/1000-1999/1700-1799/1710-1719/1714/verifierG.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to   int
+	a, b int64
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n int, edges [][]Edge) []int {
+	res := make([]int, n+1)
+	prefix := []int64{0}
+	type Node struct {
+		id   int
+		aSum int64
+		idx  int
+	}
+	stack := []Node{{id: 1, aSum: 0, idx: 0}}
+	for len(stack) > 0 {
+		top := &stack[len(stack)-1]
+		if top.idx == len(edges[top.id]) {
+			if top.id != 1 {
+				prefix = prefix[:len(prefix)-1]
+			}
+			stack = stack[:len(stack)-1]
+			continue
+		}
+		e := edges[top.id][top.idx]
+		top.idx++
+		newASum := top.aSum + e.a
+		prefix = append(prefix, prefix[len(prefix)-1]+e.b)
+		pos := sort.Search(len(prefix), func(i int) bool { return prefix[i] > newASum }) - 1
+		res[e.to] = pos
+		stack = append(stack, Node{id: e.to, aSum: newASum, idx: 0})
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, int, [][]Edge, []int) {
+	n := rng.Intn(8) + 2
+	edges := make([][]Edge, n+1)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		a := rng.Int63n(100) + 1
+		b := rng.Int63n(100) + 1
+		edges[p] = append(edges[p], Edge{to: i, a: a, b: b})
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", p, a, b))
+	}
+	ans := solve(n, edges)
+	return sb.String(), n, edges, ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, n, edges, ans := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != n-1 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\n", i+1, n-1, len(fields))
+			os.Exit(1)
+		}
+		for j, f := range fields {
+			v, err := strconv.Atoi(f)
+			if err != nil || v != ans[j+2] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %v\ninput:\n%s", i+1, ans[2:], fields, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–G of contest 1714

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68874f4996b48324a5fc247d2f207052