### PR TITLE
Add verifiers for contest 1725

### DIFF
--- a/1000-1999/1700-1799/1720-1729/1725/verifierA.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refA-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	preset := []struct{ n, m int64 }{{1, 1}, {2, 1}, {1, 2}, {1000000000, 1}, {1, 1000000000}, {1000, 1000}}
+	for _, p := range preset {
+		cases = append(cases, Case{fmt.Sprintf("%d %d\n", p.n, p.m)})
+	}
+	for len(cases) < 100 {
+		n := rng.Int63n(1_000_000_000) + 1
+		m := rng.Int63n(1_000_000_000) + 1
+		cases = append(cases, Case{fmt.Sprintf("%d %d\n", n, m)})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierB.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierB.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refB-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	preset := []struct {
+		n   int
+		d   int64
+		arr []int64
+	}{
+		{1, 1, []int64{1}},
+		{2, 1, []int64{1, 2}},
+		{3, 10, []int64{5, 5, 5}},
+	}
+	for _, p := range preset {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.n, p.d))
+		for i, v := range p.arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		n := rng.Intn(20) + 1
+		d := rng.Int63n(1_000_000_000) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, d))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			v := rng.Int63n(1_000_000_000) + 1
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierC.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierC.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refC-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	preset := []struct {
+		N, M int
+		D    []int64
+	}{{1, 2, []int64{1}}, {2, 2, []int64{1, 1}}, {3, 3, []int64{1, 2, 3}}}
+	for _, p := range preset {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.N, p.M))
+		for i, v := range p.D {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		N := rng.Intn(6) + 1
+		M := rng.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", N, M))
+		for i := 0; i < N; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Int63n(10)+1))
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierD.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierD.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refD-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	preset := []struct{ n, q int }{{1, 1}, {2, 2}}
+	for _, p := range preset {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.n, p.q))
+		for i := 0; i < p.q; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(p.n)+1))
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		n := rng.Intn(5) + 1
+		q := rng.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i := 0; i < q; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(n)+1))
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierE.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refE-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	preset := []int{1, 2, 3}
+	for _, n := range preset {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 1; i <= n; i++ {
+			sb.WriteString(fmt.Sprintf("%d ", rng.Intn(10)+1))
+		}
+		sb.WriteByte('\n')
+		for i := 1; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", i, i+1))
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(20)+1))
+		}
+		sb.WriteByte('\n')
+		for i := 2; i <= n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", i-1, i))
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierF.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierF.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refF-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	presetN := []int{1, 2, 3}
+	for _, n := range presetN {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", 1, 1))
+		}
+		sb.WriteString("1\n1\n")
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			L := rng.Int63n(10) + 1
+			R := L + rng.Int63n(10)
+			sb.WriteString(fmt.Sprintf("%d %d\n", L, R))
+		}
+		q := rng.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", q))
+		for i := 0; i < q; i++ {
+			sb.WriteString(fmt.Sprintf("%d\n", rng.Int63n(64)))
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierG.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierG.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refG-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	preset := []int64{1, 2, 3, 10}
+	for _, v := range preset {
+		cases = append(cases, Case{fmt.Sprintf("%d\n", v)})
+	}
+	for len(cases) < 100 {
+		n := rng.Int63n(100) + 1
+		cases = append(cases, Case{fmt.Sprintf("%d\n", n)})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierH.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierH.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refH-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	preset := []struct {
+		n    int
+		vals []int
+	}{{1, []int{0}}, {2, []int{1, 2}}}
+	for _, p := range preset {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", p.n))
+		for i, v := range p.vals {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		n := rng.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(10)))
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierI.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierI.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refI-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725I.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	for n := 1; n <= 3; n++ {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 1; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", i, i+1))
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 2; i <= n; i++ {
+			u := rng.Intn(i-1) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", u, i))
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierJ.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierJ.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refJ-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725J.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	for n := 2; n <= 3; n++ {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 2; i <= n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", i-1, i, 1))
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		n := rng.Intn(5) + 2
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 2; i <= n; i++ {
+			u := rng.Intn(i-1) + 1
+			w := rng.Int63n(10) + 1
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", u, i, w))
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierK.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierK.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refK-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725K.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	for _, n := range []int{1, 2} {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d ", rng.Intn(5)+1))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString("1\n2 1\n")
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		N := rng.Intn(4) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", N))
+		for i := 0; i < N; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(10)+1))
+		}
+		sb.WriteByte('\n')
+		Q := rng.Intn(3) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", Q))
+		for i := 0; i < Q; i++ {
+			typ := rng.Intn(3) + 1
+			if typ == 1 {
+				k := rng.Intn(N) + 1
+				w := rng.Intn(10) + 1
+				sb.WriteString(fmt.Sprintf("1 %d %d\n", k, w))
+			} else if typ == 2 {
+				k := rng.Intn(N) + 1
+				sb.WriteString(fmt.Sprintf("2 %d\n", k))
+			} else {
+				l := rng.Intn(N) + 1
+				r := rng.Intn(N-l+1) + l
+				sb.WriteString(fmt.Sprintf("3 %d %d\n", l, r))
+			}
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierK.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierL.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierL.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refL-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725L.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	for _, n := range []int{1, 2, 3} {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString("0")
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			v := rng.Intn(7) - 3
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierL.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1725/verifierM.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierM.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refM-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1725M.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1725))
+	cases := make([]Case, 0, 100)
+	for _, n := range []int{2, 3} {
+		var sb strings.Builder
+		m := n - 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 2; i <= n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", i-1, i, 1))
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	for len(cases) < 100 {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(n*(n-1)) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		edges := make(map[[2]int]bool)
+		for i := 0; i < m; i++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n-1) + 1
+			if v >= u {
+				v++
+			}
+			key := [2]int{u, v}
+			if edges[key] {
+				i--
+				continue
+			}
+			edges[key] = true
+			w := rng.Int63n(10) + 1
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", u, v, w))
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runProg(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runProg(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expect != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierM.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–M of contest 1725
- each verifier compiles the reference solution and runs 100 generated tests

## Testing
- `gofmt -w 1000-1999/1700-1799/1720-1729/1725/verifier*.go`


------
https://chatgpt.com/codex/tasks/task_e_6887524c45e48324b0d37114163f11ed