### PR TITLE
Add solution verifiers for contest 1759

### DIFF
--- a/1000-1999/1700-1799/1750-1759/1759/verifierA.go
+++ b/1000-1999/1700-1799/1750-1759/1759/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(s string) string {
+	pattern := "Yes"
+	for start := 0; start < 3; start++ {
+		good := true
+		for i := 0; i < len(s); i++ {
+			if s[i] != pattern[(start+i)%3] {
+				good = false
+				break
+			}
+		}
+		if good {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	s := string(b)
+	ans := solveCase(s)
+	input := fmt.Sprintf("1\n%s\n", s)
+	return input, ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1750-1759/1759/verifierB.go
+++ b/1000-1999/1700-1799/1750-1759/1759/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(m, s int, b []int) string {
+	sumB := 0
+	maxB := 0
+	used := map[int]bool{}
+	for _, x := range b {
+		sumB += x
+		if x > maxB {
+			maxB = x
+		}
+		used[x] = true
+	}
+	total := sumB + s
+	nSum := 0
+	n := 0
+	for nSum < total {
+		n++
+		nSum += n
+	}
+	if nSum == total && maxB <= n {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	m := rng.Intn(10) + 1
+	s := rng.Intn(100) + 1
+	arr := make([]int, m)
+	used := map[int]bool{}
+	for i := 0; i < m; i++ {
+		for {
+			v := rng.Intn(50) + 1
+			if !used[v] {
+				used[v] = true
+				arr[i] = v
+				break
+			}
+		}
+	}
+	ans := solveCase(m, s, arr)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", m, s))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	return sb.String(), ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1750-1759/1759/verifierC.go
+++ b/1000-1999/1700-1799/1750-1759/1759/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solveCase(l, r, x, a, b int) int {
+	if a == b {
+		return 0
+	} else if abs(a-b) >= x {
+		return 1
+	} else if abs(b-l) < x && abs(b-r) < x {
+		return -1
+	} else if abs(a-l) >= x && abs(b-l) >= x {
+		return 2
+	} else if abs(a-r) >= x && abs(b-r) >= x {
+		return 2
+	} else if abs(r-l) >= x && ((abs(a-l) >= x && abs(r-b) >= x) || (abs(a-r) >= x && abs(l-b) >= x)) {
+		return 3
+	}
+	return -1
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l := rng.Intn(21) - 10
+	r := l + rng.Intn(21)
+	x := rng.Intn(int(math.Max(float64(r-l), 1))) + 1
+	a := l + rng.Intn(r-l+1)
+	b := l + rng.Intn(r-l+1)
+	ans := solveCase(l, r, x, a, b)
+	input := fmt.Sprintf("1\n%d %d %d\n%d %d\n", l, r, x, a, b)
+	return input, fmt.Sprint(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1750-1759/1759/verifierD.go
+++ b/1000-1999/1700-1799/1750-1759/1759/verifierD.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, m int64) int64 {
+	k := int64(1)
+	cnt2, cnt5 := 0, 0
+	tmp := n
+	for tmp%2 == 0 {
+		cnt2++
+		tmp /= 2
+	}
+	for tmp%5 == 0 {
+		cnt5++
+		tmp /= 5
+	}
+	for k*2 <= m && cnt2 < cnt5 {
+		k *= 2
+		cnt2++
+	}
+	for k*5 <= m && cnt5 < cnt2 {
+		k *= 5
+		cnt5++
+	}
+	for k*10 <= m {
+		k *= 10
+	}
+	k *= m / k
+	return n * k
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(1000) + 1)
+	m := int64(rng.Intn(1000) + 1)
+	ans := solveCase(n, m)
+	input := fmt.Sprintf("1\n%d %d\n", n, m)
+	return input, fmt.Sprint(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1750-1759/1759/verifierE.go
+++ b/1000-1999/1700-1799/1750-1759/1759/verifierE.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func absorb(order []int64, a []int64, h int64) int {
+	idx := 0
+	n := len(a)
+	for _, m := range order {
+		for idx < n && a[idx] < h {
+			h += a[idx] / 2
+			idx++
+		}
+		h *= m
+	}
+	for idx < n && a[idx] < h {
+		h += a[idx] / 2
+		idx++
+	}
+	return idx
+}
+
+func solveCase(arr []int64, h int64) int {
+	orders := [][]int64{{2, 2, 3}, {2, 3, 2}, {3, 2, 2}}
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	best := 0
+	for _, ord := range orders {
+		if res := absorb(ord, arr, h); res > best {
+			best = res
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	h := int64(rng.Intn(20) + 1)
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rng.Intn(20) + 1)
+	}
+	ans := solveCase(append([]int64(nil), arr...), h)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, h))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	return sb.String(), fmt.Sprint(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1750-1759/1759/verifierF.go
+++ b/1000-1999/1700-1799/1750-1759/1759/verifierF.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveOne(n int, p int, a []int) int {
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = a[n-1-i]
+	}
+	arr0 := arr[0]
+	union := map[int]bool{}
+	earliest := map[int]int{}
+	for _, d := range arr {
+		union[d] = true
+		earliest[d] = 0
+	}
+	prefix := p - arr0
+	if arr0 != 0 && prefix <= p-1 {
+		carry := 1
+		i := 1
+		for {
+			if i < n {
+				newd := (arr[i] + carry) % p
+				t := prefix
+				jlsd := (newd - arr0) % p
+				if jlsd < 0 {
+					jlsd += p
+				}
+				if jlsd < t {
+					t = jlsd
+				}
+				if old, ok := earliest[newd]; !ok || t < old {
+					earliest[newd] = t
+				}
+				union[newd] = true
+				if arr[i]+carry >= p {
+					carry = 1
+					i++
+					continue
+				} else {
+					break
+				}
+			} else {
+				newd := carry
+				t := prefix
+				jlsd := (newd - arr0) % p
+				if jlsd < 0 {
+					jlsd += p
+				}
+				if jlsd < t {
+					t = jlsd
+				}
+				if old, ok := earliest[newd]; !ok || t < old {
+					earliest[newd] = t
+				}
+				union[newd] = true
+				break
+			}
+		}
+	}
+	jSet := map[int]bool{}
+	for d := range union {
+		j := (d - arr0) % p
+		if j < 0 {
+			j += p
+		}
+		jSet[j] = true
+	}
+	j := p - 1
+	for ; j >= 0; j-- {
+		if !jSet[j] {
+			break
+		}
+	}
+	tMissing := 0
+	if j >= 0 {
+		tMissing = j
+	}
+	tUnion := 0
+	for _, v := range earliest {
+		if v > tUnion {
+			tUnion = v
+		}
+	}
+	if tUnion > tMissing {
+		return tUnion
+	}
+	return tMissing
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	p := rng.Intn(20) + 2
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(p)
+	}
+	ans := solveOne(n, p, arr)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, p))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	return sb.String(), fmt.Sprint(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1750-1759/1759/verifierG.go
+++ b/1000-1999/1700-1799/1750-1759/1759/verifierG.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, b []int) (string, bool) {
+	m := n / 2
+	used := make([]bool, n+1)
+	for _, v := range b {
+		if v < 1 || v > n || used[v] {
+			return "", false
+		}
+		used[v] = true
+	}
+	avail := make([]int, 0, m)
+	for i := 1; i <= n; i++ {
+		if !used[i] {
+			avail = append(avail, i)
+		}
+	}
+	parent := make([]int, len(avail))
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if x < 0 {
+			return -1
+		}
+		if parent[x] == x {
+			return x
+		}
+		parent[x] = find(parent[x])
+		return parent[x]
+	}
+	remove := func(x int) { parent[x] = find(x - 1) }
+	res := make([]int, n)
+	for i := m - 1; i >= 0; i-- {
+		idx := sort.SearchInts(avail, b[i]) - 1
+		idx = find(idx)
+		if idx < 0 {
+			return "", false
+		}
+		res[2*i] = avail[idx]
+		res[2*i+1] = b[i]
+		remove(idx)
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(res[i]))
+	}
+	return sb.String(), true
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := (rng.Intn(5) + 1) * 2
+	m := n / 2
+	used := map[int]bool{}
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		for {
+			v := rng.Intn(n) + 1
+			if !used[v] {
+				used[v] = true
+				b[i] = v
+				break
+			}
+		}
+	}
+	out, ok := solveCase(n, b)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	if !ok {
+		return sb.String(), "-1"
+	}
+	return sb.String(), out
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go solution verifiers for contest 1759 problems A–G
- each verifier generates 100 random test cases and checks a target binary

## Testing
- `go build 1000-1999/1700-1799/1750-1759/1759/verifierA.go`
- `go build 1000-1999/1700-1799/1750-1759/1759/verifierB.go`
- `go build 1000-1999/1700-1799/1750-1759/1759/verifierC.go`
- `go build 1000-1999/1700-1799/1750-1759/1759/verifierD.go`
- `go build 1000-1999/1700-1799/1750-1759/1759/verifierE.go`
- `go build 1000-1999/1700-1799/1750-1759/1759/verifierF.go`
- `go build 1000-1999/1700-1799/1750-1759/1759/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68875b99c65883249051632cdd588a41