### PR TITLE
Add verifiers for CF 1716

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1716/verifierA.go
+++ b/1000-1999/1700-1799/1710-1719/1716/verifierA.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n int64) int64 {
+	if n == 1 {
+		return 2
+	}
+	return (n + 2) / 3
+}
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		input := fmt.Sprintf("1\n%d\n", n)
+		expected := fmt.Sprint(solve(n))
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1716/verifierB.go
+++ b/1000-1999/1700-1799/1710-1719/1716/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateChain(n int) [][]int {
+	perm := make([]int, n)
+	for i := 0; i < n; i++ {
+		perm[i] = i + 1
+	}
+	res := make([][]int, 0, n)
+	copyPerm := func() []int {
+		p := make([]int, n)
+		copy(p, perm)
+		return p
+	}
+	res = append(res, copyPerm())
+	perm[0], perm[n-1] = perm[n-1], perm[0]
+	res = append(res, copyPerm())
+	for i := 3; i <= n; i++ {
+		j1 := i - 3
+		j2 := i - 2
+		perm[j1], perm[j2] = perm[j2], perm[j1]
+		res = append(res, copyPerm())
+	}
+	return res
+}
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyCase(bin string, n int) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	if len(fields) < 1 {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid k: %v", err)
+	}
+	if k != n {
+		return fmt.Errorf("expected k=%d got %d", n, k)
+	}
+	if len(fields) != 1+k*n {
+		return fmt.Errorf("expected %d numbers, got %d", 1+k*n, len(fields))
+	}
+	perms := generateChain(n)
+	idx := 1
+	for i := 0; i < k; i++ {
+		for j := 0; j < n; j++ {
+			v, err := strconv.Atoi(fields[idx])
+			if err != nil {
+				return fmt.Errorf("invalid int: %v", err)
+			}
+			if v != perms[i][j] {
+				return fmt.Errorf("mismatch at perm %d index %d: expected %d got %d", i+1, j+1, perms[i][j], v)
+			}
+			idx++
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(99) + 2 // 2..100
+		if err := verifyCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1716/verifierC.go
+++ b/1000-1999/1700-1799/1710-1719/1716/verifierC.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveCase(m int, top, bottom []int) int {
+	prefTop := make([]int, m+1)
+	prefBottom := make([]int, m+1)
+	for i := 1; i <= m; i++ {
+		prefTop[i] = max(prefTop[i-1]+1, top[i]+1)
+		prefBottom[i] = max(prefBottom[i-1]+1, bottom[i]+1)
+	}
+	sufTop := make([]int, m+2)
+	sufBottom := make([]int, m+2)
+	for i := m; i >= 1; i-- {
+		sufTop[i] = max(sufTop[i+1]+1, top[i]+1)
+		sufBottom[i] = max(sufBottom[i+1]+1, bottom[i]+1)
+	}
+	ans := int(^uint(0) >> 1)
+	for i := 1; i <= m; i++ {
+		cur1 := max(prefTop[i-1], sufBottom[i+1])
+		cur2 := max(prefBottom[i-1], sufTop[i+1])
+		cur := cur1
+		if cur2 < cur {
+			cur = cur2
+		}
+		if cur < ans {
+			ans = cur
+		}
+	}
+	return ans
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyCase(bin string, m int, top, bottom []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 1; i <= m; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(top[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= m; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(bottom[i]))
+	}
+	sb.WriteByte('\n')
+	expected := fmt.Sprint(solveCase(m, top, bottom))
+	out, err := runCandidate(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != expected {
+		return fmt.Errorf("expected %s got %s", expected, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		m := rng.Intn(50) + 2
+		top := make([]int, m+1)
+		bottom := make([]int, m+1)
+		for j := 1; j <= m; j++ {
+			top[j] = rng.Intn(1000000000)
+		}
+		for j := 1; j <= m; j++ {
+			bottom[j] = rng.Intn(1000000000)
+		}
+		if err := verifyCase(bin, m, top, bottom); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1716/verifierD.go
+++ b/1000-1999/1700-1799/1710-1719/1716/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func solveCase(n, k int) []int64 {
+	dp := make([]int64, n+1)
+	dp[0] = 1
+	ans := make([]int64, n+1)
+	for step := 0; ; step++ {
+		base := k + step
+		if base > n {
+			break
+		}
+		newdp := make([]int64, n+1)
+		for r := 0; r < base; r++ {
+			sum := int64(0)
+			for x := r; x+base <= n; x += base {
+				sum += dp[x]
+				if sum >= mod {
+					sum -= mod
+				}
+				newdp[x+base] = sum
+			}
+		}
+		has := false
+		for i := base; i <= n; i++ {
+			if newdp[i] != 0 {
+				has = true
+			}
+			ans[i] += newdp[i]
+			if ans[i] >= mod {
+				ans[i] -= mod
+			}
+		}
+		if !has {
+			break
+		}
+		dp = newdp
+	}
+	return ans[1:]
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyCase(bin string, n, k int) error {
+	input := fmt.Sprintf("%d %d\n", n, k)
+	expectedVals := solveCase(n, k)
+	expectedStr := make([]string, len(expectedVals))
+	for i, v := range expectedVals {
+		expectedStr[i] = fmt.Sprint(v)
+	}
+	expected := strings.Join(expectedStr, " ")
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != expected {
+		return fmt.Errorf("expected %s got %s", expected, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(50) + 1
+		k := rng.Intn(n) + 1
+		if err := verifyCase(bin, n, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1716/verifierE.go
+++ b/1000-1999/1700-1799/1710-1719/1716/verifierE.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Node struct {
+	sum, pref, suff, ans int64
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func merge(l, r Node) Node {
+	res := Node{}
+	res.sum = l.sum + r.sum
+	res.pref = max64(l.pref, l.sum+r.pref)
+	res.suff = max64(r.suff, r.sum+l.suff)
+	cross := l.suff + r.pref
+	res.ans = max64(max64(l.ans, r.ans), cross)
+	return res
+}
+
+func build(a []int64, lvl, start int) []Node {
+	if lvl == 0 {
+		x := a[start]
+		n := Node{sum: x}
+		if x > 0 {
+			n.pref = x
+			n.suff = x
+			n.ans = x
+		}
+		return []Node{n}
+	}
+	half := 1 << (lvl - 1)
+	left := build(a, lvl-1, start)
+	right := build(a, lvl-1, start+half)
+	size := 1 << lvl
+	res := make([]Node, size)
+	maskLower := half - 1
+	for m := 0; m < size; m++ {
+		sub := m & maskLower
+		if m&half == 0 {
+			res[m] = merge(left[sub], right[sub])
+		} else {
+			res[m] = merge(right[sub], left[sub])
+		}
+	}
+	return res
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyCase(bin string, n int, arr []int64, qs []int) error {
+	nodes := build(arr, n, 0)
+	mask := 0
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", len(qs)))
+	for _, k := range qs {
+		sb.WriteString(fmt.Sprintf("%d\n", k))
+	}
+	out, err := runCandidate(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	expectedVals := make([]string, len(qs))
+	for i, k := range qs {
+		mask ^= 1 << k
+		expectedVals[i] = fmt.Sprint(nodes[mask].ans)
+	}
+	expected := strings.Join(expectedVals, "\n")
+	if strings.TrimSpace(out) != expected {
+		return fmt.Errorf("expected:\n%s\n got:\n%s", expected, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		size := 1 << n
+		arr := make([]int64, size)
+		for j := 0; j < size; j++ {
+			arr[j] = rng.Int63n(200) - 100
+		}
+		q := rng.Intn(20) + 1
+		qs := make([]int, q)
+		for j := 0; j < q; j++ {
+			qs[j] = rng.Intn(n)
+		}
+		if err := verifyCase(bin, n, arr, qs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1716/verifierF.go
+++ b/1000-1999/1700-1799/1710-1719/1716/verifierF.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 998244353
+const MAXK = 2000
+
+var stirling [MAXK + 1][MAXK + 1]int64
+
+func init() {
+	stirling[0][0] = 1
+	for n := 1; n <= MAXK; n++ {
+		for k := 1; k <= n; k++ {
+			stirling[n][k] = (stirling[n-1][k-1] + int64(k)*stirling[n-1][k]) % MOD
+		}
+	}
+}
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func solveCase(n, m, k int64) int64 {
+	a := (m + 1) / 2
+	invm := modPow(m%MOD, MOD-2)
+	p := a % MOD * invm % MOD
+	mPow := modPow(m%MOD, n)
+	maxI := k
+	if n < maxI {
+		maxI = n
+	}
+	fall := int64(1)
+	powp := int64(1)
+	ans := stirling[k][0] * fall % MOD * powp % MOD
+	for i := int64(1); i <= maxI; i++ {
+		fall = fall * ((n - i + 1) % MOD) % MOD
+		powp = powp * p % MOD
+		ans = (ans + stirling[k][i]*fall%MOD*powp) % MOD
+	}
+	ans = ans * mPow % MOD
+	return ans
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyCase(bin string, n, m, k int64) error {
+	input := fmt.Sprintf("1\n%d %d %d\n", n, m, k)
+	expected := fmt.Sprint(solveCase(n, m, k))
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != expected {
+		return fmt.Errorf("expected %s got %s", expected, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := int64(rng.Intn(1000) + 1)
+		m := int64(rng.Intn(1000) + 1)
+		k := int64(rng.Intn(10) + 1)
+		if err := verifyCase(bin, n, m, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1716 problems A–F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68874fd5dc808324bf97b1457826a48f