### PR TITLE
Add Go verifiers for Codeforces 1732

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1732/verifierA.go
+++ b/1000-1999/1700-1799/1730-1739/1732/verifierA.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solve(reader *bufio.Reader) string {
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		g := 0
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+			g = gcd(g, arr[i])
+		}
+		if g == 1 {
+			sb.WriteString("0\n")
+			continue
+		}
+		ans := 3
+		if gcd(g, n) == 1 {
+			ans = 1
+		} else if gcd(g, n-1) == 1 {
+			ans = 2
+		}
+		fmt.Fprintf(&sb, "%d\n", ans)
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for ; t > 0; t-- {
+		n := rng.Intn(20) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rng.Intn(1_000_000) + 1
+			fmt.Fprintf(&sb, "%d", val)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1732/verifierB.go
+++ b/1000-1999/1700-1799/1730-1739/1732/verifierB.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func minOps(s string) int {
+	n := len(s)
+	prefixOps := make([]int, n+1)
+	prefixPar := make([]int, n+1)
+	parity := 0
+	op := 0
+	for i := 1; i <= n; i++ {
+		bit := int(s[i-1]-'0') ^ parity
+		if bit == 1 {
+			op++
+			parity ^= 1
+		}
+		prefixOps[i] = op
+		prefixPar[i] = parity
+	}
+	suffix0 := make([]int, n+2)
+	suffix1 := make([]int, n+2)
+	op = 0
+	parity = 0
+	for i := n; i >= 1; i-- {
+		bit := int(s[i-1]-'0') ^ parity
+		if bit == 0 {
+			op++
+			parity ^= 1
+		}
+		suffix0[i] = op
+	}
+	op = 0
+	parity = 1
+	for i := n; i >= 1; i-- {
+		bit := int(s[i-1]-'0') ^ parity
+		if bit == 0 {
+			op++
+			parity ^= 1
+		}
+		suffix1[i] = op
+	}
+	best := n + 5
+	for k := 0; k <= n; k++ {
+		p := prefixPar[k]
+		ops := prefixOps[k]
+		if p == 0 {
+			ops += suffix0[k+1]
+		} else {
+			ops += suffix1[k+1]
+		}
+		if ops < best {
+			best = ops
+		}
+	}
+	return best
+}
+
+func solve(reader *bufio.Reader) string {
+	var T int
+	if _, err := fmt.Fscan(reader, &T); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for ; T > 0; T-- {
+		var n int
+		var s string
+		fmt.Fscan(reader, &n)
+		fmt.Fscan(reader, &s)
+		fmt.Fprintf(&sb, "%d\n", minOps(s))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	T := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for ; T > 0; T-- {
+		n := rng.Intn(30) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 0 {
+				b[i] = '0'
+			} else {
+				b[i] = '1'
+			}
+		}
+		sb.Write(b)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1732/verifierC1.go
+++ b/1000-1999/1700-1799/1730-1739/1732/verifierC1.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(reader *bufio.Reader) string {
+	var T int
+	if _, err := fmt.Fscan(reader, &T); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for ; T > 0; T-- {
+		var n, Q int
+		fmt.Fscan(reader, &n, &Q)
+		v := make([]int, n+2)
+		psum := make([]int64, n+2)
+		xsum := make([]int64, n+2)
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(reader, &v[i])
+			psum[i] = psum[i-1] + int64(v[i])
+			xsum[i] = xsum[i-1] ^ int64(v[i])
+		}
+		nxt := make([]int, n+2)
+		id := n + 1
+		for i := n; i >= 1; i-- {
+			nxt[i] = id
+			if v[i] != 0 {
+				id = i
+			}
+		}
+		var a, b int
+		fmt.Fscan(reader, &a, &b)
+		getval := func(i, j int) int64 {
+			return (psum[j] - psum[i-1]) - (xsum[j] ^ xsum[i-1])
+		}
+		mxval := getval(a, b)
+		s := a
+		if s <= n && v[s] == 0 {
+			s = nxt[s]
+		}
+		ansA, ansB := a, b
+		for i := 0; i < 31; i++ {
+			if s > b {
+				s = b
+				break
+			}
+			if getval(s, b) != mxval {
+				break
+			}
+			l, r := s-1, b
+			for l+1 < r {
+				m := (l + r) >> 1
+				if getval(s, m) == mxval {
+					r = m
+				} else {
+					l = m
+				}
+			}
+			if ansB-ansA > r-s {
+				ansA = s
+				ansB = r
+			}
+			if s <= n {
+				s = nxt[s]
+			}
+		}
+		fmt.Fprintf(&sb, "%d %d\n", ansA, ansB)
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	T := rng.Intn(2) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for ; T > 0; T-- {
+		n := rng.Intn(50) + 1
+		fmt.Fprintf(&sb, "%d 1\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(100))
+		}
+		sb.WriteByte('\n')
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1732/verifierC2.go
+++ b/1000-1999/1700-1799/1730-1739/1732/verifierC2.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(reader *bufio.Reader) string {
+	var T int
+	if _, err := fmt.Fscan(reader, &T); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for ; T > 0; T-- {
+		var n, Q int
+		fmt.Fscan(reader, &n, &Q)
+		v := make([]int, n+2)
+		psum := make([]int64, n+2)
+		xsum := make([]int64, n+2)
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(reader, &v[i])
+			psum[i] = psum[i-1] + int64(v[i])
+			xsum[i] = xsum[i-1] ^ int64(v[i])
+		}
+		nxt := make([]int, n+2)
+		id := n + 1
+		for i := n; i >= 1; i-- {
+			nxt[i] = id
+			if v[i] != 0 {
+				id = i
+			}
+		}
+		for q := 0; q < Q; q++ {
+			var a, b int
+			fmt.Fscan(reader, &a, &b)
+			getval := func(i, j int) int64 { return (psum[j] - psum[i-1]) - (xsum[j] ^ xsum[i-1]) }
+			mxval := getval(a, b)
+			s := a
+			if s <= n && v[s] == 0 {
+				s = nxt[s]
+			}
+			ansA, ansB := a, b
+			for i := 0; i < 31; i++ {
+				if s > b {
+					s = b
+					i = 31
+				}
+				if getval(s, b) != mxval {
+					break
+				}
+				l, r := s-1, b
+				for l+1 < r {
+					m := (l + r) >> 1
+					if getval(s, m) == mxval {
+						r = m
+					} else {
+						l = m
+					}
+				}
+				if ansB-ansA > r-s {
+					ansA = s
+					ansB = r
+				}
+				if s <= n {
+					s = nxt[s]
+				}
+			}
+			fmt.Fprintf(&sb, "%d %d\n", ansA, ansB)
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	T := rng.Intn(2) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for ; T > 0; T-- {
+		n := rng.Intn(30) + 1
+		q := rng.Intn(30) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, q)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(100))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < q; i++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			fmt.Fprintf(&sb, "%d %d\n", l, r)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1732/verifierD1.go
+++ b/1000-1999/1700-1799/1730-1739/1732/verifierD1.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(reader *bufio.Reader) string {
+	var q int
+	if _, err := fmt.Fscan(reader, &q); err != nil {
+		return ""
+	}
+	set := make(map[int64]struct{})
+	set[0] = struct{}{}
+	next := make(map[int64]int64)
+	var sb strings.Builder
+	for i := 0; i < q; i++ {
+		var op string
+		fmt.Fscan(reader, &op)
+		if op == "+" {
+			var x int64
+			fmt.Fscan(reader, &x)
+			set[x] = struct{}{}
+		} else if op == "?" {
+			var k int64
+			fmt.Fscan(reader, &k)
+			v := next[k]
+			for {
+				if _, found := set[v]; !found {
+					fmt.Fprintf(&sb, "%d\n", v)
+					next[k] = v
+					break
+				}
+				v += k
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	q := rng.Intn(50) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", q)
+	set := map[int64]bool{0: true}
+	ask := false
+	for i := 0; i < q; i++ {
+		typ := rng.Intn(2) // 0 add, 1 query
+		if i == q-1 && !ask {
+			typ = 1
+		}
+		if typ == 0 {
+			var x int64
+			for {
+				x = int64(rng.Intn(1000000) + 1)
+				if !set[x] {
+					break
+				}
+			}
+			set[x] = true
+			fmt.Fprintf(&sb, "+ %d\n", x)
+		} else {
+			k := int64(rng.Intn(10) + 1)
+			fmt.Fprintf(&sb, "? %d\n", k)
+			ask = true
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1732/verifierD2.go
+++ b/1000-1999/1700-1799/1730-1739/1732/verifierD2.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func mulMod(a, b, mod uint64) uint64 {
+	return new(big.Int).Mod(new(big.Int).Mul(new(big.Int).SetUint64(a), new(big.Int).SetUint64(b)), new(big.Int).SetUint64(mod)).Uint64()
+}
+
+func powMod(a, d, mod uint64) uint64 {
+	res := uint64(1)
+	a %= mod
+	for d > 0 {
+		if d&1 == 1 {
+			res = mulMod(res, a, mod)
+		}
+		a = mulMod(a, a, mod)
+		d >>= 1
+	}
+	return res
+}
+
+func gcd(a, b uint64) uint64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func isPrime(n uint64) bool {
+	if n < 2 {
+		return false
+	}
+	small := []uint64{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37}
+	for _, p := range small {
+		if n%p == 0 {
+			return n == p
+		}
+	}
+	d := n - 1
+	s := 0
+	for d&1 == 0 {
+		d >>= 1
+		s++
+	}
+	bases := []uint64{2, 325, 9375, 28178, 450775, 9780504, 1795265022}
+	for _, a := range bases {
+		if a%n == 0 {
+			continue
+		}
+		x := powMod(a, d, n)
+		if x == 1 || x == n-1 {
+			continue
+		}
+		composite := true
+		for r := 1; r < s; r++ {
+			x = mulMod(x, x, n)
+			if x == n-1 {
+				composite = false
+				break
+			}
+		}
+		if composite {
+			return false
+		}
+	}
+	return true
+}
+
+func pollardsRho(n uint64) uint64 {
+	if n%2 == 0 {
+		return 2
+	}
+	if n%3 == 0 {
+		return 3
+	}
+	for {
+		c := uint64(rand.Int63n(int64(n-1))) + 1
+		x := uint64(rand.Int63n(int64(n)))
+		y := x
+		d := uint64(1)
+		for d == 1 {
+			x = (mulMod(x, x, n) + c) % n
+			y = (mulMod(y, y, n) + c) % n
+			y = (mulMod(y, y, n) + c) % n
+			if x > y {
+				d = gcd(x-y, n)
+			} else {
+				d = gcd(y-x, n)
+			}
+			if d == n {
+				break
+			}
+		}
+		if d > 1 && d < n {
+			return d
+		}
+	}
+}
+
+func factor(n uint64, res *[]uint64) {
+	if n == 1 {
+		return
+	}
+	if isPrime(n) {
+		*res = append(*res, n)
+		return
+	}
+	d := pollardsRho(n)
+	factor(d, res)
+	factor(n/d, res)
+}
+
+func divisors(n uint64) []uint64 {
+	var pf []uint64
+	factor(n, &pf)
+	mp := make(map[uint64]int)
+	for _, p := range pf {
+		mp[p]++
+	}
+	divs := []uint64{1}
+	for p, e := range mp {
+		sz := len(divs)
+		mul := uint64(1)
+		for i := 0; i < e; i++ {
+			mul *= p
+			for j := 0; j < sz; j++ {
+				divs = append(divs, divs[j]*mul)
+			}
+		}
+	}
+	sort.Slice(divs, func(i, j int) bool { return divs[i] < divs[j] })
+	return divs
+}
+
+type kData struct {
+	present map[uint64]struct{}
+	mex     uint64
+}
+
+func solve(reader *bufio.Reader) string {
+	var q int
+	if _, err := fmt.Fscan(reader, &q); err != nil {
+		return ""
+	}
+	numbers := make(map[uint64]struct{})
+	numbers[0] = struct{}{}
+	divisorCache := make(map[uint64][]uint64)
+	kMap := make(map[uint64]*kData)
+	var sb strings.Builder
+	for ; q > 0; q-- {
+		var op string
+		fmt.Fscan(reader, &op)
+		if op == "+" {
+			var x uint64
+			fmt.Fscan(reader, &x)
+			if _, ok := numbers[x]; ok {
+				continue
+			}
+			numbers[x] = struct{}{}
+			divs, ok := divisorCache[x]
+			if !ok {
+				divs = divisors(x)
+				divisorCache[x] = divs
+			}
+			for _, d := range divs {
+				if kd, ok := kMap[d]; ok {
+					idx := x / d
+					kd.present[idx] = struct{}{}
+					if idx == kd.mex {
+						for {
+							if _, ex := kd.present[kd.mex]; ex {
+								kd.mex++
+							} else {
+								break
+							}
+						}
+					}
+				}
+			}
+		} else if op == "-" {
+			var x uint64
+			fmt.Fscan(reader, &x)
+			delete(numbers, x)
+			divs := divisorCache[x]
+			for _, d := range divs {
+				if kd, ok := kMap[d]; ok {
+					idx := x / d
+					delete(kd.present, idx)
+					if idx < kd.mex {
+						kd.mex = idx
+					}
+				}
+			}
+		} else if op == "?" {
+			var k uint64
+			fmt.Fscan(reader, &k)
+			kd, ok := kMap[k]
+			if !ok {
+				kd = &kData{present: make(map[uint64]struct{})}
+				for num := range numbers {
+					if num%k == 0 {
+						kd.present[num/k] = struct{}{}
+					}
+				}
+				kd.mex = 0
+				for {
+					if _, ex := kd.present[kd.mex]; ex {
+						kd.mex++
+					} else {
+						break
+					}
+				}
+				kMap[k] = kd
+			} else {
+				for {
+					if _, ex := kd.present[kd.mex]; ex {
+						kd.mex++
+					} else {
+						break
+					}
+				}
+			}
+			fmt.Fprintf(&sb, "%d\n", kd.mex*k)
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	q := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", q)
+	set := map[uint64]bool{0: true}
+	ask := false
+	for i := 0; i < q; i++ {
+		typ := rng.Intn(3) // 0 add,1 remove,2 query
+		if len(set) <= 1 && typ == 1 {
+			typ = 0
+		}
+		if i == q-1 && !ask {
+			typ = 2
+		}
+		if typ == 0 {
+			var x uint64
+			for {
+				x = uint64(rng.Intn(1000000) + 1)
+				if !set[x] {
+					break
+				}
+			}
+			set[x] = true
+			fmt.Fprintf(&sb, "+ %d\n", x)
+		} else if typ == 1 {
+			var idx int
+			if len(set) == 0 {
+				i--
+				continue
+			}
+			idx = rng.Intn(len(set))
+			var val uint64
+			j := 0
+			for k := range set {
+				if j == idx {
+					val = k
+					break
+				}
+				j++
+			}
+			delete(set, val)
+			fmt.Fprintf(&sb, "- %d\n", val)
+		} else {
+			k := uint64(rng.Intn(10) + 1)
+			fmt.Fprintf(&sb, "? %d\n", k)
+			ask = true
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1732/verifierE.go
+++ b/1000-1999/1700-1799/1730-1739/1732/verifierE.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solve(reader *bufio.Reader) string {
+	var n, q int
+	if _, err := fmt.Fscan(reader, &n, &q); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &b[i])
+	}
+	var sb strings.Builder
+	for ; q > 0; q-- {
+		var t int
+		fmt.Fscan(reader, &t)
+		if t == 1 {
+			var l, r, x int
+			fmt.Fscan(reader, &l, &r, &x)
+			l--
+			r--
+			for i := l; i <= r; i++ {
+				a[i] = x
+			}
+		} else {
+			var l, r int
+			fmt.Fscan(reader, &l, &r)
+			l--
+			r--
+			res := int64(1<<63 - 1)
+			for i := l; i <= r; i++ {
+				g := gcd(a[i], b[i])
+				val := int64(a[i]) * int64(b[i]) / int64(g*g)
+				if val < res {
+					res = val
+				}
+			}
+			fmt.Fprintf(&sb, "%d\n", res)
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	q := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(50)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(50)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		t := rng.Intn(2) + 1
+		if t == 1 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			x := rng.Intn(50) + 1
+			fmt.Fprintf(&sb, "1 %d %d %d\n", l, r, x)
+		} else {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			fmt.Fprintf(&sb, "2 %d %d\n", l, r)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for contest 1732 problems (A–E, C1/C2, D1/D2)
- each verifier runs 100 random tests using an embedded reference solution
- usage example: `go run verifierA.go /path/to/binary`

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC1.go`
- `go build verifierC2.go`
- `go build verifierD1.go`
- `go build verifierD2.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68875436efcc8324b15041fcb48cb87d