### PR TITLE
Add Go verifiers for Codeforces 1742

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1742/verifierA.go
+++ b/1000-1999/1700-1799/1740-1749/1742/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	a, b, c int
+}
+
+func generateCases() []testCase {
+	rand.Seed(1)
+	cases := make([]testCase, 100)
+	for i := range cases {
+		cases[i] = testCase{rand.Intn(21), rand.Intn(21), rand.Intn(21)}
+	}
+	return cases
+}
+
+func expected(t testCase) string {
+	if t.a+t.b == t.c || t.a+t.c == t.b || t.b+t.c == t.a {
+		return "YES"
+	}
+	return "NO"
+}
+
+func buildIO(cases []testCase) (string, string) {
+	var inBuilder strings.Builder
+	var outBuilder strings.Builder
+	fmt.Fprintf(&inBuilder, "%d\n", len(cases))
+	for _, tc := range cases {
+		fmt.Fprintf(&inBuilder, "%d %d %d\n", tc.a, tc.b, tc.c)
+		fmt.Fprintln(&outBuilder, expected(tc))
+	}
+	return inBuilder.String(), outBuilder.String()
+}
+
+func run(binary, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(binary, ".go") {
+		cmd = exec.Command("go", "run", binary)
+	} else {
+		cmd = exec.Command(binary)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.TrimSpace(s)
+	return s
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	cases := generateCases()
+	input, expectedOutput := buildIO(cases)
+	actualOutput, err := run(binary, input)
+	if err != nil {
+		fmt.Printf("Runtime error: %v\n", err)
+		os.Exit(1)
+	}
+	if normalize(actualOutput) != normalize(expectedOutput) {
+		fmt.Println("Wrong answer")
+		fmt.Println("Expected:")
+		fmt.Println(expectedOutput)
+		fmt.Println("Got:")
+		fmt.Println(actualOutput)
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed!")
+}

--- a/1000-1999/1700-1799/1740-1749/1742/verifierB.go
+++ b/1000-1999/1700-1799/1740-1749/1742/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func generateCases() []testCase {
+	rand.Seed(2)
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rand.Intn(10) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(20) + 1
+		}
+		cases[i] = testCase{arr: arr}
+	}
+	return cases
+}
+
+func expected(tc testCase) string {
+	seen := make(map[int]struct{})
+	for _, v := range tc.arr {
+		if _, ok := seen[v]; ok {
+			return "NO"
+		}
+		seen[v] = struct{}{}
+	}
+	return "YES"
+}
+
+func buildIO(cases []testCase) (string, string) {
+	var inBuilder strings.Builder
+	var outBuilder strings.Builder
+	fmt.Fprintf(&inBuilder, "%d\n", len(cases))
+	for _, tc := range cases {
+		fmt.Fprintf(&inBuilder, "%d\n", len(tc.arr))
+		for i, v := range tc.arr {
+			if i > 0 {
+				inBuilder.WriteByte(' ')
+			}
+			fmt.Fprint(&inBuilder, v)
+		}
+		inBuilder.WriteByte('\n')
+		fmt.Fprintln(&outBuilder, expected(tc))
+	}
+	return inBuilder.String(), outBuilder.String()
+}
+
+func run(binary, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(binary, ".go") {
+		cmd = exec.Command("go", "run", binary)
+	} else {
+		cmd = exec.Command(binary)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalizeTokens(s string) []string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.TrimSpace(s)
+	return strings.Fields(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	cases := generateCases()
+	input, expectedOutput := buildIO(cases)
+	actualOutput, err := run(binary, input)
+	if err != nil {
+		fmt.Printf("Runtime error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.Join(normalizeTokens(actualOutput), " ") != strings.Join(normalizeTokens(expectedOutput), " ") {
+		fmt.Println("Wrong answer")
+		fmt.Println("Expected:")
+		fmt.Println(expectedOutput)
+		fmt.Println("Got:")
+		fmt.Println(actualOutput)
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed!")
+}

--- a/1000-1999/1700-1799/1740-1749/1742/verifierC.go
+++ b/1000-1999/1700-1799/1740-1749/1742/verifierC.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	board [8]string
+	ans   string
+}
+
+func randomSet(n, k int) []int {
+	perm := rand.Perm(n)
+	return perm[:k]
+}
+
+func generateCases() []testCase {
+	rand.Seed(3)
+	cases := make([]testCase, 100)
+	for idx := range cases {
+		lastRed := rand.Intn(2) == 0
+		numRows := rand.Intn(8) + 1
+		numCols := rand.Intn(8) + 1
+		rows := randomSet(8, numRows)
+		cols := randomSet(8, numCols)
+		var grid [8][8]byte
+		if lastRed {
+			for _, c := range cols {
+				for r := 0; r < 8; r++ {
+					grid[r][c] = 'B'
+				}
+			}
+			for _, r := range rows {
+				for c := 0; c < 8; c++ {
+					grid[r][c] = 'R'
+				}
+			}
+		} else {
+			for _, r := range rows {
+				for c := 0; c < 8; c++ {
+					grid[r][c] = 'R'
+				}
+			}
+			for _, c := range cols {
+				for r := 0; r < 8; r++ {
+					grid[r][c] = 'B'
+				}
+			}
+		}
+		var board [8]string
+		for r := 0; r < 8; r++ {
+			line := make([]byte, 8)
+			for c := 0; c < 8; c++ {
+				ch := grid[r][c]
+				if ch == 0 {
+					ch = '.'
+				}
+				line[c] = ch
+			}
+			board[r] = string(line)
+		}
+		ans := "B"
+		if lastRed {
+			ans = "R"
+		}
+		cases[idx] = testCase{board: board, ans: ans}
+	}
+	return cases
+}
+
+func buildIO(cases []testCase) (string, string) {
+	var inBuilder strings.Builder
+	var outBuilder strings.Builder
+	fmt.Fprintf(&inBuilder, "%d\n", len(cases))
+	for _, tc := range cases {
+		for i := 0; i < 8; i++ {
+			fmt.Fprintln(&inBuilder, tc.board[i])
+		}
+		fmt.Fprintln(&outBuilder, tc.ans)
+	}
+	return inBuilder.String(), outBuilder.String()
+}
+
+func run(binary, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(binary, ".go") {
+		cmd = exec.Command("go", "run", binary)
+	} else {
+		cmd = exec.Command(binary)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalizeTokens(s string) []string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.TrimSpace(s)
+	return strings.Fields(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	cases := generateCases()
+	input, expectedOutput := buildIO(cases)
+	actualOutput, err := run(binary, input)
+	if err != nil {
+		fmt.Printf("Runtime error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.Join(normalizeTokens(actualOutput), " ") != strings.Join(normalizeTokens(expectedOutput), " ") {
+		fmt.Println("Wrong answer")
+		fmt.Println("Expected:")
+		fmt.Println(expectedOutput)
+		fmt.Println("Got:")
+		fmt.Println(actualOutput)
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed!")
+}

--- a/1000-1999/1700-1799/1740-1749/1742/verifierD.go
+++ b/1000-1999/1700-1799/1740-1749/1742/verifierD.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func generateCases() []testCase {
+	rand.Seed(4)
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rand.Intn(10) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(1000) + 1
+		}
+		cases[i] = testCase{arr: arr}
+	}
+	return cases
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expected(tc testCase) string {
+	pos := make([]int, 1001)
+	for i, v := range tc.arr {
+		if i+1 > pos[v] {
+			pos[v] = i + 1
+		}
+	}
+	ans := -1
+	for i := 1; i <= 1000; i++ {
+		if pos[i] == 0 {
+			continue
+		}
+		for j := 1; j <= 1000; j++ {
+			if pos[j] == 0 {
+				continue
+			}
+			if gcd(i, j) == 1 {
+				sum := pos[i] + pos[j]
+				if sum > ans {
+					ans = sum
+				}
+			}
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func buildIO(cases []testCase) (string, string) {
+	var inBuilder strings.Builder
+	var outBuilder strings.Builder
+	fmt.Fprintf(&inBuilder, "%d\n", len(cases))
+	for _, tc := range cases {
+		fmt.Fprintf(&inBuilder, "%d\n", len(tc.arr))
+		for i, v := range tc.arr {
+			if i > 0 {
+				inBuilder.WriteByte(' ')
+			}
+			fmt.Fprint(&inBuilder, v)
+		}
+		inBuilder.WriteByte('\n')
+		fmt.Fprintln(&outBuilder, expected(tc))
+	}
+	return inBuilder.String(), outBuilder.String()
+}
+
+func run(binary, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(binary, ".go") {
+		cmd = exec.Command("go", "run", binary)
+	} else {
+		cmd = exec.Command(binary)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalizeTokens(s string) []string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.TrimSpace(s)
+	return strings.Fields(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	cases := generateCases()
+	input, expectedOutput := buildIO(cases)
+	actualOutput, err := run(binary, input)
+	if err != nil {
+		fmt.Printf("Runtime error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.Join(normalizeTokens(actualOutput), " ") != strings.Join(normalizeTokens(expectedOutput), " ") {
+		fmt.Println("Wrong answer")
+		fmt.Println("Expected:")
+		fmt.Println(expectedOutput)
+		fmt.Println("Got:")
+		fmt.Println(actualOutput)
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed!")
+}

--- a/1000-1999/1700-1799/1740-1749/1742/verifierE.go
+++ b/1000-1999/1700-1799/1740-1749/1742/verifierE.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCase struct {
+	a       []int
+	queries []int
+}
+
+func generateCases() []testCase {
+	rand.Seed(5)
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rand.Intn(10) + 1
+		q := rand.Intn(10) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rand.Intn(10) + 1
+		}
+		queries := make([]int, q)
+		for j := range queries {
+			queries[j] = rand.Intn(12)
+		}
+		cases[i] = testCase{a: a, queries: queries}
+	}
+	return cases
+}
+
+func expected(tc testCase) string {
+	n := len(tc.a)
+	prefMax := make([]int, n)
+	prefSum := make([]int64, n)
+	curMax := 0
+	var curSum int64
+	for i, v := range tc.a {
+		if v > curMax {
+			curMax = v
+		}
+		curSum += int64(v)
+		prefMax[i] = curMax
+		prefSum[i] = curSum
+	}
+	var out strings.Builder
+	for idx, k := range tc.queries {
+		pos := sort.Search(n, func(j int) bool { return prefMax[j] > k })
+		var ans int64
+		if pos > 0 {
+			ans = prefSum[pos-1]
+		}
+		if idx > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprint(&out, ans)
+	}
+	return out.String()
+}
+
+func buildIO(cases []testCase) (string, string) {
+	var inBuilder strings.Builder
+	var outBuilder strings.Builder
+	fmt.Fprintf(&inBuilder, "%d\n", len(cases))
+	for _, tc := range cases {
+		fmt.Fprintf(&inBuilder, "%d %d\n", len(tc.a), len(tc.queries))
+		for i, v := range tc.a {
+			if i > 0 {
+				inBuilder.WriteByte(' ')
+			}
+			fmt.Fprint(&inBuilder, v)
+		}
+		inBuilder.WriteByte('\n')
+		for i, v := range tc.queries {
+			if i > 0 {
+				inBuilder.WriteByte(' ')
+			}
+			fmt.Fprint(&inBuilder, v)
+		}
+		inBuilder.WriteByte('\n')
+		fmt.Fprintln(&outBuilder, expected(tc))
+	}
+	return inBuilder.String(), outBuilder.String()
+}
+
+func run(binary, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(binary, ".go") {
+		cmd = exec.Command("go", "run", binary)
+	} else {
+		cmd = exec.Command(binary)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalizeTokens(s string) []string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.TrimSpace(s)
+	return strings.Fields(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	cases := generateCases()
+	input, expectedOutput := buildIO(cases)
+	actualOutput, err := run(binary, input)
+	if err != nil {
+		fmt.Printf("Runtime error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.Join(normalizeTokens(actualOutput), " ") != strings.Join(normalizeTokens(expectedOutput), " ") {
+		fmt.Println("Wrong answer")
+		fmt.Println("Expected:")
+		fmt.Println(expectedOutput)
+		fmt.Println("Got:")
+		fmt.Println(actualOutput)
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed!")
+}

--- a/1000-1999/1700-1799/1740-1749/1742/verifierF.go
+++ b/1000-1999/1700-1799/1740-1749/1742/verifierF.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type operation struct {
+	d int
+	k int
+	x string
+}
+
+type testCase struct {
+	ops []operation
+}
+
+func randomString() string {
+	length := rand.Intn(3) + 1
+	bytes := make([]byte, length)
+	for i := range bytes {
+		bytes[i] = byte('a' + rand.Intn(3))
+	}
+	return string(bytes)
+}
+
+func generateCases() []testCase {
+	rand.Seed(6)
+	cases := make([]testCase, 100)
+	for i := range cases {
+		q := rand.Intn(5) + 1
+		ops := make([]operation, q)
+		for j := range ops {
+			ops[j] = operation{
+				d: 1 + rand.Intn(2),
+				k: rand.Intn(5) + 1,
+				x: randomString(),
+			}
+		}
+		cases[i] = testCase{ops: ops}
+	}
+	return cases
+}
+
+func expected(tc testCase) string {
+	cntS := make([]int64, 26)
+	cntT := make([]int64, 26)
+	cntS[0], cntT[0] = 1, 1
+	lenS, lenT := int64(1), int64(1)
+	var out strings.Builder
+	for _, op := range tc.ops {
+		freq := make([]int64, 26)
+		for i := 0; i < len(op.x); i++ {
+			freq[op.x[i]-'a']++
+		}
+		if op.d == 1 {
+			for i := 0; i < 26; i++ {
+				if freq[i] > 0 {
+					cntS[i] += int64(op.k) * freq[i]
+				}
+			}
+			lenS += int64(op.k) * int64(len(op.x))
+		} else {
+			for i := 0; i < 26; i++ {
+				if freq[i] > 0 {
+					cntT[i] += int64(op.k) * freq[i]
+				}
+			}
+			lenT += int64(op.k) * int64(len(op.x))
+		}
+		hasTBig := false
+		for i := 1; i < 26; i++ {
+			if cntT[i] > 0 {
+				hasTBig = true
+				break
+			}
+		}
+		if hasTBig {
+			out.WriteString("YES\n")
+			continue
+		}
+		hasSBig := false
+		for i := 1; i < 26; i++ {
+			if cntS[i] > 0 {
+				hasSBig = true
+				break
+			}
+		}
+		if hasSBig {
+			out.WriteString("NO\n")
+			continue
+		}
+		if lenS < lenT {
+			out.WriteString("YES\n")
+		} else {
+			out.WriteString("NO\n")
+		}
+	}
+	return strings.TrimSuffix(out.String(), "\n")
+}
+
+func buildIO(cases []testCase) (string, string) {
+	var inBuilder strings.Builder
+	var outBuilder strings.Builder
+	fmt.Fprintf(&inBuilder, "%d\n", len(cases))
+	for _, tc := range cases {
+		fmt.Fprintf(&inBuilder, "%d\n", len(tc.ops))
+		for _, op := range tc.ops {
+			fmt.Fprintf(&inBuilder, "%d %d %s\n", op.d, op.k, op.x)
+		}
+		outBuilder.WriteString(expected(tc))
+		outBuilder.WriteByte('\n')
+	}
+	return inBuilder.String(), outBuilder.String()
+}
+
+func run(binary, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(binary, ".go") {
+		cmd = exec.Command("go", "run", binary)
+	} else {
+		cmd = exec.Command(binary)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalizeTokens(s string) []string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.TrimSpace(s)
+	return strings.Fields(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	cases := generateCases()
+	input, expectedOutput := buildIO(cases)
+	actualOutput, err := run(binary, input)
+	if err != nil {
+		fmt.Printf("Runtime error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.Join(normalizeTokens(actualOutput), " ") != strings.Join(normalizeTokens(expectedOutput), " ") {
+		fmt.Println("Wrong answer")
+		fmt.Println("Expected:")
+		fmt.Println(expectedOutput)
+		fmt.Println("Got:")
+		fmt.Println(actualOutput)
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed!")
+}

--- a/1000-1999/1700-1799/1740-1749/1742/verifierG.go
+++ b/1000-1999/1700-1799/1740-1749/1742/verifierG.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func generateCases() []testCase {
+	rand.Seed(7)
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rand.Intn(10) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(100)
+		}
+		cases[i] = testCase{arr: arr}
+	}
+	return cases
+}
+
+func expected(tc testCase) string {
+	arr := append([]int(nil), tc.arr...)
+	cur := 0
+	limit := len(arr)
+	if limit > 32 {
+		limit = 32
+	}
+	for i := 0; i < limit; i++ {
+		best := cur
+		bestIdx := -1
+		for j := i; j < len(arr); j++ {
+			if cur|arr[j] > best {
+				best = cur | arr[j]
+				bestIdx = j
+			}
+		}
+		if bestIdx != -1 {
+			arr[i], arr[bestIdx] = arr[bestIdx], arr[i]
+		}
+		cur = best
+	}
+	var out strings.Builder
+	for i, v := range arr {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprint(&out, v)
+	}
+	return out.String()
+}
+
+func buildIO(cases []testCase) (string, string) {
+	var inBuilder strings.Builder
+	var outBuilder strings.Builder
+	fmt.Fprintf(&inBuilder, "%d\n", len(cases))
+	for _, tc := range cases {
+		fmt.Fprintf(&inBuilder, "%d\n", len(tc.arr))
+		for i, v := range tc.arr {
+			if i > 0 {
+				inBuilder.WriteByte(' ')
+			}
+			fmt.Fprint(&inBuilder, v)
+		}
+		inBuilder.WriteByte('\n')
+		fmt.Fprintln(&outBuilder, expected(tc))
+	}
+	return inBuilder.String(), outBuilder.String()
+}
+
+func run(binary, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(binary, ".go") {
+		cmd = exec.Command("go", "run", binary)
+	} else {
+		cmd = exec.Command(binary)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalizeTokens(s string) []string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.TrimSpace(s)
+	return strings.Fields(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	cases := generateCases()
+	input, expectedOutput := buildIO(cases)
+	actualOutput, err := run(binary, input)
+	if err != nil {
+		fmt.Printf("Runtime error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.Join(normalizeTokens(actualOutput), " ") != strings.Join(normalizeTokens(expectedOutput), " ") {
+		fmt.Println("Wrong answer")
+		fmt.Println("Expected:")
+		fmt.Println(expectedOutput)
+		fmt.Println("Got:")
+		fmt.Println(actualOutput)
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed!")
+}


### PR DESCRIPTION
## Summary
- add standalone verifiers for contest 1742 problems A-G
- each verifier generates 100 random test cases and checks a given binary
- verifiers support running `go run verifierX.go /path/to/binary`

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_688756f33cec8324bc60bd09e1134285