### PR TITLE
Add Go verifiers for contest 1749

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1749/verifierA.go
+++ b/1000-1999/1700-1799/1740-1749/1749/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(input string) string {
+	r := strings.NewReader(input)
+	var n, m int
+	fmt.Fscan(r, &n, &m)
+	for i := 0; i < m; i++ {
+		var x, y int
+		fmt.Fscan(r, &x, &y)
+	}
+	if m < n {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(n) + 1
+	rows := rng.Perm(n)[:m]
+	cols := rng.Perm(n)[:m]
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", rows[i]+1, cols[i]+1)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		expect := oracle(tc)
+		got, err := run(bin, "1\n"+tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1749/verifierB.go
+++ b/1000-1999/1700-1799/1740-1749/1749/verifierB.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(input string) string {
+	r := strings.NewReader(input)
+	var n int
+	fmt.Fscan(r, &n)
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &a[i])
+	}
+	b := make([]int64, n)
+	var sumB, maxB int64
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &b[i])
+		sumB += b[i]
+		if b[i] > maxB {
+			maxB = b[i]
+		}
+	}
+	var sumA int64
+	for _, v := range a {
+		sumA += v
+	}
+	ans := sumA + sumB - maxB
+	return fmt.Sprint(ans)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(1000)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(1000)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	rng := rand.New(rand.NewSource(43))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		expect := oracle(tc)
+		got, err := run(bin, "1\n"+tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1749/verifierC.go
+++ b/1000-1999/1700-1799/1740-1749/1749/verifierC.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func canWin(a []int, k int) bool {
+	arr := make([]int, len(a))
+	copy(arr, a)
+	sort.Ints(arr)
+	for i := 0; i < k; i++ {
+		need := k - i
+		idx := sort.Search(len(arr), func(j int) bool { return arr[j] > need }) - 1
+		if idx < 0 {
+			return false
+		}
+		arr = append(arr[:idx], arr[idx+1:]...)
+		if len(arr) > 0 {
+			arr[len(arr)-1] += need
+			sort.Ints(arr)
+		}
+	}
+	return true
+}
+
+func oracle(input string) string {
+	r := strings.NewReader(input)
+	var n int
+	fmt.Fscan(r, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &a[i])
+	}
+	ans := 0
+	for k := n; k >= 0; k-- {
+		if canWin(a, k) {
+			ans = k
+			break
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(n)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	rng := rand.New(rand.NewSource(44))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		expect := oracle(tc)
+		got, err := run(bin, "1\n"+tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1749/verifierD.go
+++ b/1000-1999/1700-1799/1740-1749/1749/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD int64 = 998244353
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(input string) string {
+	r := strings.NewReader(input)
+	var n int
+	var m int64
+	if _, err := fmt.Fscan(r, &n, &m); err != nil {
+		return ""
+	}
+	isPrime := make([]bool, n+1)
+	if n >= 2 {
+		for i := 2; i <= n; i++ {
+			isPrime[i] = true
+		}
+		for i := 2; i*i <= n; i++ {
+			if isPrime[i] {
+				for j := i * i; j <= n; j += i {
+					isPrime[j] = false
+				}
+			}
+		}
+	}
+	mm := m % MOD
+	total := int64(0)
+	pw := int64(1)
+	for i := 1; i <= n; i++ {
+		pw = pw * mm % MOD
+		total = (total + pw) % MOD
+	}
+	prod := int64(1)
+	ways := mm
+	unamb := ways % MOD
+	for i := 2; i <= n; i++ {
+		if isPrime[i] {
+			prod *= int64(i)
+		}
+		if prod > m {
+			break
+		}
+		q := m / prod
+		ways = ways * (q % MOD) % MOD
+		unamb = (unamb + ways) % MOD
+	}
+	ans := (total - unamb) % MOD
+	if ans < 0 {
+		ans += MOD
+	}
+	return fmt.Sprint(ans)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	m := int64(rng.Intn(1000) + 1)
+	return fmt.Sprintf("%d %d\n", n, m)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	rng := rand.New(rand.NewSource(45))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		expect := oracle(tc)
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1749/verifierE.go
+++ b/1000-1999/1700-1799/1740-1749/1749/verifierE.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const INF = 1000000000
+
+type deque struct {
+	data       []int
+	head, tail int
+}
+
+func newDeque(n int) *deque {
+	size := 2*n + 10
+	d := &deque{data: make([]int, size)}
+	d.head = size / 2
+	d.tail = d.head
+	return d
+}
+
+func (d *deque) empty() bool     { return d.head == d.tail }
+func (d *deque) pushFront(x int) { d.head--; d.data[d.head] = x }
+func (d *deque) pushBack(x int)  { d.data[d.tail] = x; d.tail++ }
+func (d *deque) popFront() int   { x := d.data[d.head]; d.head++; return x }
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isok(r, c, n, m int, s [][]byte) bool {
+	dirs := [][2]int{{0, 1}, {0, -1}, {1, 0}, {-1, 0}}
+	for _, dxy := range dirs {
+		nr := r + dxy[0]
+		nc := c + dxy[1]
+		if nr >= 0 && nr < n && nc >= 0 && nc < m && s[nr][nc] == '#' {
+			return false
+		}
+	}
+	return true
+}
+
+func oracle(input string) string {
+	r := strings.NewReader(input)
+	var t int
+	fmt.Fscan(r, &t)
+	var out strings.Builder
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(r, &n, &m)
+		s := make([][]byte, n)
+		for i := 0; i < n; i++ {
+			var row string
+			fmt.Fscan(r, &row)
+			s[i] = []byte(row)
+		}
+		nm := n * m
+		dis := make([]int, nm)
+		par := make([]int, nm)
+		mark := make([]bool, nm)
+		for i := 0; i < nm; i++ {
+			dis[i] = INF
+		}
+		dq := newDeque(nm)
+		for i := 0; i < n; i++ {
+			idx := i * m
+			dis[idx] = 0
+			if isok(i, 0, n, m, s) {
+				if s[i][0] != '#' {
+					dis[idx] = 1
+					dq.pushBack(idx)
+				} else {
+					dq.pushFront(idx)
+				}
+			}
+		}
+		for !dq.empty() {
+			x := dq.popFront()
+			if x%m == m-1 || mark[x] {
+				if mark[x] {
+					continue
+				}
+				continue
+			}
+			mark[x] = true
+			r0 := x / m
+			c0 := x % m
+			for _, dxy := range [][2]int{{-1, 1}, {1, 1}, {1, -1}, {-1, -1}} {
+				nr := r0 + dxy[0]
+				nc := c0 + dxy[1]
+				if nr < 0 || nr >= n || nc < 0 || nc >= m {
+					continue
+				}
+				ni := nr*m + nc
+				if mark[ni] {
+					continue
+				}
+				if !isok(nr, nc, n, m, s) {
+					continue
+				}
+				w := 0
+				if s[nr][nc] != '#' {
+					w = 1
+				}
+				nd := dis[x] + w
+				if nd < dis[ni] {
+					dis[ni] = nd
+					par[ni] = x
+					if w == 0 {
+						dq.pushFront(ni)
+					} else {
+						dq.pushBack(ni)
+					}
+				}
+			}
+		}
+		ans := INF
+		stp := -1
+		for i := 0; i < n; i++ {
+			idx := i*m + (m - 1)
+			if dis[idx] < ans {
+				ans = dis[idx]
+				stp = idx
+			}
+		}
+		if ans == INF {
+			out.WriteString("NO\n")
+			continue
+		}
+		out.WriteString("YES\n")
+		x := stp
+		for x%m != 0 {
+			r1 := x / m
+			c1 := x % m
+			s[r1][c1] = '#'
+			x = par[x]
+		}
+		s[x/m][0] = '#'
+		for i := 0; i < n; i++ {
+			out.Write(s[i])
+			out.WriteByte('\n')
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(4) + 2
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if j > 0 && row[j-1] == '#' {
+				row[j] = '.'
+				continue
+			}
+			if i > 0 && grid[i-1][j] == '#' {
+				row[j] = '.'
+				continue
+			}
+			if rng.Intn(3) == 0 {
+				row[j] = '#'
+			} else {
+				row[j] = '.'
+			}
+		}
+		grid[i] = row
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		sb.Write(grid[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	rng := rand.New(rand.NewSource(46))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		expect := oracle(fmt.Sprintf("1\n%s", tc))
+		got, err := run(bin, fmt.Sprintf("1\n%s", tc))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1740-1749/1749/verifierF.go
+++ b/1000-1999/1700-1799/1740-1749/1749/verifierF.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const LOG = 20
+
+var (
+	n     int
+	adj   [][]int
+	up    [LOG + 1][]int
+	depth []int
+	value []int64
+)
+
+func dfs(root int) {
+	stack := []int{root}
+	parent := make([]int, n+1)
+	parent[root] = 0
+	depth[root] = 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, to := range adj[v] {
+			if to == parent[v] {
+				continue
+			}
+			parent[to] = v
+			depth[to] = depth[v] + 1
+			stack = append(stack, to)
+		}
+	}
+	up[0] = parent
+	for k := 1; k <= LOG; k++ {
+		up[k] = make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			up[k][i] = up[k-1][up[k-1][i]]
+		}
+	}
+}
+
+func lca(a, b int) int {
+	if depth[a] < depth[b] {
+		a, b = b, a
+	}
+	diff := depth[a] - depth[b]
+	for k := LOG; k >= 0; k-- {
+		if diff&(1<<uint(k)) != 0 {
+			a = up[k][a]
+		}
+	}
+	if a == b {
+		return a
+	}
+	for k := LOG; k >= 0; k-- {
+		if up[k][a] != up[k][b] {
+			a = up[k][a]
+			b = up[k][b]
+		}
+	}
+	return up[0][a]
+}
+
+func getPath(u, v int) []int {
+	w := lca(u, v)
+	var path []int
+	x := u
+	for x != w {
+		path = append(path, x)
+		x = up[0][x]
+	}
+	path = append(path, w)
+	var tmp []int
+	x = v
+	for x != w {
+		tmp = append(tmp, x)
+		x = up[0][x]
+	}
+	for i := len(tmp) - 1; i >= 0; i-- {
+		path = append(path, tmp[i])
+	}
+	return path
+}
+
+func update(u, v, k, d int) {
+	path := getPath(u, v)
+	visited := make([]bool, n+1)
+	q := make([]int, 0, len(path))
+	dist := make([]int, 0, len(path))
+	for _, x := range path {
+		if !visited[x] {
+			visited[x] = true
+			q = append(q, x)
+			dist = append(dist, 0)
+		}
+	}
+	head := 0
+	for head < len(q) {
+		node := q[head]
+		dd := dist[head]
+		head++
+		value[node] += int64(k)
+		if dd == d {
+			continue
+		}
+		for _, to := range adj[node] {
+			if !visited[to] {
+				visited[to] = true
+				q = append(q, to)
+				dist = append(dist, dd+1)
+			}
+		}
+	}
+}
+
+func buildExecutable(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "bin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, stderr.String())
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(input string) string {
+	r := strings.NewReader(input)
+	fmt.Fscan(r, &n)
+	adj = make([][]int, n+1)
+	for i := 0; i < n-1; i++ {
+		var u, v int
+		fmt.Fscan(r, &u, &v)
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	depth = make([]int, n+1)
+	for i := 0; i <= LOG; i++ {
+		up[i] = make([]int, n+1)
+	}
+	value = make([]int64, n+1)
+	dfs(1)
+	var m int
+	fmt.Fscan(r, &m)
+	var out strings.Builder
+	for i := 0; i < m; i++ {
+		var t int
+		fmt.Fscan(r, &t)
+		if t == 1 {
+			var v int
+			fmt.Fscan(r, &v)
+			fmt.Fprintf(&out, "%d\n", value[v])
+		} else {
+			var u, v, k, d int
+			fmt.Fscan(r, &u, &v, &k, &d)
+			update(u, v, k, d)
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(7) + 2
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{i, p}
+	}
+	q := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	fmt.Fprintf(&sb, "%d\n", q)
+	hasPrint := false
+	for i := 0; i < q; i++ {
+		if rng.Intn(3) == 0 {
+			v := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "1 %d\n", v)
+			hasPrint = true
+		} else {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			k := rng.Intn(10) + 1
+			d := rng.Intn(3)
+			fmt.Fprintf(&sb, "2 %d %d %d %d\n", u, v, k, d)
+		}
+	}
+	if !hasPrint {
+		fmt.Fprintf(&sb, "1 %d\n", 1)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := buildExecutable(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to prepare binary: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	rng := rand.New(rand.NewSource(47))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		expect := oracle(tc)
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E
- add verifierF.go for problem F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688758dd51ac8324a6ce14eed57327de