### PR TITLE
Add Go verifiers for contest 1718

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1718/verifierA.go
+++ b/1000-1999/1700-1799/1710-1719/1718/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1718A2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := rng.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(16)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1718/verifierB.go
+++ b/1000-1999/1700-1799/1710-1719/1718/verifierB.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1718B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		k := rng.Intn(6) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", k))
+		for i := 0; i < k; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(20)+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1718/verifierC.go
+++ b/1000-1999/1700-1799/1710-1719/1718/verifierC.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1718C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := rng.Intn(5) + 2
+		q := rng.Intn(3)
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(50)+1))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < q; i++ {
+			p := rng.Intn(n) + 1
+			x := rng.Intn(50) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", p, x))
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1718/verifierD.go
+++ b/1000-1999/1700-1799/1710-1719/1718/verifierD.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genCase(rng *rand.Rand) string {
+	t := 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	n := rng.Intn(4) + 2
+	q := rng.Intn(3) + 1
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	// permutation p
+	perm := rand.Perm(n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", perm[i]+1))
+	}
+	sb.WriteByte('\n')
+	// array a with at least 2 zeros
+	k := rng.Intn(n-1) + 2
+	zeros := rand.Perm(n)[:k]
+	arr := make([]int, n)
+	used := map[int]bool{}
+	for i := 0; i < n; i++ {
+		arr[i] = 0
+	}
+	for i := 0; i < n; i++ {
+		if !contains(zeros, i) {
+			val := rng.Intn(15) + 1
+			for used[val] {
+				val = rng.Intn(15) + 1
+			}
+			used[val] = true
+			arr[i] = val
+		}
+	}
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	// set S
+	numbers := []int{}
+	for len(numbers) < k-1 {
+		v := rng.Intn(15) + 1
+		if !used[v] {
+			used[v] = true
+			numbers = append(numbers, v)
+		}
+	}
+	for i, v := range numbers {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		d := rng.Intn(15) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", d))
+	}
+	return sb.String()
+}
+
+func contains(arr []int, x int) bool {
+	for _, v := range arr {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isSimilar(p, arr []int) bool {
+	n := len(arr)
+	for l := 0; l < n; l++ {
+		maxpIdx := l
+		maxp := p[l]
+		for r := l; r < n; r++ {
+			if p[r] > maxp {
+				maxp = p[r]
+				maxpIdx = r
+			}
+			maxaIdx := l
+			maxa := arr[l]
+			for i := l; i <= r; i++ {
+				if arr[i] > maxa {
+					maxa = arr[i]
+					maxaIdx = i
+				}
+			}
+			if maxaIdx != maxpIdx {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func brute(input string) (string, error) {
+	var t int
+	fmt.Sscan(input, &t)
+	lines := strings.Split(strings.TrimSpace(input), "\n")
+	idx := 1
+	var outputs []string
+	for caseNum := 0; caseNum < t; caseNum++ {
+		var n, q int
+		fmt.Sscanf(lines[idx], "%d %d", &n, &q)
+		idx++
+		p := make([]int, n)
+		vals := strings.Fields(lines[idx])
+		for i := 0; i < n; i++ {
+			fmt.Sscanf(vals[i], "%d", &p[i])
+		}
+		idx++
+		a := make([]int, n)
+		vals = strings.Fields(lines[idx])
+		for i := 0; i < n; i++ {
+			fmt.Sscanf(vals[i], "%d", &a[i])
+		}
+		idx++
+		Svals := strings.Fields(lines[idx])
+		S := make([]int, len(Svals))
+		for i := range Svals {
+			fmt.Sscanf(Svals[i], "%d", &S[i])
+		}
+		idx++
+		zeros := []int{}
+		used := map[int]bool{}
+		for i, v := range a {
+			if v == 0 {
+				zeros = append(zeros, i)
+			} else {
+				used[v] = true
+			}
+		}
+		for ; q > 0; q-- {
+			dLine := lines[idx]
+			idx++
+			var d int
+			fmt.Sscanf(dLine, "%d", &d)
+			nums := append([]int{}, S...)
+			nums = append(nums, d)
+			if len(nums) != len(zeros) {
+				outputs = append(outputs, "NO")
+				continue
+			}
+			usedPerm := make([]bool, len(nums))
+			arr := make([]int, len(a))
+			copy(arr, a)
+			found := false
+			var dfs func(int)
+			dfs = func(pos int) {
+				if found {
+					return
+				}
+				if pos == len(zeros) {
+					uniq := map[int]bool{}
+					for _, v := range arr {
+						if uniq[v] {
+							return
+						}
+						uniq[v] = true
+					}
+					if isSimilar(p, arr) {
+						found = true
+					}
+					return
+				}
+				for i, v := range nums {
+					if usedPerm[i] {
+						continue
+					}
+					arr[zeros[pos]] = v
+					usedPerm[i] = true
+					dfs(pos + 1)
+					usedPerm[i] = false
+				}
+			}
+			dfs(0)
+			if found {
+				outputs = append(outputs, "YES")
+			} else {
+				outputs = append(outputs, "NO")
+			}
+		}
+	}
+	return strings.Join(outputs, "\n"), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := brute(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "brute error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1718/verifierE.go
+++ b/1000-1999/1700-1799/1710-1719/1718/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1718E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(2) + 1
+	m := rng.Intn(2) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(10)))
+		}
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(10)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1700-1799/1710-1719/1718/verifierF.go
+++ b/1000-1999/1700-1799/1710-1719/1718/verifierF.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(6) + 2
+	C := rng.Intn(10) + 1
+	q := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, C, q))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(m)+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func brute(input string) (string, error) {
+	fields := strings.Fields(input)
+	idx := 0
+	n := atoi(fields[idx])
+	idx++
+	_ = atoi(fields[idx])
+	idx++
+	C := atoi(fields[idx])
+	idx++
+	q := atoi(fields[idx])
+	idx++
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = atoi(fields[idx])
+		idx++
+	}
+	outputs := make([]string, q)
+	for i := 0; i < q; i++ {
+		l := atoi(fields[idx])
+		idx++
+		r := atoi(fields[idx])
+		idx++
+		prod := 1
+		for j := l - 1; j < r; j++ {
+			prod *= a[j]
+		}
+		count := 0
+		for x := 1; x <= C; x++ {
+			if gcd(x, prod) == 1 {
+				count++
+			}
+		}
+		outputs[i] = fmt.Sprintf("%d", count)
+	}
+	return strings.Join(outputs, "\n"), nil
+}
+
+func atoi(s string) int {
+	v := 0
+	for i := 0; i < len(s); i++ {
+		v = v*10 + int(s[i]-'0')
+	}
+	return v
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := brute(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "brute error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` for Problem A using `1718A2.go` as oracle
- add `verifierB.go` for Problem B
- add `verifierC.go` for Problem C
- add `verifierD.go` with brute-force checker
- add `verifierE.go` for Problem E
- add `verifierF.go` with brute-force checker

Each verifier runs 100 randomized tests against a reference solution or brute-force implementation.

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6887506231648324959edccf9324510a