### PR TITLE
Add Go verifiers for Codeforces contest 1747

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1747/verifierA.go
+++ b/1000-1999/1700-1799/1740-1749/1747/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+// generateTests returns the input and expected outputs for problem A
+func generateTests() (string, []int64) {
+	rand.Seed(1)
+	t := 100
+	var buf bytes.Buffer
+	var answers []int64
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(5) + 1 // n in [1,5]
+		fmt.Fprintln(&buf, n)
+		sum := int64(0)
+		for j := 0; j < n; j++ {
+			x := rand.Intn(21) - 10 // values in [-10,10]
+			fmt.Fprint(&buf, x)
+			if j+1 < n {
+				fmt.Fprint(&buf, " ")
+			}
+			sum += int64(x)
+		}
+		fmt.Fprintln(&buf)
+		if sum < 0 {
+			sum = -sum
+		}
+		answers = append(answers, sum)
+	}
+	return buf.String(), answers
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	input, expected := generateTests()
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewBufferString(input)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Printf("missing output for case %d\n", i+1)
+			os.Exit(1)
+		}
+		var got int64
+		fmt.Sscan(scanner.Text(), &got)
+		if got != exp {
+			fmt.Printf("case %d: expected %d, got %d\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1747/verifierB.go
+++ b/1000-1999/1700-1799/1740-1749/1747/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+// testCase represents one input and expected minimal operations for problem B
+type testCase struct {
+	n int
+	m int
+}
+
+func generateTests() (string, []testCase) {
+	rand.Seed(1)
+	t := 100
+	var buf bytes.Buffer
+	var cases []testCase
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(100) + 1
+		fmt.Fprintln(&buf, n)
+		m := 1
+		if n > 2 {
+			m = n/2 + n%2
+		}
+		cases = append(cases, testCase{n: n, m: m})
+	}
+	return buf.String(), cases
+}
+
+func hasBAN(s []byte) bool {
+	b := bytes.IndexByte(s, 'B')
+	if b < 0 {
+		return false
+	}
+	a := bytes.IndexByte(s[b+1:], 'A')
+	if a < 0 {
+		return false
+	}
+	n := bytes.IndexByte(s[b+a+2:], 'N')
+	return n >= 0
+}
+
+func applyOps(s []byte, ops [][2]int) []byte {
+	for _, op := range ops {
+		i := op[0] - 1
+		j := op[1] - 1
+		s[i], s[j] = s[j], s[i]
+	}
+	return s
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	input, cases := generateTests()
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewBufferString(input)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for idx, tc := range cases {
+		if !scanner.Scan() {
+			fmt.Printf("missing output for case %d\n", idx+1)
+			os.Exit(1)
+		}
+		var m int
+		fmt.Sscan(scanner.Text(), &m)
+		if m != tc.m {
+			fmt.Printf("case %d: expected %d operations, got %d\n", idx+1, tc.m, m)
+			os.Exit(1)
+		}
+		var ops [][2]int
+		for k := 0; k < m; k++ {
+			if !scanner.Scan() {
+				fmt.Printf("missing swap at case %d operation %d\n", idx+1, k+1)
+				os.Exit(1)
+			}
+			var i, j int
+			fmt.Sscan(scanner.Text(), &i, &j)
+			if i < 1 || i > 3*tc.n || j < 1 || j > 3*tc.n || i == j {
+				fmt.Printf("invalid indices in case %d: %d %d\n", idx+1, i, j)
+				os.Exit(1)
+			}
+			ops = append(ops, [2]int{i, j})
+		}
+		s := bytes.Repeat([]byte("BAN"), tc.n)
+		s = applyOps(s, ops)
+		if hasBAN(s) {
+			fmt.Printf("case %d: resulting string still contains BAN subsequence\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1747/verifierC.go
+++ b/1000-1999/1700-1799/1740-1749/1747/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+type testCase struct {
+	n      int
+	arr    []int
+	winner string
+}
+
+func generateTests() (string, []testCase) {
+	rand.Seed(1)
+	t := 100
+	var buf bytes.Buffer
+	var cases []testCase
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(5) + 2 // n in [2,6]
+		fmt.Fprintln(&buf, n)
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rand.Intn(9) + 1
+			fmt.Fprint(&buf, arr[j])
+			if j+1 < n {
+				fmt.Fprint(&buf, " ")
+			}
+		}
+		fmt.Fprintln(&buf)
+		winner := "Bob"
+		mn := arr[0]
+		for _, v := range arr[1:] {
+			if v < mn {
+				winner = "Alice"
+				break
+			}
+		}
+		cases = append(cases, testCase{n: n, arr: arr, winner: winner})
+	}
+	return buf.String(), cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	input, cases := generateTests()
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewBufferString(input)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for idx, tc := range cases {
+		if !scanner.Scan() {
+			fmt.Printf("missing output for case %d\n", idx+1)
+			os.Exit(1)
+		}
+		got := scanner.Text()
+		if got != tc.winner {
+			fmt.Printf("case %d: expected %s, got %s\n", idx+1, tc.winner, got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1747/verifierD.go
+++ b/1000-1999/1700-1799/1740-1749/1747/verifierD.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+)
+
+// generateTests creates a single test for problem D with q=100 queries
+func generateTests() (string, []int) {
+	rand.Seed(1)
+	n := 10
+	q := 100
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rand.Intn(8)
+	}
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, n, q)
+	for i, v := range arr {
+		if i > 0 {
+			fmt.Fprint(&buf, " ")
+		}
+		fmt.Fprint(&buf, v)
+	}
+	fmt.Fprintln(&buf)
+	lvals := make([]int, q)
+	rvals := make([]int, q)
+	for i := 0; i < q; i++ {
+		l := rand.Intn(n) + 1
+		r := rand.Intn(n-l+1) + l
+		lvals[i] = l
+		rvals[i] = r
+		fmt.Fprintln(&buf, l, r)
+	}
+	// compute expected answers using solution algorithm
+	px := make([]int, n+1)
+	nz := make([]int, n+1)
+	even := map[int][]int{}
+	odd := map[int][]int{}
+	for i := 0; i <= n; i++ {
+		if i > 0 {
+			px[i] = px[i-1] ^ arr[i-1]
+			if arr[i-1] != 0 {
+				nz[i] = nz[i-1] + 1
+			} else {
+				nz[i] = nz[i-1]
+			}
+		}
+		if i%2 == 0 {
+			even[px[i]] = append(even[px[i]], i)
+		} else {
+			odd[px[i]] = append(odd[px[i]], i)
+		}
+	}
+	answers := make([]int, q)
+	for idx := 0; idx < q; idx++ {
+		l := lvals[idx]
+		r := rvals[idx]
+		xor := px[r] ^ px[l-1]
+		if xor != 0 {
+			answers[idx] = -1
+			continue
+		}
+		if nz[r]-nz[l-1] == 0 {
+			answers[idx] = 0
+			continue
+		}
+		if (r-l+1)%2 == 1 {
+			answers[idx] = 1
+			continue
+		}
+		if arr[l-1] == 0 || arr[r-1] == 0 {
+			answers[idx] = 1
+			continue
+		}
+		par := (l - 1) % 2
+		var arrP []int
+		if par == 0 {
+			arrP = odd[px[l-1]]
+		} else {
+			arrP = even[px[l-1]]
+		}
+		i := sort.SearchInts(arrP, l)
+		if i < len(arrP) && arrP[i] <= r {
+			answers[idx] = 2
+			continue
+		}
+		par = r % 2
+		if par == 0 {
+			arrP = odd[px[r]]
+		} else {
+			arrP = even[px[r]]
+		}
+		i = sort.SearchInts(arrP, l-1)
+		if i < len(arrP) && arrP[i] < r {
+			answers[idx] = 2
+			continue
+		}
+		answers[idx] = -1
+	}
+	return buf.String(), answers
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	input, answers := generateTests()
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewBufferString(input)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for idx, exp := range answers {
+		if !scanner.Scan() {
+			fmt.Printf("missing output for query %d\n", idx+1)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscan(scanner.Text(), &got)
+		if got != exp {
+			fmt.Printf("query %d: expected %d, got %d\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1747/verifierE.go
+++ b/1000-1999/1700-1799/1740-1749/1747/verifierE.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+const mod int64 = 1000000007
+
+var fact []int64
+var invFact []int64
+var pow2 []int64
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func prep(maxN int) {
+	fact = make([]int64, maxN+2)
+	invFact = make([]int64, maxN+2)
+	pow2 = make([]int64, maxN+2)
+	fact[0] = 1
+	pow2[0] = 1
+	for i := 1; i <= maxN+1; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+		pow2[i] = pow2[i-1] * 2 % mod
+	}
+	invFact[maxN+1] = modPow(fact[maxN+1], mod-2)
+	for i := maxN; i >= 0; i-- {
+		invFact[i] = invFact[i+1] * int64(i+1) % mod
+	}
+}
+
+func F2(n, m int) int64 {
+	if n < 0 || m < 0 {
+		return 0
+	}
+	limit := n
+	if m < limit {
+		limit = m
+	}
+	var res int64
+	for r := 0; r <= limit; r++ {
+		k := n + m - r
+		term := fact[k+1]
+		term = term * invFact[n-r] % mod
+		term = term * invFact[m-r] % mod
+		term = term * invFact[r] % mod
+		term = term * pow2[k] % mod
+		if r%2 == 1 {
+			res -= term
+		} else {
+			res += term
+		}
+	}
+	res %= mod
+	if res < 0 {
+		res += mod
+	}
+	return res
+}
+
+func solve(n, m int) int64 {
+	ans := int64(0)
+	ans = (ans - 3*F2(n-2, m-2)) % mod
+	ans = (ans + 6*F2(n-2, m-1)) % mod
+	ans = (ans - 3*F2(n-2, m)) % mod
+	ans = (ans + 6*F2(n-1, m-2)) % mod
+	ans = (ans - 8*F2(n-1, m-1)) % mod
+	ans = (ans + 2*F2(n-1, m)) % mod
+	ans = (ans - 3*F2(n, m-2)) % mod
+	ans = (ans + 2*F2(n, m-1)) % mod
+	ans %= mod
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+func generateTests() (string, []int64) {
+	rand.Seed(1)
+	t := 100
+	var buf bytes.Buffer
+	tests := make([][2]int, t)
+	fmt.Fprintln(&buf, t)
+	maxSum := 0
+	for i := 0; i < t; i++ {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(10) + 1
+		tests[i] = [2]int{n, m}
+		fmt.Fprintln(&buf, n, m)
+		if n+m > maxSum {
+			maxSum = n + m
+		}
+	}
+	prep(maxSum)
+	var answers []int64
+	for _, p := range tests {
+		answers = append(answers, solve(p[0], p[1]))
+	}
+	return buf.String(), answers
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	input, answers := generateTests()
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewBufferString(input)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("failed to run binary:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for idx, exp := range answers {
+		if !scanner.Scan() {
+			fmt.Printf("missing output for case %d\n", idx+1)
+			os.Exit(1)
+		}
+		var got int64
+		fmt.Sscan(scanner.Text(), &got)
+		if got != exp {
+			fmt.Printf("case %d: expected %d, got %d\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for each problem in contest 1747
- each verifier generates 100 deterministic test cases
- run the provided binary with generated input and check outputs

## Testing
- `go build 1000-1999/1700-1799/1740-1749/1747/verifierA.go`
- `go build 1000-1999/1700-1799/1740-1749/1747/verifierB.go`
- `go build 1000-1999/1700-1799/1740-1749/1747/verifierC.go`
- `go build 1000-1999/1700-1799/1740-1749/1747/verifierD.go`
- `go build 1000-1999/1700-1799/1740-1749/1747/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688758514b3c83249373abcfe71822eb