### PR TITLE
Add verifiers for Codeforces 1735

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1735/verifierA.go
+++ b/1000-1999/1700-1799/1730-1739/1735/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1735A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []string {
+	rng := rand.New(rand.NewSource(1735))
+	cases := []string{"1\n6\n", "1\n7\n", "1\n8\n", "1\n1000000000\n"}
+	for len(cases) < 100 {
+		n := rng.Int63n(1000000000-6+1) + 6
+		cases = append(cases, fmt.Sprintf("1\n%d\n", n))
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, tc := range cases {
+		exp, err := runBinary(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on case %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(cases))
+}

--- a/1000-1999/1700-1799/1730-1739/1735/verifierB.go
+++ b/1000-1999/1700-1799/1730-1739/1735/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1735B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(10000000) + 1
+	}
+	sort.Ints(arr)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func genCases() []string {
+	rng := rand.New(rand.NewSource(1735))
+	cases := make([]string, 0, 100)
+	cases = append(cases, "1\n1\n1\n")
+	cases = append(cases, "1\n3\n1 2 3\n")
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, tc := range cases {
+		exp, err := runBinary(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on case %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(cases))
+}

--- a/1000-1999/1700-1799/1730-1739/1735/verifierC.go
+++ b/1000-1999/1700-1799/1730-1739/1735/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1735C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + rng.Intn(26)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func genCases() []string {
+	rng := rand.New(rand.NewSource(1735))
+	cases := []string{"1\n1\na\n", "1\n2\nab\n"}
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, tc := range cases {
+		exp, err := runBinary(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on case %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(cases))
+}

--- a/1000-1999/1700-1799/1730-1739/1735/verifierD.go
+++ b/1000-1999/1700-1799/1730-1739/1735/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1735D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(4) + 1
+	used := make(map[int64]bool)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	count := 0
+	for count < n {
+		val := int64(0)
+		card := make([]int, k)
+		for i := 0; i < k; i++ {
+			x := rng.Intn(3)
+			card[i] = x
+			val = val*3 + int64(x)
+		}
+		if used[val] {
+			continue
+		}
+		used[val] = true
+		for i, x := range card {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", x)
+		}
+		sb.WriteByte('\n')
+		count++
+	}
+	return sb.String()
+}
+
+func genCases() []string {
+	rng := rand.New(rand.NewSource(1735))
+	cases := make([]string, 0, 100)
+	cases = append(cases, "1 1\n0\n")
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, tc := range cases {
+		exp, err := runBinary(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on case %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(cases))
+}

--- a/1000-1999/1700-1799/1730-1739/1735/verifierE.go
+++ b/1000-1999/1700-1799/1730-1739/1735/verifierE.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1735E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	d1 := make([]int64, n)
+	d2 := make([]int64, n)
+	for i := 0; i < n; i++ {
+		d1[i] = rng.Int63n(1000000000)
+		d2[i] = rng.Int63n(1000000000)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i, v := range d1 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range d2 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func genCases() []string {
+	rng := rand.New(rand.NewSource(1735))
+	cases := make([]string, 0, 100)
+	cases = append(cases, "1\n1\n0\n0\n")
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, tc := range cases {
+		exp, err := runBinary(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on case %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(cases))
+}

--- a/1000-1999/1700-1799/1730-1739/1735/verifierF.go
+++ b/1000-1999/1700-1799/1730-1739/1735/verifierF.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1735F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	a := rng.Int63n(1000000000)
+	b := rng.Int63n(1000000000)
+	p := make([]int64, n)
+	q := make([]int64, n)
+	for i := 0; i < n; i++ {
+		p[i] = rng.Int63n(1000000000) + 1
+		q[i] = rng.Int63n(1000000000) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d\n", n, a, b)
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range q {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func genCases() []string {
+	rng := rand.New(rand.NewSource(1735))
+	cases := make([]string, 0, 100)
+	cases = append(cases, "1\n1 0 0\n1\n1\n")
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, tc := range cases {
+		exp, err := runBinary(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on case %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add solution verifiers in Go for contest 1735 problems A–F

## Testing
- `go run verifierA.go ./cand1735A`
- `go run verifierB.go ./cand1735B`


------
https://chatgpt.com/codex/tasks/task_e_68875508e8d08324a19dc46f7e4f537a