### PR TITLE
Add verifiers for contest 1728

### DIFF
--- a/1000-1999/1700-1799/1720-1729/1728/verifierA.go
+++ b/1000-1999/1700-1799/1720-1729/1728/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(cnt []int) int {
+	pos := 1
+	maxVal := cnt[0]
+	for i := 1; i < len(cnt); i++ {
+		if cnt[i] > maxVal || (cnt[i] == maxVal && i+1 > pos) {
+			maxVal = cnt[i]
+			pos = i + 1
+		}
+	}
+	return pos
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(1))
+	tests := []testCase{}
+	// some fixed cases
+	tests = append(tests, testCase{input: "1\n1\n5\n", expected: "1"})
+	tests = append(tests, testCase{input: "1\n3\n1 1 1\n", expected: "3"})
+	tests = append(tests, testCase{input: "1\n3\n1 2 3\n", expected: "3"})
+	tests = append(tests, testCase{input: "1\n4\n1 5 3 5\n", expected: "4"})
+	for len(tests) < 100 {
+		n := rng.Intn(20) + 1
+		cnt := make([]int, n)
+		sum := 0
+		for i := 0; i < n; i++ {
+			cnt[i] = rng.Intn(100) + 1
+			sum += cnt[i]
+		}
+		if sum%2 == 0 {
+			cnt[0]++
+			sum++
+		}
+		pos := solveCase(cnt)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+		for i, v := range cnt {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteString("\n")
+		tests = append(tests, testCase{input: sb.String(), expected: fmt.Sprint(pos)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	_ = rng // quiet lint
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1728/verifierB.go
+++ b/1000-1999/1700-1799/1720-1729/1728/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func buildPermutation(n int) []int {
+	p := []int{}
+	if n%2 == 1 {
+		for i := n - 2; i >= 5; i -= 2 {
+			p = append(p, i, i-1)
+		}
+		p = append(p, 1, 2, 3)
+	} else {
+		for i := n - 2; i >= 2; i -= 2 {
+			p = append(p, i, i-1)
+		}
+	}
+	p = append(p, n-1, n)
+	return p
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(2))
+	tests := []testCase{}
+	tests = append(tests, testCase{input: "1\n4\n", expected: "2 1 3 4"})
+	tests = append(tests, testCase{input: "1\n5\n", expected: "3 2 1 4 5"})
+	for len(tests) < 100 {
+		n := rng.Intn(97) + 4
+		perm := buildPermutation(n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+		expSb := strings.Builder{}
+		for i, v := range perm {
+			if i > 0 {
+				expSb.WriteByte(' ')
+			}
+			expSb.WriteString(fmt.Sprintf("%d", v))
+		}
+		tests = append(tests, testCase{input: sb.String(), expected: expSb.String()})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	_ = rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1728/verifierC.go
+++ b/1000-1999/1700-1799/1720-1729/1728/verifierC.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func digits(x int) int {
+	c := 0
+	for x > 0 {
+		c++
+		x /= 10
+	}
+	return c
+}
+
+func solveCase(a, b []int) int {
+	countA := map[int]int{}
+	countB := map[int]int{}
+	for _, v := range a {
+		countA[v]++
+	}
+	for _, v := range b {
+		countB[v]++
+	}
+	for val, ca := range countA {
+		if cb, ok := countB[val]; ok {
+			if ca < cb {
+				countB[val] -= ca
+				delete(countA, val)
+			} else if cb < ca {
+				countA[val] -= cb
+				delete(countB, val)
+			} else {
+				delete(countA, val)
+				delete(countB, val)
+			}
+		}
+	}
+	ops := 0
+	newA := map[int]int{}
+	for val, cnt := range countA {
+		if val >= 10 {
+			d := digits(val)
+			newA[d] += cnt
+			ops += cnt
+		} else {
+			newA[val] += cnt
+		}
+	}
+	countA = newA
+	newB := map[int]int{}
+	for val, cnt := range countB {
+		if val >= 10 {
+			d := digits(val)
+			newB[d] += cnt
+			ops += cnt
+		} else {
+			newB[val] += cnt
+		}
+	}
+	countB = newB
+	for val, ca := range countA {
+		if cb, ok := countB[val]; ok {
+			if ca < cb {
+				countB[val] -= ca
+				delete(countA, val)
+			} else if cb < ca {
+				countA[val] -= cb
+				delete(countB, val)
+			} else {
+				delete(countA, val)
+				delete(countB, val)
+			}
+		}
+	}
+	for val, cnt := range countA {
+		if val > 1 {
+			ops += cnt
+			countA[val] -= cnt
+			countA[1] += cnt
+			delete(countA, val)
+		}
+	}
+	for val, cnt := range countB {
+		if val > 1 {
+			ops += cnt
+			countB[val] -= cnt
+			countB[1] += cnt
+			delete(countB, val)
+		}
+	}
+	return ops
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(3))
+	tests := []testCase{}
+	tests = append(tests, testCase{input: "1\n1\n1\n1\n", expected: "0"})
+	tests = append(tests, testCase{input: "1\n3\n1 2 3\n3 2 1\n", expected: "2"})
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		a := make([]int, n)
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(1000) + 1
+			b[i] = rng.Intn(1000) + 1
+		}
+		ops := solveCase(append([]int{}, a...), append([]int{}, b...))
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d\n", n))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range b {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, testCase{input: sb.String(), expected: fmt.Sprint(ops)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	_ = rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1728/verifierD.go
+++ b/1000-1999/1700-1799/1720-1729/1728/verifierD.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func cmp(a, b byte) int8 {
+	if a < b {
+		return 1
+	} else if a > b {
+		return -1
+	}
+	return 0
+}
+
+func solveGame(s string) string {
+	n := len(s)
+	dp := make([][]int8, n)
+	for i := range dp {
+		dp[i] = make([]int8, n)
+	}
+	for i := 0; i+1 < n; i++ {
+		if s[i] == s[i+1] {
+			dp[i][i+1] = 0
+		} else {
+			dp[i][i+1] = 1
+		}
+	}
+	for length := 4; length <= n; length += 2 {
+		for l := 0; l+length-1 < n; l++ {
+			r := l + length - 1
+			a1 := dp[l+2][r]
+			if a1 == 0 {
+				a1 = cmp(s[l], s[l+1])
+			}
+			a2 := dp[l+1][r-1]
+			if a2 == 0 {
+				a2 = cmp(s[l], s[r])
+			}
+			if a1 > a2 {
+				a1 = a2
+			}
+			b1 := dp[l][r-2]
+			if b1 == 0 {
+				b1 = cmp(s[r], s[r-1])
+			}
+			b2 := dp[l+1][r-1]
+			if b2 == 0 {
+				b2 = cmp(s[r], s[l])
+			}
+			if b1 > b2 {
+				b1 = b2
+			}
+			if a1 < b1 {
+				dp[l][r] = b1
+			} else {
+				dp[l][r] = a1
+			}
+		}
+	}
+	res := dp[0][n-1]
+	if res > 0 {
+		return "Alice"
+	} else if res < 0 {
+		return "Bob"
+	}
+	return "Draw"
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(4))
+	tests := []testCase{}
+	tests = append(tests, testCase{input: "1\naa\n", expected: "Draw"})
+	tests = append(tests, testCase{input: "1\naba\n", expected: "Alice"})
+	for len(tests) < 100 {
+		length := (rng.Intn(3) + 1) * 2
+		b := make([]byte, length)
+		for i := 0; i < length; i++ {
+			b[i] = byte('a' + rng.Intn(3))
+		}
+		s := string(b)
+		expect := solveGame(s)
+		tests = append(tests, testCase{input: fmt.Sprintf("1\n%s\n", s), expected: expect})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	_ = rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1728/verifierE.go
+++ b/1000-1999/1700-1799/1720-1729/1728/verifierE.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func extgcd(a, b int64) (g, x, y int64) {
+	if b == 0 {
+		return a, 1, 0
+	}
+	g, x1, y1 := extgcd(b, a%b)
+	return g, y1, x1 - (a/b)*y1
+}
+
+func modInverse(a, mod int64) int64 {
+	g, x, _ := extgcd(a, mod)
+	if g != 1 {
+		return 0
+	}
+	x %= mod
+	if x < 0 {
+		x += mod
+	}
+	return x
+}
+
+func solveCase(n int, ab [][2]int64, queries [][2]int64) []int64 {
+	diffs := make([]int64, n)
+	var bsum int64
+	for i := 0; i < n; i++ {
+		diffs[i] = ab[i][0] - ab[i][1]
+		bsum += ab[i][1]
+	}
+	sort.Slice(diffs, func(i, j int) bool { return diffs[i] > diffs[j] })
+	prefix := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		prefix[i] = prefix[i-1] + diffs[i-1]
+	}
+	values := make([]int64, n+1)
+	for i := 0; i <= n; i++ {
+		values[i] = bsum + prefix[i]
+	}
+	S := int64(1)
+	for S*S <= int64(n) {
+		S++
+	}
+	pre := make([][]int64, S+1)
+	for s := int64(1); s <= S; s++ {
+		pre[s] = make([]int64, s)
+		for i := 0; i < int(s); i++ {
+			pre[s][i] = -1 << 63
+		}
+		for r := int64(0); r < s; r++ {
+			maxv := int64(-1 << 63)
+			for x := r; x <= int64(n); x += s {
+				if v := values[x]; v > maxv {
+					maxv = v
+				}
+			}
+			pre[s][r] = maxv
+		}
+	}
+	res := make([]int64, len(queries))
+	for idx, q := range queries {
+		xj, yj := q[0], q[1]
+		g := gcd(xj, yj)
+		if int64(n)%g != 0 {
+			res[idx] = -1
+			continue
+		}
+		lcm := xj / g * yj
+		x1 := xj / g
+		y1 := yj / g
+		n1 := int64(n) / g
+		inv := modInverse(x1%y1, y1)
+		t0 := (n1 % y1) * inv % y1
+		r0 := xj * t0
+		if r0 > int64(n) {
+			res[idx] = -1
+			continue
+		}
+		if lcm <= S {
+			val := pre[lcm][r0%lcm]
+			if val == -1<<63 {
+				res[idx] = -1
+			} else {
+				res[idx] = val
+			}
+		} else {
+			maxv := int64(-1 << 63)
+			for R := r0; R <= int64(n); R += lcm {
+				if v := values[R]; v > maxv {
+					maxv = v
+				}
+			}
+			if maxv == -1<<63 {
+				res[idx] = -1
+			} else {
+				res[idx] = maxv
+			}
+		}
+	}
+	return res
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(5))
+	tests := []testCase{}
+	// small fixed example
+	tests = append(tests, testCase{
+		input:    "2\n5 4\n3 6\n2\n1 1\n2 2\n",
+		expected: "11\n11"})
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		ab := make([][2]int64, n)
+		for i := 0; i < n; i++ {
+			ab[i][0] = int64(rng.Intn(10) + 1)
+			ab[i][1] = int64(rng.Intn(10) + 1)
+		}
+		m := rng.Intn(3) + 1
+		qs := make([][2]int64, m)
+		for j := 0; j < m; j++ {
+			qs[j][0] = int64(rng.Intn(n) + 1)
+			qs[j][1] = int64(rng.Intn(n) + 1)
+		}
+		res := solveCase(n, ab, qs)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", ab[i][0], ab[i][1]))
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for i, q := range qs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", q[0], q[1]))
+			res[i] = res[i]
+		}
+		expSb := strings.Builder{}
+		for i, v := range res {
+			if i > 0 {
+				expSb.WriteByte('\n')
+			}
+			expSb.WriteString(fmt.Sprint(v))
+		}
+		tests = append(tests, testCase{input: sb.String(), expected: expSb.String()})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	_ = rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1728/verifierF.go
+++ b/1000-1999/1700-1799/1720-1729/1728/verifierF.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(arr []int) int {
+	ones := []int{}
+	others := []int{}
+	for _, v := range arr {
+		if v == 1 {
+			ones = append(ones, v)
+		} else {
+			others = append(others, v)
+		}
+	}
+	sort.Ints(others)
+	cnt := map[int]int{}
+	for _, v := range others {
+		cnt[v]++
+	}
+	uniq := []int{}
+	for v := range cnt {
+		uniq = append(uniq, v)
+	}
+	sort.Ints(uniq)
+	seq := make([]int, 0, len(arr))
+	seq = append(seq, ones...)
+	for _, v := range uniq {
+		seq = append(seq, v)
+	}
+	extras := []int{}
+	for _, v := range uniq {
+		for i := 1; i < cnt[v]; i++ {
+			extras = append(extras, v)
+		}
+	}
+	sort.Ints(extras)
+	seq = append(seq, extras...)
+
+	prev := 0
+	total := 0
+	for _, v := range seq {
+		next := prev + v - (prev % v)
+		if next <= prev {
+			next += v
+		}
+		total += next
+		prev = next
+	}
+	return total
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(6))
+	tests := []testCase{}
+	tests = append(tests, testCase{input: "1\n", expected: "1"})
+	tests = append(tests, testCase{input: "3\n1 2 3\n", expected: fmt.Sprint(solveCase([]int{1, 2, 3}))})
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(6) + 1
+		}
+		res := solveCase(arr)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, testCase{input: sb.String(), expected: fmt.Sprint(res)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	_ = rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1728/verifierG.go
+++ b/1000-1999/1700-1799/1720-1729/1728/verifierG.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+const MOD int = 998244353
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func countWays(d int, lanterns []int, points []int) int {
+	L := len(lanterns)
+	powers := make([]int, L)
+	ways := 0
+	var dfs func(int)
+	dfs = func(idx int) {
+		if idx == L {
+			for _, p := range points {
+				ok := false
+				for i := 0; i < L; i++ {
+					if abs(lanterns[i]-p) <= powers[i] {
+						ok = true
+						break
+					}
+				}
+				if !ok {
+					return
+				}
+			}
+			ways = (ways + 1) % MOD
+			return
+		}
+		for pw := 0; pw <= d; pw++ {
+			powers[idx] = pw
+			dfs(idx + 1)
+		}
+	}
+	dfs(0)
+	return ways
+}
+
+func solveCase(d int, lanterns []int, points []int, queries []int) []int {
+	res := make([]int, len(queries))
+	for i, f := range queries {
+		ls := append(lanterns, f)
+		res[i] = countWays(d, ls, points)
+	}
+	return res
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(7))
+	tests := []testCase{}
+	for len(tests) < 100 {
+		d := rng.Intn(3) + 4 // 4..6
+		n := rng.Intn(2) + 1 // 1..2
+		m := rng.Intn(2) + 1 // 1..2
+		used := map[int]bool{}
+		lanterns := make([]int, n)
+		for i := 0; i < n; i++ {
+			for {
+				x := rng.Intn(d-1) + 1
+				if !used[x] {
+					used[x] = true
+					lanterns[i] = x
+					break
+				}
+			}
+		}
+		points := make([]int, m)
+		for i := 0; i < m; i++ {
+			for {
+				x := rng.Intn(d-1) + 1
+				if !used[x] {
+					used[x] = true
+					points[i] = x
+					break
+				}
+			}
+		}
+		q := rng.Intn(2) + 1
+		queries := make([]int, q)
+		for i := 0; i < q; i++ {
+			for {
+				x := rng.Intn(d-1) + 1
+				if !used[x] {
+					used[x] = true
+					queries[i] = x
+					break
+				}
+			}
+		}
+		res := solveCase(d, lanterns, points, queries)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", d, n, m))
+		for i, v := range lanterns {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range points {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d\n", q))
+		for i, v := range queries {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		expSb := strings.Builder{}
+		for i, v := range res {
+			if i > 0 {
+				expSb.WriteByte('\n')
+			}
+			expSb.WriteString(fmt.Sprint(v))
+		}
+		tests = append(tests, testCase{input: sb.String(), expected: expSb.String()})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	_ = rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for problems A through G of contest 1728
- each verifier generates 100 random test cases
- verifiers execute a candidate binary and compare against known good results

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6887531e7f248324846ee7f30b8c402f