### PR TITLE
Add go verifiers for contest 1741

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1741/verifierA.go
+++ b/1000-1999/1700-1799/1740-1749/1741/verifierA.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct{ a, b string }
+
+func genSize(rng *rand.Rand) string {
+	typ := rng.Intn(3)
+	if typ == 1 { // M
+		return "M"
+	}
+	cnt := rng.Intn(6)
+	s := strings.Repeat("X", cnt)
+	if typ == 0 {
+		return s + "S"
+	}
+	return s + "L"
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		cases[i] = Case{genSize(rng), genSize(rng)}
+	}
+	return cases
+}
+
+func expected(a, b string) string {
+	rank := func(c byte) int {
+		if c == 'S' {
+			return 0
+		}
+		if c == 'M' {
+			return 1
+		}
+		return 2
+	}
+	la, lb := len(a), len(b)
+	ca, cb := a[la-1], b[lb-1]
+	ra, rb := rank(ca), rank(cb)
+	if ra != rb {
+		if ra > rb {
+			return ">"
+		}
+		return "<"
+	}
+	if ca == 'M' {
+		return "="
+	}
+	if ca == 'S' {
+		if la == lb {
+			return "="
+		}
+		if la < lb {
+			return ">"
+		}
+		return "<"
+	}
+	if la == lb {
+		return "="
+	}
+	if la > lb {
+		return ">"
+	}
+	return "<"
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, c Case) error {
+	exp := expected(c.a, c.b)
+	input := fmt.Sprintf("1\n%s %s\n", c.a, c.b)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != exp {
+		return fmt.Errorf("expected %s got %s", exp, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1741/verifierB.go
+++ b/1000-1999/1700-1799/1740-1749/1741/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct{ n int }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		cases[i] = Case{n: rng.Intn(20) + 2}
+	}
+	return cases
+}
+
+func expected(n int) string {
+	if n == 3 {
+		return "-1"
+	}
+	var sb strings.Builder
+	for i := 3; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", i))
+	}
+	sb.WriteString("2 1")
+	return strings.TrimSpace(sb.String())
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, c Case) error {
+	exp := expected(c.n)
+	input := fmt.Sprintf("1\n%d\n", c.n)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != exp {
+		return fmt.Errorf("expected %s got %s", exp, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1741/verifierC.go
+++ b/1000-1999/1700-1799/1740-1749/1741/verifierC.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Case struct{ a []int }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(8) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(10) + 1
+		}
+		cases[i] = Case{a: arr}
+	}
+	return cases
+}
+
+func solve(a []int) int {
+	n := len(a)
+	prefix := make([]int, n+1)
+	pos := make(map[int]int, n+1)
+	pos[0] = 0
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] + a[i]
+		pos[prefix[i+1]] = i + 1
+	}
+	ans := n
+	for i := 1; i <= n; i++ {
+		target := prefix[i]
+		last := i
+		maxLen := i
+		valid := true
+		for last < n {
+			needed := prefix[last] + target
+			idx, ok := pos[needed]
+			if !ok {
+				valid = false
+				break
+			}
+			segLen := idx - last
+			if segLen > maxLen {
+				maxLen = segLen
+			}
+			last = idx
+		}
+		if valid && last == n && maxLen < ans {
+			ans = maxLen
+		}
+	}
+	return ans
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, c Case) error {
+	exp := solve(c.a)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(c.a)))
+	for i, v := range c.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	out, err := runCandidate(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil || got != exp {
+		return fmt.Errorf("expected %d got %s", exp, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1741/verifierD.go
+++ b/1000-1999/1700-1799/1740-1749/1741/verifierD.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Case struct {
+	n    int
+	perm []int
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		k := rng.Intn(4) + 1 // n=1..4 -> size up to 16
+		n := 1 << uint(k)
+		perm := rand.Perm(n)
+		for j := range perm {
+			perm[j]++
+		}
+		cases[i] = Case{n: n, perm: perm}
+	}
+	return cases
+}
+
+func solve(a []int, base int) int {
+	n := len(a)
+	if n == 1 {
+		if a[0] == base {
+			return 0
+		}
+		return -1
+	}
+	mid := n / 2
+	left := a[:mid]
+	right := a[mid:]
+	check := func(seg []int, l, r int) bool {
+		for _, v := range seg {
+			if v < l || v > r {
+				return false
+			}
+		}
+		return true
+	}
+	best := -1
+	if check(left, base, base+mid-1) && check(right, base+mid, base+n-1) {
+		op1 := solve(left, base)
+		if op1 != -1 {
+			op2 := solve(right, base+mid)
+			if op2 != -1 {
+				best = op1 + op2
+			}
+		}
+	}
+	if check(left, base+mid, base+n-1) && check(right, base, base+mid-1) {
+		op1 := solve(left, base+mid)
+		if op1 != -1 {
+			op2 := solve(right, base)
+			if op2 != -1 {
+				val := op1 + op2 + 1
+				if best == -1 || val < best {
+					best = val
+				}
+			}
+		}
+	}
+	return best
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, c Case) error {
+	exp := solve(append([]int(nil), c.perm...), 1)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", c.n))
+	for i, v := range c.perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	out, err := runCandidate(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil || got != exp {
+		return fmt.Errorf("expected %d got %s", exp, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1741/verifierE.go
+++ b/1000-1999/1700-1799/1740-1749/1741/verifierE.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct{ b []int }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(8) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(n) + 1
+		}
+		cases[i] = Case{b: arr}
+	}
+	return cases
+}
+
+func solve(b []int) bool {
+	n := len(b)
+	dp := make([]bool, n+1)
+	dp[0] = true
+	for i := 0; i < n; i++ {
+		if dp[i] && i+b[i]+1 <= n {
+			dp[i+b[i]+1] = true
+		}
+		if i-b[i] >= 0 && dp[i-b[i]] {
+			dp[i+1] = true
+		}
+	}
+	return dp[n]
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, c Case) error {
+	exp := "NO"
+	if solve(c.b) {
+		exp = "YES"
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(c.b)))
+	for i, v := range c.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	out, err := runCandidate(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != exp {
+		return fmt.Errorf("expected %s got %s", exp, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1741/verifierF.go
+++ b/1000-1999/1700-1799/1740-1749/1741/verifierF.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type Segment struct{ l, r, c int }
+
+type Case struct{ segs []Segment }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 1
+		segs := make([]Segment, n)
+		for j := range segs {
+			l := rng.Intn(20) + 1
+			r := l + rng.Intn(20)
+			c := rng.Intn(3) + 1
+			segs[j] = Segment{l, r, c}
+		}
+		cases[i] = Case{segs: segs}
+	}
+	return cases
+}
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refF.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1741F.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(c.segs)))
+	for _, s := range c.segs {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", s.l, s.r, s.c))
+	}
+	input := sb.String()
+	exp, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if exp != got {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %+v\n", i+1, err, c)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1741/verifierG.go
+++ b/1000-1999/1700-1799/1740-1749/1741/verifierG.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type Case struct {
+	n, m  int
+	edges [][2]int
+	f     int
+	h     []int
+	k     int
+	p     []int
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 2
+		maxEdges := n * (n - 1) / 2
+		m := rng.Intn(maxEdges) + 1
+		edgeSet := make(map[[2]int]bool)
+		edges := make([][2]int, 0, m)
+		for len(edges) < m {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			if a == b {
+				continue
+			}
+			if a > b {
+				a, b = b, a
+			}
+			if edgeSet[[2]int{a, b}] {
+				continue
+			}
+			edgeSet[[2]int{a, b}] = true
+			edges = append(edges, [2]int{a, b})
+		}
+		f := rng.Intn(n) + 1
+		h := make([]int, f)
+		for j := 0; j < f; j++ {
+			h[j] = rng.Intn(n) + 1
+		}
+		k := rng.Intn(f) + 1
+		p := make([]int, k)
+		used := rand.Perm(f)[:k]
+		for j := 0; j < k; j++ {
+			p[j] = used[j] + 1
+		}
+		cases[i] = Case{n: n, m: m, edges: edges, f: f, h: h, k: k, p: p}
+	}
+	return cases
+}
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refG.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1741G.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", c.n, c.m))
+	for _, e := range c.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", c.f))
+	for i, v := range c.h {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("%d\n", c.k))
+	for i, v := range c.p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteString("\n")
+	input := sb.String()
+	exp, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if exp != got {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %+v\n", i+1, err, c)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for Codeforces contest 1741 problems A-G
- each verifier generates 100 random test cases and checks a candidate binary
- problems F and G build reference solutions from existing Go files

## Testing
- `go run verifierA.go -- 1741A.go`
- `go run verifierB.go -- 1741B.go`
- `go run verifierF.go -- 1741F.go`


------
https://chatgpt.com/codex/tasks/task_e_688756acef308324a6a8dfca8ed602da