### PR TITLE
Add verifiers for CF 1733

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1733/verifierA.go
+++ b/1000-1999/1700-1799/1730-1739/1733/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveCase(n, k int, a []int) int {
+	sum := 0
+	for r := 0; r < k; r++ {
+		maxv := 0
+		for i := r; i < n; i += k {
+			if a[i] > maxv {
+				maxv = a[i]
+			}
+		}
+		sum += maxv
+	}
+	return sum
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(3) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(10) + 1
+		k := rng.Intn(n) + 1
+		arr := make([]int, n)
+		in.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(100)
+			if j > 0 {
+				in.WriteByte(' ')
+			}
+			in.WriteString(strconv.Itoa(arr[j]))
+		}
+		in.WriteByte('\n')
+		ans := solveCase(n, k, arr)
+		out.WriteString(fmt.Sprintf("%d\n", ans))
+	}
+	return in.String(), strings.TrimSpace(out.String())
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1733/verifierB.go
+++ b/1000-1999/1700-1799/1730-1739/1733/verifierB.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveB(n, x, y int) ([]int, bool) {
+	if (x > 0 && y > 0) || (x == 0 && y == 0) {
+		return nil, false
+	}
+	if x == 0 {
+		x, y = y, x
+	}
+	if x == 0 || (n-1)%x != 0 {
+		return nil, false
+	}
+	res := make([]int, n-1)
+	a, b, cnt := 1, 2, 0
+	for i := 0; i < n-1; i++ {
+		if cnt < x {
+			res[i] = a
+			b++
+			cnt++
+		} else {
+			res[i] = b
+			a = b + 1
+			a, b = b, a
+			cnt = 1
+		}
+	}
+	return res, true
+}
+
+func checkSequence(n, x, y int, seq []int) error {
+	if len(seq) != n-1 {
+		return fmt.Errorf("expected %d numbers, got %d", n-1, len(seq))
+	}
+	wins := make([]int, n+1)
+	prevWinner := seq[0]
+	if prevWinner != 1 && prevWinner != 2 {
+		return fmt.Errorf("game 1 winner must be 1 or 2")
+	}
+	wins[prevWinner]++
+	for i := 1; i < n-1; i++ {
+		nextPlayer := i + 2
+		w := seq[i]
+		if w != prevWinner && w != nextPlayer {
+			return fmt.Errorf("game %d invalid winner", i+1)
+		}
+		wins[w]++
+		prevWinner = w
+	}
+	for i := 1; i <= n; i++ {
+		if wins[i] != x && wins[i] != y {
+			return fmt.Errorf("player %d wins %d not %d/%d", i, wins[i], x, y)
+		}
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (string, int, int, int) {
+	n := rng.Intn(10) + 2
+	x := rng.Intn(n)
+	y := rng.Intn(n)
+	input := fmt.Sprintf("1\n%d %d %d\n", n, x, y)
+	return input, n, x, y
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, n, x, y := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 1 && fields[0] == "-1" {
+			if _, ok := solveB(n, x, y); ok {
+				fmt.Fprintf(os.Stderr, "case %d failed: output -1 but solution exists\ninput:\n%s", i+1, input)
+				os.Exit(1)
+			}
+			continue
+		}
+		seq := make([]int, len(fields))
+		for j, f := range fields {
+			v, err := strconv.Atoi(f)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid integer %q\n", i+1, f)
+				os.Exit(1)
+			}
+			seq[j] = v
+		}
+		if _, ok := solveB(n, x, y); !ok {
+			fmt.Fprintf(os.Stderr, "case %d failed: solution impossible but output provided\ninput:\n%s", i+1, input)
+			os.Exit(1)
+		}
+		if err := checkSequence(n, x, y, seq); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1733/verifierC.go
+++ b/1000-1999/1700-1799/1730-1739/1733/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func genCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(50)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), arr
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return out.String(), nil
+}
+
+func checkOutput(arr []int, out string) error {
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(out)))
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	mStr := strings.TrimSpace(scanner.Text())
+	m, err := strconv.Atoi(mStr)
+	if err != nil {
+		return fmt.Errorf("invalid operation count")
+	}
+	if m < 0 || m > len(arr) {
+		return fmt.Errorf("invalid operation count %d", m)
+	}
+	ops := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("expected %d operations", m)
+		}
+		var l, r int
+		if _, err := fmt.Sscan(scanner.Text(), &l, &r); err != nil {
+			return fmt.Errorf("bad operation format")
+		}
+		if l < 1 || l > len(arr) || r < 1 || r > len(arr) || l >= r {
+			return fmt.Errorf("invalid indices")
+		}
+		ops[i] = [2]int{l - 1, r - 1}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	a := make([]int, len(arr))
+	copy(a, arr)
+	for _, op := range ops {
+		l := op[0]
+		r := op[1]
+		if (a[l]+a[r])%2 == 1 {
+			a[r] = a[l]
+		} else {
+			a[l] = a[r]
+		}
+	}
+	for i := 1; i < len(a); i++ {
+		if a[i] < a[i-1] {
+			return fmt.Errorf("array not sorted")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, arr := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := checkOutput(arr, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1733/verifierD1.go
+++ b/1000-1999/1700-1799/1730-1739/1733/verifierD1.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	exe := filepath.Join(dir, "oracleD1")
+	cmd := exec.Command("go", "build", "-o", exe, "1733D1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	x := rng.Intn(5) + 1
+	y := rng.Intn(x + 1) // ensure y <= x
+	a := make([]byte, n)
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			a[i] = '0'
+		} else {
+			a[i] = '1'
+		}
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return fmt.Sprintf("1\n%d %d %d\n%s\n%s\n", n, x, y, a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1733/verifierD2.go
+++ b/1000-1999/1700-1799/1730-1739/1733/verifierD2.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	exe := filepath.Join(dir, "oracleD2")
+	cmd := exec.Command("go", "build", "-o", exe, "1733D2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	x := rng.Intn(5) + 1
+	y := rng.Intn(5) + 1
+	a := make([]byte, n)
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			a[i] = '0'
+		} else {
+			a[i] = '1'
+		}
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return fmt.Sprintf("1\n%d %d %d\n%s\n%s\n", n, x, y, a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1733/verifierE.go
+++ b/1000-1999/1700-1799/1730-1739/1733/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const N = 120
+const maxSteps = 300
+
+type slime struct{ x, y int }
+
+func precompute() []map[[2]int]bool {
+	belts := make([][]int, N)
+	for i := range belts {
+		belts[i] = make([]int, N)
+	}
+	slimes := []slime{{0, 0}}
+	history := make([]map[[2]int]bool, maxSteps+1)
+	for t := 0; t <= maxSteps; t++ {
+		grid := make(map[[2]int]bool)
+		for _, s := range slimes {
+			if s.x < N && s.y < N {
+				grid[[2]int{s.x, s.y}] = true
+			}
+		}
+		history[t] = grid
+		if t == maxSteps {
+			break
+		}
+		var next []slime
+		for _, s := range slimes {
+			nx, ny := s.x, s.y
+			if belts[nx][ny] == 0 {
+				ny++
+			} else {
+				nx++
+			}
+			if nx < N && ny < N {
+				next = append(next, slime{nx, ny})
+			}
+		}
+		for _, s := range slimes {
+			belts[s.x][s.y] ^= 1
+		}
+		next = append(next, slime{0, 0})
+		slimes = next
+	}
+	return history
+}
+
+var history = precompute()
+
+func genCase(rng *rand.Rand) (string, []string) {
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	answers := make([]string, q)
+	for i := 0; i < q; i++ {
+		t := rng.Intn(maxSteps + 1)
+		x := rng.Intn(N)
+		y := rng.Intn(N)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", t, x, y))
+		if history[t][[2]int{x, y}] {
+			answers[i] = "YES"
+		} else {
+			answers[i] = "NO"
+		}
+	}
+	return sb.String(), answers
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else if strings.HasSuffix(bin, ".py") {
+		cmd = exec.Command("python3", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, answers := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != len(answers) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, len(answers), len(fields), input)
+			os.Exit(1)
+		}
+		for j, ans := range answers {
+			if strings.ToUpper(fields[j]) != ans {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, ans, fields[j], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1733 problems A–E
- each verifier generates 100 random tests and checks the output
- verifiers for D1/D2 build oracle binaries from reference solutions

## Testing
- `go build -o /tmp/verifierA verifierA.go && /tmp/verifierA 1733A.go`
- `go build -o /tmp/verifierB verifierB.go && /tmp/verifierB 1733B.go`
- `go build -o /tmp/verifierC verifierC.go && /tmp/verifierC 1733C.go`
- `go build -o /tmp/verifierD1 verifierD1.go && /tmp/verifierD1 1733D1.go`
- `go build -o /tmp/verifierD2 verifierD2.go && /tmp/verifierD2 1733D2.go`
- `go build -o /tmp/verifierE verifierE.go && /tmp/verifierE 1733E.go`


------
https://chatgpt.com/codex/tasks/task_e_6887547c8f088324a4af3d1c95d96f35