### PR TITLE
Add Go verifiers for contest 1739

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1739/verifierA.go
+++ b/1000-1999/1700-1799/1730-1739/1739/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1739A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(8) + 1
+	return fmt.Sprintf("1\n%d %d\n", n, m)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(0))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1739/verifierB.go
+++ b/1000-1999/1700-1799/1730-1739/1739/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1739B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(101)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1739/verifierC.go
+++ b/1000-1999/1700-1799/1730-1739/1739/verifierC.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1739C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := 2 * (rng.Intn(30) + 1) // even 2..60
+	return fmt.Sprintf("1\n%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1739/verifierD.go
+++ b/1000-1999/1700-1799/1730-1739/1739/verifierD.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1739D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(30) + 2
+	k := rng.Intn(n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(i-1) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1739/verifierE.go
+++ b/1000-1999/1700-1799/1730-1739/1739/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1739E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 2
+	var row1 strings.Builder
+	var row2 strings.Builder
+	row1.WriteByte('0')
+	row2.WriteByte(byte('0' + rng.Intn(2)))
+	for i := 1; i < n; i++ {
+		row1.WriteByte(byte('0' + rng.Intn(2)))
+		row2.WriteByte(byte('0' + rng.Intn(2)))
+	}
+	return fmt.Sprintf("%d\n%s\n%s\n", n, row1.String(), row2.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1730-1739/1739/verifierF.go
+++ b/1000-1999/1700-1799/1730-1739/1739/verifierF.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1739F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+var letters = []rune("abcdefghijkl")
+
+func genString(rng *rand.Rand, length int) string {
+	var sb strings.Builder
+	prev := -1
+	for i := 0; i < length; i++ {
+		idx := rng.Intn(len(letters))
+		if idx == prev {
+			idx = (idx + 1) % len(letters)
+		}
+		sb.WriteRune(letters[idx])
+		prev = idx
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		w := rng.Intn(100) + 1
+		l := rng.Intn(8) + 2
+		s := genString(rng, l)
+		sb.WriteString(fmt.Sprintf("%d %s\n", w, s))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(5))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierF.go` for contest 1739
- each verifier builds the official solution and runs 100 random tests

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go vet verifierF.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68875620cdfc8324b83f4aac1bb39392