### PR TITLE
Add Go verifiers for contest 1758

### DIFF
--- a/1000-1999/1700-1799/1750-1759/1758/verifierA.go
+++ b/1000-1999/1700-1799/1750-1759/1758/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]string, 100)
+	for i := range tests {
+		n := r.Intn(100) + 1
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = byte('a' + r.Intn(26))
+		}
+		tests[i] = string(b)
+	}
+	return tests
+}
+
+func solve(s string) string {
+	runes := []rune(s)
+	for l, r := 0, len(runes)-1; l < r; l, r = l+1, r-1 {
+		runes[l], runes[r] = runes[r], runes[l]
+	}
+	return string(runes) + s
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, s := range tests {
+		fmt.Fprintln(&input, s)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = &input
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "execution failed: %v\n", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(&out)
+	for i, s := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "missing output for test case %d\n", i+1)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(scanner.Text())
+		want := solve(s)
+		if got != want {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: input=%s expected=%s got=%s\n", i+1, s, want, got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed.")
+}

--- a/1000-1999/1700-1799/1750-1759/1758/verifierB.go
+++ b/1000-1999/1700-1799/1750-1759/1758/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func generateTests() []int {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]int, 100)
+	for i := range tests {
+		tests[i] = r.Intn(20) + 1
+	}
+	return tests
+}
+
+func solve(n int) []int {
+	if n == 1 {
+		return []int{69}
+	}
+	if n == 2 {
+		return []int{1, 3}
+	}
+	if n%2 == 1 {
+		ans := make([]int, n)
+		for i := range ans {
+			ans[i] = 7
+		}
+		return ans
+	}
+	ans := make([]int, n)
+	for i := 0; i < n-3; i++ {
+		ans[i] = 2
+	}
+	ans[n-3] = 1
+	ans[n-2] = 2
+	ans[n-1] = 3
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, n := range tests {
+		fmt.Fprintln(&input, n)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = &input
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "execution failed: %v\n", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(&out)
+	for i, n := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "missing output for test case %d\n", i+1)
+			os.Exit(1)
+		}
+		line := strings.TrimSpace(scanner.Text())
+		parts := strings.Fields(line)
+		if len(parts) != n {
+			fmt.Fprintf(os.Stderr, "wrong number of integers on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got := make([]int, n)
+		for j, p := range parts {
+			v, err := strconv.Atoi(p)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid integer in output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			got[j] = v
+		}
+		want := solve(n)
+		for j := 0; j < n; j++ {
+			if got[j] != want[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed.")
+}

--- a/1000-1999/1700-1799/1750-1759/1758/verifierC.go
+++ b/1000-1999/1700-1799/1750-1759/1758/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func generateTests() [][2]int {
+	r := rand.New(rand.NewSource(3))
+	tests := make([][2]int, 100)
+	for i := range tests {
+		n := r.Intn(20) + 2
+		x := r.Intn(n-1) + 2
+		tests[i] = [2]int{n, x}
+	}
+	return tests
+}
+
+func buildFunnyPerm(n, x int) []int {
+	if n%x != 0 {
+		return nil
+	}
+	p := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = i
+	}
+	p[1] = x
+	p[n] = 1
+	cur := x
+	for i := x + 1; i < n; i++ {
+		if i%cur == 0 && n%i == 0 {
+			p[cur], p[i] = p[i], p[cur]
+			cur = i
+		}
+	}
+	if cur != n {
+		p[cur] = n
+	}
+	return p[1:]
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc[0], tc[1])
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = &input
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "execution failed: %v\n", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(&out)
+	for i, tc := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "missing output for test case %d\n", i+1)
+			os.Exit(1)
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "-1" {
+			if buildFunnyPerm(tc[0], tc[1]) != nil {
+				fmt.Fprintf(os.Stderr, "unexpected -1 on test %d\n", i+1)
+				os.Exit(1)
+			}
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != tc[0] {
+			fmt.Fprintf(os.Stderr, "wrong length on test %d\n", i+1)
+			os.Exit(1)
+		}
+		want := buildFunnyPerm(tc[0], tc[1])
+		if want == nil {
+			fmt.Fprintf(os.Stderr, "expected -1 on test %d\n", i+1)
+			os.Exit(1)
+		}
+		for j, p := range parts {
+			v, err := strconv.Atoi(p)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid integer on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if v != want[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed.")
+}

--- a/1000-1999/1700-1799/1750-1759/1758/verifierD.go
+++ b/1000-1999/1700-1799/1750-1759/1758/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func generateTests() []int {
+	r := rand.New(rand.NewSource(4))
+	tests := make([]int, 100)
+	for i := range tests {
+		tests[i] = r.Intn(20) + 2
+	}
+	return tests
+}
+
+func solveOne(n int) []int64 {
+	nn := int64(n)
+	for sq := nn + 100; ; sq++ {
+		mx := sq + 1
+		ans := make([]int64, n)
+		var sum int64
+		for i := 0; i < n; i++ {
+			if i == n-1 {
+				ans[i] = mx
+			} else {
+				ans[i] = int64(i + 1)
+			}
+			sum += ans[i]
+		}
+		rem := sq*sq - sum
+		inc := rem / nn
+		mod := rem % nn
+		if mod > nn-2 {
+			continue
+		}
+		for i := n - 1; i >= 0; i-- {
+			ans[i] += inc
+			if i > 0 && i+1 < n && mod > 0 {
+				mod--
+				ans[i]++
+			}
+		}
+		return ans
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, n := range tests {
+		fmt.Fprintln(&input, n)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = &input
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "execution failed: %v\n", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(&out)
+	for i, n := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		line := strings.TrimSpace(scanner.Text())
+		parts := strings.Fields(line)
+		if len(parts) != n {
+			fmt.Fprintf(os.Stderr, "wrong length on test %d\n", i+1)
+			os.Exit(1)
+		}
+		want := solveOne(n)
+		for j, p := range parts {
+			v, err := strconv.ParseInt(p, 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid integer on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if v != want[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed.")
+}

--- a/1000-1999/1700-1799/1750-1759/1758/verifierE.go
+++ b/1000-1999/1700-1799/1750-1759/1758/verifierE.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const MOD int64 = 1_000_000_007
+
+type DSU struct {
+	parent []int
+	diff   []int64
+	mod    int64
+}
+
+func NewDSU(n int, mod int64) *DSU {
+	parent := make([]int, n)
+	diff := make([]int64, n)
+	for i := 0; i < n; i++ {
+		parent[i] = i
+	}
+	return &DSU{parent: parent, diff: diff, mod: mod}
+}
+
+func (d *DSU) find(x int) (int, int64) {
+	if d.parent[x] == x {
+		return x, 0
+	}
+	r, w := d.find(d.parent[x])
+	d.diff[x] = (d.diff[x] + w) % d.mod
+	d.parent[x] = r
+	return r, d.diff[x]
+}
+
+func (d *DSU) unite(x, y int, val int64) bool {
+	rx, dx := d.find(x)
+	ry, dy := d.find(y)
+	if rx == ry {
+		if (dx-dy-val)%d.mod != 0 {
+			return false
+		}
+		return true
+	}
+	d.parent[rx] = ry
+	d.diff[rx] = ((val-dx+dy)%d.mod + d.mod) % d.mod
+	return true
+}
+
+func powMod(a, b, mod int64) int64 {
+	res := int64(1)
+	a %= mod
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func generateTests() []struct {
+	n, m int
+	h    int64
+	grid [][]int64
+} {
+	r := rand.New(rand.NewSource(5))
+	tests := make([]struct {
+		n, m int
+		h    int64
+		grid [][]int64
+	}, 100)
+	for idx := range tests {
+		n := r.Intn(3) + 1
+		m := r.Intn(3) + 1
+		h := int64(r.Intn(5) + 2)
+		grid := make([][]int64, n)
+		for i := 0; i < n; i++ {
+			row := make([]int64, m)
+			for j := 0; j < m; j++ {
+				if r.Intn(3) == 0 {
+					row[j] = -1
+				} else {
+					row[j] = int64(r.Intn(int(h)))
+				}
+			}
+			grid[i] = row
+		}
+		tests[idx] = struct {
+			n, m int
+			h    int64
+			grid [][]int64
+		}{n, m, h, grid}
+	}
+	return tests
+}
+
+func solve(t struct {
+	n, m int
+	h    int64
+	grid [][]int64
+}) int64 {
+	n, m, h := t.n, t.m, t.h
+	dsu := NewDSU(n+m, h)
+	ok := true
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			x := t.grid[i][j]
+			if x != -1 {
+				if !dsu.unite(i, n+j, x%h) {
+					ok = false
+				}
+			}
+		}
+	}
+	if !ok {
+		return 0
+	}
+	comp := 0
+	for i := 0; i < n+m; i++ {
+		r, _ := dsu.find(i)
+		if r == i {
+			comp++
+		}
+	}
+	return powMod(h, int64(comp-1), MOD)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tcase := range tests {
+		fmt.Fprintf(&input, "%d %d %d\n", tcase.n, tcase.m, tcase.h)
+		for i := 0; i < tcase.n; i++ {
+			for j := 0; j < tcase.m; j++ {
+				if j > 0 {
+					input.WriteByte(' ')
+				}
+				fmt.Fprint(&input, tcase.grid[i][j])
+			}
+			input.WriteByte('\n')
+		}
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = &input
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "execution failed: %v\n", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(&out)
+	for i, tc := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		gotLine := strings.TrimSpace(scanner.Text())
+		got, err := strconv.ParseInt(gotLine, 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid integer on test %d\n", i+1)
+			os.Exit(1)
+		}
+		want := solve(tc)
+		if got != want {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed.")
+}

--- a/1000-1999/1700-1799/1750-1759/1758/verifierF.go
+++ b/1000-1999/1700-1799/1750-1759/1758/verifierF.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+func generateInput() []byte {
+	r := rand.New(rand.NewSource(6))
+	n := 100
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintln(&buf, r.Intn(20)+1)
+	}
+	return buf.Bytes()
+}
+
+func run(bin string, args []string, input []byte) ([]byte, error) {
+	cmd := exec.Command(bin, args...)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	input := generateInput()
+
+	// Run candidate binary
+	candOut, err := run(bin, nil, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "execution failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Run reference solution using go run
+	refPath := "1000-1999/1700-1799/1750-1759/1758/1758F.go"
+	refOut, err := run("go", []string{"run", refPath}, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reference execution failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	if !bytes.Equal(bytes.TrimSpace(candOut), bytes.TrimSpace(refOut)) {
+		fmt.Fprintln(os.Stderr, "output mismatch")
+		os.Exit(1)
+	}
+	fmt.Println("All test cases passed.")
+}


### PR DESCRIPTION
## Summary
- add verifiers for problems A–F of contest 1758
- each verifier generates 100 test cases and checks an arbitrary binary
- F verifier compares output with the official Go solution

## Testing
- `go build 1000-1999/1700-1799/1750-1759/1758/verifierA.go`
- `go build 1000-1999/1700-1799/1750-1759/1758/verifierB.go`
- `go build 1000-1999/1700-1799/1750-1759/1758/verifierC.go`
- `go build 1000-1999/1700-1799/1750-1759/1758/verifierD.go`
- `go build 1000-1999/1700-1799/1750-1759/1758/verifierE.go`
- `go build 1000-1999/1700-1799/1750-1759/1758/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68875b53a7408324aedd6e8578cb4971