### PR TITLE
Add random test verifiers for contest 1744

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1744/verifierA.go
+++ b/1000-1999/1700-1799/1740-1749/1744/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleA.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1744A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(1))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(50) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(50)+1)
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1744/verifierB.go
+++ b/1000-1999/1700-1799/1740-1749/1744/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleB.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1744B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(2))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(5) + 1
+		q := rng.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, q)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(20)+1)
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < q; j++ {
+			typ := rng.Intn(2)
+			x := rng.Intn(10) + 1
+			fmt.Fprintf(&sb, "%d %d\n", typ, x)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1744/verifierC.go
+++ b/1000-1999/1700-1799/1740-1749/1744/verifierC.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleC.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1744C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(3))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	colors := []byte{'r', 'y', 'g'}
+	for i := 0; i < T; i++ {
+		n := rng.Intn(10) + 1
+		c := colors[rng.Intn(3)]
+		fmt.Fprintf(&sb, "%d %c\n", n, c)
+		b := make([]byte, n)
+		hasG := false
+		hasC := false
+		for j := 0; j < n; j++ {
+			b[j] = colors[rng.Intn(3)]
+			if b[j] == 'g' {
+				hasG = true
+			}
+			if b[j] == c {
+				hasC = true
+			}
+		}
+		if !hasG {
+			b[rng.Intn(n)] = 'g'
+		}
+		if !hasC {
+			b[rng.Intn(n)] = c
+		}
+		sb.WriteString(string(b))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1744/verifierD.go
+++ b/1000-1999/1700-1799/1740-1749/1744/verifierD.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleD.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1744D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(4))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(100)+1)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1744/verifierE1.go
+++ b/1000-1999/1700-1799/1740-1749/1744/verifierE1.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleE1.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1744E1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(5))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		a := rng.Intn(100) + 1
+		b := rng.Intn(100) + 1
+		c := a + rng.Intn(100) + 1
+		d := b + rng.Intn(100) + 1
+		fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, c, d)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1744/verifierE2.go
+++ b/1000-1999/1700-1799/1740-1749/1744/verifierE2.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleE2.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1744E2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(6))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		a := rng.Int63n(1_000_000) + 1
+		b := rng.Int63n(1_000_000) + 1
+		c := a + rng.Int63n(1_000_000) + 1
+		d := b + rng.Int63n(1_000_000) + 1
+		fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, c, d)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1744/verifierF.go
+++ b/1000-1999/1700-1799/1740-1749/1744/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleF.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1744F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(7))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(6) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		perm := rand.Perm(n)
+		for j, v := range perm {
+			if j+1 == n {
+				fmt.Fprintf(&sb, "%d\n", v)
+			} else {
+				fmt.Fprintf(&sb, "%d ", v)
+			}
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1744 problems A–F (including E1/E2)
- each verifier builds the reference solution, generates 100 random tests and compares results

## Testing
- `go run verifierA.go ./1744A_bin` *(passes)*
- `go run verifierB.go ./1744B_bin` *(passes)*

------
https://chatgpt.com/codex/tasks/task_e_6887577f45648324a25d7b0565b28fd3