### PR TITLE
Add output-checking verifier for 1534 F2

### DIFF
--- a/1000-1999/1500-1599/1530-1539/1534/verifierF2.go
+++ b/1000-1999/1500-1599/1530-1539/1534/verifierF2.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const numTestsF2 = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binF2")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	grid := make([][]byte, n)
+	cnt := make([]int, m)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '.'
+			} else {
+				row[j] = '#'
+				cnt[j]++
+			}
+		}
+		grid[i] = row
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		sb.Write(grid[i])
+		sb.WriteByte('\n')
+	}
+	for j := 0; j < m; j++ {
+		if j > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(cnt[j] + 1)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleF2")
+	cmd := exec.Command("go", "build", "-o", tmp, "1534F2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func runCase(bin, oracle, input string) error {
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF2.go /path/to/binary")
+		return
+	}
+	path := os.Args[1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsF2; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- update `verifierF2.go` to compare candidate output with a reference solver
- build oracle from `1534F2.go` and run 100 random tests

## Testing
- `gofmt -w 1000-1999/1500-1599/1530-1539/1534/verifierF2.go`


------
https://chatgpt.com/codex/tasks/task_e_68875673512c8324a40df7ff1b116a30