### PR TITLE
Add Go verifiers for contest 1722

### DIFF
--- a/1000-1999/1700-1799/1720-1729/1722/verifierA.go
+++ b/1000-1999/1700-1799/1720-1729/1722/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n int
+	s string
+}
+
+func solveA(n int, s string) string {
+	if n != 5 {
+		return "NO"
+	}
+	letters := []rune(s)
+	sort.Slice(letters, func(i, j int) bool { return letters[i] < letters[j] })
+	if string(letters) == "Timru" {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func generateTests() []testCaseA {
+	rand.Seed(42)
+	tests := make([]testCaseA, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 1
+		s := make([]rune, n)
+		if n == 5 && rand.Intn(2) == 0 {
+			t := []rune("Timur")
+			rand.Shuffle(5, func(i, j int) { t[i], t[j] = t[j], t[i] })
+			copy(s, t)
+		} else {
+			for j := 0; j < n; j++ {
+				s[j] = letters[rand.Intn(len(letters))]
+			}
+		}
+		tests[i] = testCaseA{n: n, s: string(s)}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%s\n", tc.n, tc.s)
+		expected := solveA(tc.n, tc.s)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(output) != expected {
+			fmt.Printf("test %d failed:\ninput:%sexpected %s got %s\n", i+1, input, expected, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1700-1799/1720-1729/1722/verifierB.go
+++ b/1000-1999/1700-1799/1720-1729/1722/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n  int
+	s1 string
+	s2 string
+}
+
+func solveB(n int, s1, s2 string) string {
+	for i := 0; i < n; i++ {
+		a := s1[i] == 'R'
+		b := s2[i] == 'R'
+		if a != b {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseB {
+	rand.Seed(43)
+	tests := make([]testCaseB, 100)
+	letters := []byte{'R', 'G', 'B'}
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		b1 := make([]byte, n)
+		b2 := make([]byte, n)
+		for j := 0; j < n; j++ {
+			b1[j] = letters[rand.Intn(3)]
+			b2[j] = letters[rand.Intn(3)]
+		}
+		tests[i] = testCaseB{n, string(b1), string(b2)}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%s\n%s\n", tc.n, tc.s1, tc.s2)
+		expected := solveB(tc.n, tc.s1, tc.s2)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(output) != expected {
+			fmt.Printf("test %d failed:\ninput:%sexpected %s got %s\n", i+1, input, expected, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1700-1799/1720-1729/1722/verifierC.go
+++ b/1000-1999/1700-1799/1720-1729/1722/verifierC.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	n int
+	a []string
+	b []string
+	c []string
+}
+
+func solveC(n int, a, b, c []string) (int, int, int) {
+	counts := make(map[string]int)
+	for i := 0; i < n; i++ {
+		counts[a[i]]++
+		counts[b[i]]++
+		counts[c[i]]++
+	}
+	scores := [3]int{}
+	for i := 0; i < n; i++ {
+		if counts[a[i]] == 1 {
+			scores[0] += 3
+		} else if counts[a[i]] == 2 {
+			scores[0]++
+		}
+		if counts[b[i]] == 1 {
+			scores[1] += 3
+		} else if counts[b[i]] == 2 {
+			scores[1]++
+		}
+		if counts[c[i]] == 1 {
+			scores[2] += 3
+		} else if counts[c[i]] == 2 {
+			scores[2]++
+		}
+	}
+	return scores[0], scores[1], scores[2]
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+var words = []string{"one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"}
+
+func generateTests() []testCaseC {
+	rand.Seed(44)
+	tests := make([]testCaseC, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 1
+		a := make([]string, n)
+		b := make([]string, n)
+		c := make([]string, n)
+		for j := 0; j < n; j++ {
+			a[j] = words[rand.Intn(len(words))]
+			b[j] = words[rand.Intn(len(words))]
+			c[j] = words[rand.Intn(len(words))]
+		}
+		tests[i] = testCaseC{n, a, b, c}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(tc.a[j])
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(tc.b[j])
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(tc.c[j])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		x, y, z := solveC(tc.n, tc.a, tc.b, tc.c)
+		expected := fmt.Sprintf("%d %d %d", x, y, z)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(output) != expected {
+			fmt.Printf("test %d failed:\ninput:%sexpected %s got %s\n", i+1, input, expected, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1700-1799/1720-1729/1722/verifierD.go
+++ b/1000-1999/1700-1799/1720-1729/1722/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseD struct {
+	n int
+	s string
+}
+
+func solveD(n int, s string) []int64 {
+	improvements := make([]int64, n)
+	var total int64
+	for i := 0; i < n; i++ {
+		if s[i] == 'L' {
+			total += int64(i)
+			improvements[i] = int64(n - 1 - 2*i)
+		} else {
+			total += int64(n - 1 - i)
+			improvements[i] = int64(2*i - n + 1)
+		}
+	}
+	sort.Slice(improvements, func(i, j int) bool { return improvements[i] > improvements[j] })
+	prefix := int64(0)
+	ans := make([]int64, n)
+	for i := 0; i < n; i++ {
+		if improvements[i] > 0 {
+			prefix += improvements[i]
+		}
+		ans[i] = total + prefix
+	}
+	return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseD {
+	rand.Seed(45)
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				b[j] = 'L'
+			} else {
+				b[j] = 'R'
+			}
+		}
+		tests[i] = testCaseD{n, string(b)}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%s\n", tc.n, tc.s)
+		expectedSlice := solveD(tc.n, tc.s)
+		expected := make([]string, len(expectedSlice))
+		for j, v := range expectedSlice {
+			expected[j] = fmt.Sprint(v)
+		}
+		expectedStr := strings.Join(expected, " ")
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(output) != expectedStr {
+			fmt.Printf("test %d failed:\ninput:%sexpected %s got %s\n", i+1, input, expectedStr, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1700-1799/1720-1729/1722/verifierE.go
+++ b/1000-1999/1700-1799/1720-1729/1722/verifierE.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const maxHW = 1000
+
+type rectangle struct{ h, w int }
+type query struct{ hs, ws, hb, wb int }
+
+type testCaseE struct {
+	n       int
+	rects   []rectangle
+	q       int
+	queries []query
+}
+
+func solveE(n int, rects []rectangle, q int, queries []query) []int64 {
+	rect := make([][]int64, maxHW+1)
+	for i := range rect {
+		rect[i] = make([]int64, maxHW+1)
+	}
+	for _, r := range rects {
+		if r.h <= maxHW && r.w <= maxHW {
+			rect[r.h][r.w] += int64(r.h * r.w)
+		}
+	}
+	prefix := make([][]int64, maxHW+1)
+	for i := range prefix {
+		prefix[i] = make([]int64, maxHW+1)
+	}
+	for i := 1; i <= maxHW; i++ {
+		var rowSum int64
+		for j := 1; j <= maxHW; j++ {
+			rowSum += rect[i][j]
+			prefix[i][j] = prefix[i-1][j] + rowSum
+		}
+	}
+	ans := make([]int64, q)
+	for idx, qu := range queries {
+		if qu.hs+1 > qu.hb-1 || qu.ws+1 > qu.wb-1 {
+			ans[idx] = 0
+			continue
+		}
+		h2, w2 := qu.hb-1, qu.wb-1
+		ans[idx] = prefix[h2][w2] - prefix[qu.hs][w2] - prefix[h2][qu.ws] + prefix[qu.hs][qu.ws]
+	}
+	return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseE {
+	rand.Seed(46)
+	tests := make([]testCaseE, 100)
+	for i := range tests {
+		n := rand.Intn(5) + 1
+		rects := make([]rectangle, n)
+		for j := 0; j < n; j++ {
+			rects[j] = rectangle{rand.Intn(5) + 1, rand.Intn(5) + 1}
+		}
+		q := rand.Intn(5) + 1
+		queries := make([]query, q)
+		for j := 0; j < q; j++ {
+			hs := rand.Intn(5)
+			ws := rand.Intn(5)
+			hb := hs + rand.Intn(5-hs) + 1
+			wb := ws + rand.Intn(5-ws) + 1
+			queries[j] = query{hs, ws, hb, wb}
+		}
+		tests[i] = testCaseE{n, rects, q, queries}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.q))
+		for _, r := range tc.rects {
+			sb.WriteString(fmt.Sprintf("%d %d\n", r.h, r.w))
+		}
+		for _, qu := range tc.queries {
+			sb.WriteString(fmt.Sprintf("%d %d %d %d\n", qu.hs, qu.ws, qu.hb, qu.wb))
+		}
+		input := sb.String()
+		expectedAns := solveE(tc.n, tc.rects, tc.q, tc.queries)
+		expected := make([]string, len(expectedAns))
+		for j, v := range expectedAns {
+			expected[j] = fmt.Sprint(v)
+		}
+		expectedStr := strings.Join(expected, "\n")
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(output) != expectedStr {
+			fmt.Printf("test %d failed:\ninput:%sexpected %s got %s\n", i+1, input, expectedStr, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1700-1799/1720-1729/1722/verifierF.go
+++ b/1000-1999/1700-1799/1720-1729/1722/verifierF.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ r, c int }
+
+type testCaseF struct {
+	n, m int
+	grid []string
+}
+
+func check(grid [][]byte, n, m int) bool {
+	vis := make([][]int, n)
+	for i := range vis {
+		vis[i] = make([]int, m)
+	}
+	dirs4 := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	dirs8 := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}, {1, 1}, {1, -1}, {-1, 1}, {-1, -1}}
+	id := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '*' && vis[i][j] == 0 {
+				id++
+				q := []pair{{i, j}}
+				vis[i][j] = id
+				for k := 0; k < len(q); k++ {
+					p := q[k]
+					for _, d := range dirs4 {
+						nr, nc := p.r+d[0], p.c+d[1]
+						if nr >= 0 && nr < n && nc >= 0 && nc < m && grid[nr][nc] == '*' && vis[nr][nc] == 0 {
+							vis[nr][nc] = id
+							q = append(q, pair{nr, nc})
+						}
+					}
+				}
+				if len(q) != 3 {
+					return false
+				}
+				minr, maxr := q[0].r, q[0].r
+				minc, maxc := q[0].c, q[0].c
+				for _, p := range q[1:] {
+					if p.r < minr {
+						minr = p.r
+					}
+					if p.r > maxr {
+						maxr = p.r
+					}
+					if p.c < minc {
+						minc = p.c
+					}
+					if p.c > maxc {
+						maxc = p.c
+					}
+				}
+				if maxr-minr != 1 || maxc-minc != 1 {
+					return false
+				}
+				count := 0
+				for r := minr; r <= maxr; r++ {
+					for c := minc; c <= maxc; c++ {
+						if grid[r][c] == '*' {
+							if vis[r][c] != id {
+								return false
+							}
+							count++
+						}
+					}
+				}
+				if count != 3 {
+					return false
+				}
+				for _, p := range q {
+					for _, d := range dirs8 {
+						nr, nc := p.r+d[0], p.c+d[1]
+						if nr >= 0 && nr < n && nc >= 0 && nc < m && grid[nr][nc] == '*' && vis[nr][nc] != id {
+							return false
+						}
+					}
+				}
+			}
+		}
+	}
+	return true
+}
+
+func solveF(n, m int, lines []string) string {
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		grid[i] = []byte(lines[i])
+	}
+	if check(grid, n, m) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseF {
+	rand.Seed(47)
+	tests := make([]testCaseF, 100)
+	for i := range tests {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(5) + 1
+		grid := make([]string, n)
+		for r := 0; r < n; r++ {
+			b := make([]byte, m)
+			for c := 0; c < m; c++ {
+				if rand.Intn(4) == 0 {
+					b[c] = '*'
+				} else {
+					b[c] = '.'
+				}
+			}
+			grid[r] = string(b)
+		}
+		tests[i] = testCaseF{n, m, grid}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+		for _, line := range tc.grid {
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expected := solveF(tc.n, tc.m, tc.grid)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(output) != expected {
+			fmt.Printf("test %d failed:\ninput:%sexpected %s got %s\n", i+1, input, expected, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1700-1799/1720-1729/1722/verifierG.go
+++ b/1000-1999/1700-1799/1720-1729/1722/verifierG.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseG struct {
+	n int
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseG {
+	rand.Seed(48)
+	tests := make([]testCaseG, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 3
+		tests[i] = testCaseG{n}
+	}
+	return tests
+}
+
+func validOutput(n int, nums []int64) bool {
+	if len(nums) != n {
+		return false
+	}
+	seen := make(map[int64]bool)
+	xorOdd, xorEven := int64(0), int64(0)
+	for i, v := range nums {
+		if v < 0 || v >= 1<<31 {
+			return false
+		}
+		if seen[v] {
+			return false
+		}
+		seen[v] = true
+		if (i+1)%2 == 1 {
+			xorOdd ^= v
+		} else {
+			xorEven ^= v
+		}
+	}
+	return xorOdd == xorEven
+}
+
+func parseOutput(out string) ([]int64, error) {
+	fields := strings.Fields(out)
+	nums := make([]int64, len(fields))
+	for i, f := range fields {
+		v, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		nums[i] = v
+	}
+	return nums, nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n", tc.n)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		nums, err := parseOutput(output)
+		if err != nil {
+			fmt.Printf("test %d: cannot parse output: %v\n", i+1, err)
+			return
+		}
+		if !validOutput(tc.n, nums) {
+			fmt.Printf("test %d failed:\ninput:%soutput:%s\n", i+1, input, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add standalone verifiers `verifierA.go` through `verifierG.go`
- each verifier generates 100 random tests and checks candidate binaries

## Testing
- `gofmt -w 1000-1999/1700-1799/1720-1729/1722/verifier*.go`
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_6887517a344c83248132d28f7c9272f7