### PR TITLE
Add Go verifiers for contest 1753

### DIFF
--- a/1000-1999/1700-1799/1750-1759/1753/verifierA.go
+++ b/1000-1999/1700-1799/1750-1759/1753/verifierA.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	input string
+	n     int
+	arr   []int
+}
+
+func computePartition(n int, a []int) ([][2]int, bool) {
+	sum := 0
+	for _, v := range a {
+		if v < 0 {
+			sum -= v
+		} else {
+			sum += v
+		}
+	}
+	if sum%2 != 0 {
+		return nil, false
+	}
+	p := []int{1}
+	i := 1
+	rev := 0
+	for {
+		for i <= n && a[i-1] == 0 {
+			i++
+		}
+		if i > n {
+			break
+		}
+		l := i
+		i++
+		for i <= n && a[i-1] == 0 {
+			i++
+		}
+		if i > n {
+			break
+		}
+		r := i
+		i++
+		if (r-l)%2 == 1 {
+			if a[l-1] == a[r-1] {
+				continue
+			}
+			sgnl := (l % 2) ^ rev
+			if sgnl != 0 {
+				if p[len(p)-1] != r {
+					p = append(p, r)
+				}
+				p = append(p, r+1)
+			} else {
+				if p[len(p)-1] != l {
+					p = append(p, l)
+				}
+				p = append(p, l+1)
+			}
+		} else {
+			if a[l-1] != a[r-1] {
+				continue
+			}
+			sgnl := (l % 2) ^ rev
+			if sgnl != 0 {
+				if p[len(p)-1] != r {
+					p = append(p, r-1)
+				}
+				p = append(p, r+1)
+				rev ^= 1
+			} else {
+				if p[len(p)-1] != l {
+					p = append(p, l)
+				}
+				p = append(p, l+1)
+			}
+		}
+	}
+	if p[len(p)-1] != n+1 {
+		p = append(p, n+1)
+	}
+	m := len(p) - 1
+	segs := make([][2]int, m)
+	for j := 0; j < m; j++ {
+		segs[j] = [2]int{p[j], p[j+1] - 1}
+	}
+	return segs, true
+}
+
+func verifyOutput(n int, a []int, out string) error {
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) == 0 {
+		return fmt.Errorf("empty output")
+	}
+	if fields[0] == "-1" {
+		segs, ok := computePartition(n, a)
+		if ok && len(segs) > 0 {
+			return fmt.Errorf("partition exists but got -1")
+		}
+		if len(fields) != 1 {
+			return fmt.Errorf("extra data after -1")
+		}
+		return nil
+	}
+	k, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid k: %v", err)
+	}
+	if len(fields) != 1+2*k {
+		return fmt.Errorf("expected %d numbers got %d", 1+2*k, len(fields))
+	}
+	segs := make([][2]int, k)
+	idx := 1
+	for i := 0; i < k; i++ {
+		l, err1 := strconv.Atoi(fields[idx])
+		r, err2 := strconv.Atoi(fields[idx+1])
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("invalid segment")
+		}
+		segs[i] = [2]int{l, r}
+		idx += 2
+	}
+	if k == 0 {
+		return fmt.Errorf("k=0")
+	}
+	if segs[0][0] != 1 || segs[k-1][1] != n {
+		return fmt.Errorf("segments must cover array")
+	}
+	for i := 0; i < k; i++ {
+		l := segs[i][0]
+		r := segs[i][1]
+		if l > r || l < 1 || r > n {
+			return fmt.Errorf("invalid segment %d %d", l, r)
+		}
+		if i+1 < k && segs[i+1][0] != r+1 {
+			return fmt.Errorf("segments not contiguous")
+		}
+	}
+	total := 0
+	for _, seg := range segs {
+		sgn := 1
+		sum := 0
+		for j := seg[0] - 1; j <= seg[1]-1; j++ {
+			sum += sgn * a[j]
+			sgn *= -1
+		}
+		total += sum
+	}
+	if total != 0 {
+		return fmt.Errorf("alternating sum not zero")
+	}
+	return nil
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(42))
+	var tests []test
+	tests = append(tests, test{input: "1\n1\n1\n", n: 1, arr: []int{1}})
+	tests = append(tests, test{input: "1\n2\n1 -1\n", n: 2, arr: []int{1, -1}})
+	for len(tests) < 100 {
+		n := rng.Intn(6) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(3) - 1
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, test{input: sb.String(), n: n, arr: arr})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verifyOutput(t.n, t.arr, out); err != nil {
+			fmt.Printf("Wrong answer on test %d: %v\nInput:\n%sOutput:%s\n", i+1, err, t.input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1700-1799/1750-1759/1753/verifierB.go
+++ b/1000-1999/1700-1799/1750-1759/1753/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solveCase(n, x int, arr []int) string {
+	cnt := make([]int64, x+1)
+	for _, v := range arr {
+		if v <= x {
+			cnt[v]++
+		}
+	}
+	q := cnt[1]
+	for i := 2; i <= x; i++ {
+		val := q + cnt[i]*int64(i)
+		if val%int64(i) != 0 {
+			return "No"
+		}
+		q = val / int64(i)
+	}
+	return "Yes"
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(43))
+	var tests []test
+	tests = append(tests, test{input: "1 1\n1\n", expected: "Yes"})
+	tests = append(tests, test{input: "2 2\n1 2\n", expected: solveCase(2, 2, []int{1, 2})})
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		x := rng.Intn(5) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(x) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, test{input: sb.String(), expected: solveCase(n, x, arr)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1700-1799/1750-1759/1753/verifierC.go
+++ b/1000-1999/1700-1799/1750-1759/1753/verifierC.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod int64 = 998244353
+const maxn = 200000
+
+var inv [maxn + 1]int64
+var pref [maxn + 1]int64
+
+func init() {
+	inv[1] = 1
+	for i := 2; i <= maxn; i++ {
+		inv[i] = mod - mod/int64(i)*inv[mod%int64(i)]%mod
+	}
+	for i := 1; i <= maxn; i++ {
+		pref[i] = (pref[i-1] + inv[i]*inv[i]) % mod
+	}
+}
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solveCase(a []int) string {
+	n := len(a)
+	ones := 0
+	for _, v := range a {
+		if v == 1 {
+			ones++
+		}
+	}
+	zeros := n - ones
+	k := 0
+	for i := 0; i < zeros; i++ {
+		if a[i] == 1 {
+			k++
+		}
+	}
+	C := int64(n) * int64(n-1) / 2 % mod
+	ans := C * pref[k] % mod
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(44))
+	var tests []test
+	tests = append(tests, test{input: "1\n1\n1\n", expected: solveCase([]int{1})})
+	tests = append(tests, test{input: "2\n1 0\n", expected: solveCase([]int{1, 0})})
+	for len(tests) < 100 {
+		n := rng.Intn(6) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(2)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, test{input: sb.String(), expected: solveCase(arr)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader("1\n" + input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1700-1799/1750-1759/1753/verifierD.go
+++ b/1000-1999/1700-1799/1750-1759/1753/verifierD.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Edge struct {
+	to   int
+	cost int64
+}
+
+type Item struct {
+	node int
+	dist int64
+}
+
+type PriorityQueue []Item
+
+func (pq PriorityQueue) Len() int            { return len(pq) }
+func (pq PriorityQueue) Less(i, j int) bool  { return pq[i].dist < pq[j].dist }
+func (pq PriorityQueue) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PriorityQueue) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	x := old[n-1]
+	*pq = old[:n-1]
+	return x
+}
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solveCase(n, m int, pCost, qCost int64, grid []string) string {
+	idx := func(r, c int) int { return r*m + c }
+	valid := func(r, c int) bool {
+		return r >= 0 && r < n && c >= 0 && c < m && grid[r][c] != '#'
+	}
+	adj := make([][]Edge, n*m)
+	dotCount := 0
+	addEdge := func(fr, fc, toR, toC int, cost int64) {
+		if !valid(fr, fc) || !valid(toR, toC) {
+			return
+		}
+		from := idx(fr, fc)
+		to := idx(toR, toC)
+		adj[from] = append(adj[from], Edge{to: to, cost: cost})
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			switch grid[i][j] {
+			case '.':
+				dotCount++
+			case 'L':
+				addEdge(i, j-1, i, j+1, qCost)
+				addEdge(i, j+2, i, j, qCost)
+				addEdge(i-1, j, i, j+1, pCost)
+				addEdge(i+1, j, i, j+1, pCost)
+				addEdge(i-1, j+1, i, j, pCost)
+				addEdge(i+1, j+1, i, j, pCost)
+			case 'U':
+				addEdge(i-1, j, i+1, j, qCost)
+				addEdge(i+2, j, i, j, qCost)
+				addEdge(i, j-1, i+1, j, pCost)
+				addEdge(i, j+1, i+1, j, pCost)
+				addEdge(i+1, j-1, i, j, pCost)
+				addEdge(i+1, j+1, i, j, pCost)
+			}
+		}
+	}
+	if dotCount < 2 {
+		return "-1"
+	}
+	const INF int64 = 1 << 60
+	dist := make([]int64, n*m)
+	for i := range dist {
+		dist[i] = INF
+	}
+	pq := &PriorityQueue{}
+	heap.Init(pq)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '.' {
+				id := idx(i, j)
+				dist[id] = 0
+				heap.Push(pq, Item{node: id, dist: 0})
+			}
+		}
+	}
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(Item)
+		if it.dist != dist[it.node] {
+			continue
+		}
+		v := it.node
+		for _, e := range adj[v] {
+			nd := it.dist + e.cost
+			if nd < dist[e.to] {
+				dist[e.to] = nd
+				heap.Push(pq, Item{node: e.to, dist: nd})
+			}
+		}
+	}
+	ans := INF
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			id := idx(i, j)
+			if j+1 < m {
+				id2 := idx(i, j+1)
+				sum := dist[id] + dist[id2]
+				if sum < ans {
+					ans = sum
+				}
+			}
+			if i+1 < n {
+				id2 := idx(i+1, j)
+				sum := dist[id] + dist[id2]
+				if sum < ans {
+					ans = sum
+				}
+			}
+		}
+	}
+	if ans >= INF {
+		return "-1"
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(45))
+	var tests []test
+	base := []string{"..", ".."}
+	tests = append(tests, test{input: "2 2\n1 1\n..\n..\n", expected: solveCase(2, 2, 1, 1, base)})
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(3) + 1
+		p := int64(rng.Intn(3) + 1)
+		q := int64(rng.Intn(3) + 1)
+		grid := make([]string, n)
+		for i := 0; i < n; i++ {
+			var sb strings.Builder
+			for j := 0; j < m; j++ {
+				chars := ".#LU"
+				sb.WriteByte(chars[rng.Intn(len(chars))])
+			}
+			grid[i] = sb.String()
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, q))
+		for i := 0; i < n; i++ {
+			sb.WriteString(grid[i])
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, test{input: sb.String(), expected: solveCase(n, m, p, q, grid)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1700-1799/1750-1759/1753/verifierE.go
+++ b/1000-1999/1700-1799/1750-1759/1753/verifierE.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solveCase(n int, b, pc, mc int64, opsType []byte, opsVal []int64) string {
+	orig := int64(1)
+	prodAll := int64(1)
+	plusSum := int64(0)
+	for i := 0; i < n; i++ {
+		if opsType[i] == '+' {
+			orig += opsVal[i]
+			plusSum += opsVal[i]
+		} else {
+			orig *= opsVal[i]
+			if opsVal[i] > 1 {
+				prodAll *= opsVal[i]
+			}
+		}
+	}
+	sufProd := make([]int64, n+1)
+	sufProd[n] = 1
+	for i := n - 1; i >= 0; i-- {
+		sufProd[i] = sufProd[i+1]
+		if opsType[i] == '*' && opsVal[i] > 1 {
+			sufProd[i] *= opsVal[i]
+		}
+	}
+	prefMult := int64(0)
+	minCost := int64(1 << 60)
+	plusSuffix := make([]int, n+1)
+	for i := n - 1; i >= 0; i-- {
+		plusSuffix[i] = plusSuffix[i+1]
+		if opsType[i] == '+' {
+			plusSuffix[i]++
+		}
+	}
+	for i := 0; i <= n; i++ {
+		multBefore := prefMult
+		plusAfter := int64(plusSuffix[i])
+		cost := multBefore*mc + plusAfter*pc
+		if cost < minCost {
+			minCost = cost
+		}
+		if i < n && opsType[i] == '*' && opsVal[i] > 1 {
+			prefMult++
+		}
+	}
+	if minCost <= b {
+		result := (1 + plusSum) * prodAll
+		return fmt.Sprintf("%d", result)
+	}
+	profits := make([]int64, 0)
+	for i := 0; i < n; i++ {
+		if opsType[i] == '+' {
+			gain := opsVal[i] * (prodAll - sufProd[i])
+			if gain > 0 {
+				profits = append(profits, gain)
+			}
+		}
+	}
+	sort.Slice(profits, func(i, j int) bool { return profits[i] > profits[j] })
+	moves := int64(len(profits))
+	if moves*pc > b {
+		moves = b / pc
+	}
+	sumGain := int64(0)
+	for i := int64(0); i < moves; i++ {
+		sumGain += profits[i]
+	}
+	result := orig + sumGain
+	return fmt.Sprintf("%d", result)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(46))
+	var tests []test
+	tests = append(tests, test{input: "1 0 1 1\n", expected: solveCase(1, 0, 1, 1, []byte{'+'}, []int64{0})})
+	for len(tests) < 100 {
+		n := rng.Intn(4) + 1
+		b := int64(rng.Intn(5))
+		pc := int64(rng.Intn(3) + 1)
+		mc := int64(rng.Intn(3) + 1)
+		opsT := make([]byte, n)
+		opsV := make([]int64, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, b, pc, mc))
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 0 {
+				opsT[i] = '+'
+			} else {
+				opsT[i] = '*'
+			}
+			opsV[i] = int64(rng.Intn(4) + 1)
+			sb.WriteByte(opsT[i])
+			sb.WriteByte(' ')
+			sb.WriteString(fmt.Sprintf("%d\n", opsV[i]))
+		}
+		tests = append(tests, test{input: sb.String(), expected: solveCase(n, b, pc, mc, opsT, opsV)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1700-1799/1750-1759/1753/verifierF.go
+++ b/1000-1999/1700-1799/1750-1759/1753/verifierF.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+type cell struct {
+	weights []int
+	set     map[int]struct{}
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func addCell(c *cell, posCount, negCount []int, posPresent, negPresent []bool, rFirst, nFirst *int, limit int) {
+	for _, w := range c.weights {
+		if w > 0 {
+			if w > limit {
+				continue
+			}
+			if posCount[w] == 0 {
+				posPresent[w] = true
+			}
+			posCount[w]++
+			if w == *rFirst {
+				for *rFirst <= limit && posPresent[*rFirst] {
+					*rFirst++
+				}
+			}
+		} else {
+			idx := -w
+			if idx > limit {
+				continue
+			}
+			if negCount[idx] == 0 {
+				negPresent[idx] = true
+			}
+			negCount[idx]++
+			if idx == *nFirst {
+				for *nFirst <= limit && negPresent[*nFirst] {
+					*nFirst++
+				}
+			}
+		}
+	}
+}
+
+func removeCell(c *cell, posCount, negCount []int, posPresent, negPresent []bool, rFirst, nFirst *int) {
+	for _, w := range c.weights {
+		if w > 0 {
+			if posCount[w] > 0 {
+				posCount[w]--
+				if posCount[w] == 0 {
+					posPresent[w] = false
+					if w < *rFirst {
+						*rFirst = w
+					}
+				}
+			}
+		} else {
+			idx := -w
+			if negCount[idx] > 0 {
+				negCount[idx]--
+				if negCount[idx] == 0 {
+					negPresent[idx] = false
+					if idx < *nFirst {
+						*nFirst = idx
+					}
+				}
+			}
+		}
+	}
+}
+
+func solveCase(n, m, k, t int, studs [][3]int) string {
+	trans := false
+	if n > m {
+		n, m = m, n
+		trans = true
+	}
+	limit := t - 1
+	cells := make([][]cell, n)
+	for i := range cells {
+		cells[i] = make([]cell, m)
+	}
+	for _, st := range studs {
+		x, y, w := st[0], st[1], st[2]
+		if trans {
+			x, y = y, x
+		}
+		if abs(w) > limit {
+			continue
+		}
+		c := &cells[x-1][y-1]
+		if c.set == nil {
+			c.set = make(map[int]struct{})
+		}
+		if _, ok := c.set[w]; !ok {
+			c.set[w] = struct{}{}
+			c.weights = append(c.weights, w)
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			cells[i][j].set = nil
+		}
+	}
+	if t <= 1 {
+		ans := 0
+		minnm := n
+		if m < n {
+			minnm = m
+		}
+		for L := 1; L <= minnm; L++ {
+			ans += (n - L + 1) * (m - L + 1)
+		}
+		return fmt.Sprintf("%d", ans)
+	}
+	posCount := make([]int, limit+1)
+	negCount := make([]int, limit+1)
+	posPresent := make([]bool, limit+1)
+	negPresent := make([]bool, limit+1)
+	minnm := n
+	if m < n {
+		minnm = m
+	}
+	ans := 0
+	for L := 1; L <= minnm; L++ {
+		for top := 0; top <= n-L; top++ {
+			for i := 1; i <= limit; i++ {
+				posCount[i] = 0
+				negCount[i] = 0
+				posPresent[i] = false
+				negPresent[i] = false
+			}
+			rFirst, nFirst := 1, 1
+			for i := 0; i < L; i++ {
+				for j := 0; j < L; j++ {
+					addCell(&cells[top+i][j], posCount, negCount, posPresent, negPresent, &rFirst, &nFirst, limit)
+				}
+			}
+			teamSize := rFirst + nFirst - 1
+			if teamSize >= t {
+				ans++
+			}
+			for left := 1; left <= m-L; left++ {
+				for i := 0; i < L; i++ {
+					removeCell(&cells[top+i][left-1], posCount, negCount, posPresent, negPresent, &rFirst, &nFirst)
+					addCell(&cells[top+i][left+L-1], posCount, negCount, posPresent, negPresent, &rFirst, &nFirst, limit)
+				}
+				if rFirst <= limit {
+					for rFirst <= limit && posPresent[rFirst] {
+						rFirst++
+					}
+				}
+				if nFirst <= limit {
+					for nFirst <= limit && negPresent[nFirst] {
+						nFirst++
+					}
+				}
+				teamSize = rFirst + nFirst - 1
+				if teamSize >= t {
+					ans++
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(47))
+	var tests []test
+	tests = append(tests, test{input: "1 1 0 1\n", expected: solveCase(1, 1, 0, 1, nil)})
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(3) + 1
+		k := rng.Intn(n*m + 1)
+		tVal := rng.Intn(3) + 1
+		studs := make([][3]int, k)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, k, tVal))
+		for i := 0; i < k; i++ {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(m) + 1
+			w := rng.Intn(5) - 2
+			if w == 0 {
+				w = 1
+			}
+			studs[i] = [3]int{x, y, w}
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", x, y, w))
+		}
+		tests = append(tests, test{input: sb.String(), expected: solveCase(n, m, k, tVal, studs)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest 1753
- each verifier generates 100+ randomized tests and checks the output
- verifiers support running arbitrary binaries or Go programs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688759f56ec483249f758c76b01b8843