### PR TITLE
Add Go verifiers for contest 1762

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1762/verifierA.go
+++ b/1000-1999/1700-1799/1760-1769/1762/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedA(arr []int) int {
+	sum := 0
+	for _, v := range arr {
+		sum += v
+	}
+	if sum%2 == 0 {
+		return 0
+	}
+	minOps := 1 << 30
+	for _, x := range arr {
+		cnt := 0
+		y := x
+		if y%2 == 0 {
+			for y%2 == 0 {
+				y /= 2
+				cnt++
+			}
+		} else {
+			for y%2 == 1 {
+				y /= 2
+				cnt++
+			}
+		}
+		if cnt < minOps {
+			minOps = cnt
+		}
+	}
+	return minOps
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTestA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(1000000) + 1
+	}
+	exp := expectedA(arr)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), fmt.Sprintf("%d", exp)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := genTestA(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1700-1799/1760-1769/1762/verifierB.go
+++ b/1000-1999/1700-1799/1760-1769/1762/verifierB.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testB struct {
+	n   int
+	arr []int64
+}
+
+func genTestB(rng *rand.Rand) testB {
+	n := rng.Intn(10) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Int63n(1000) + 1
+	}
+	return testB{n: n, arr: arr}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isGood(arr []int64) bool {
+	n := len(arr)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			a := arr[i]
+			b := arr[j]
+			if a == 0 || b == 0 {
+				return false
+			}
+			x := a
+			y := b
+			if x < y {
+				x, y = y, x
+			}
+			if x%y != 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func verifyOutput(out string, tc testB) error {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return fmt.Errorf("empty output")
+	}
+	p, err := strconv.Atoi(fields[0])
+	if err != nil || p < 0 || p > tc.n {
+		return fmt.Errorf("invalid p")
+	}
+	if len(fields) != 1+2*p {
+		return fmt.Errorf("expected %d numbers, got %d", 1+2*p, len(fields))
+	}
+	arr := make([]int64, len(tc.arr))
+	copy(arr, tc.arr)
+	idx := 1
+	for op := 0; op < p; op++ {
+		iVal, err1 := strconv.Atoi(fields[idx])
+		xVal, err2 := strconv.ParseInt(fields[idx+1], 10, 64)
+		if err1 != nil || err2 != nil || iVal < 1 || iVal > tc.n || xVal < 0 {
+			return fmt.Errorf("invalid operation")
+		}
+		idx += 2
+		arr[iVal-1] += xVal
+		if arr[iVal-1] > 1e18 {
+			return fmt.Errorf("value exceeds limit")
+		}
+	}
+	if !isGood(arr) {
+		return fmt.Errorf("final array not good")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		tc := genTestB(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for i, v := range tc.arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", t+1, err, out)
+			os.Exit(1)
+		}
+		if err := verifyOutput(out, tc); err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%soutput:\n%s\n", t+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1700-1799/1760-1769/1762/verifierC.go
+++ b/1000-1999/1700-1799/1760-1769/1762/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func expectedC(s string) int64 {
+	same, large := int64(1), int64(0)
+	ans := int64(1)
+	for i := 1; i < len(s); i++ {
+		if s[i] == s[i-1] {
+			newSame := same
+			newLarge := (same + 2*large) % mod
+			same = newSame % mod
+			large = newLarge
+		} else {
+			same = same % mod
+			large = 0
+		}
+		ans = (ans + same + large) % mod
+	}
+	return ans % mod
+}
+
+func genTestC(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	s := sb.String()
+	exp := expectedC(s)
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	return input, fmt.Sprintf("%d", exp)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := genTestC(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", t+1, err, got)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1700-1799/1760-1769/1762/verifierD.go
+++ b/1000-1999/1700-1799/1760-1769/1762/verifierD.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedD(arr []int) int {
+	pos := 1
+	for i, v := range arr {
+		if v == 0 {
+			pos = i + 1
+		}
+	}
+	return pos
+}
+
+func genTestD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(5) == 0 {
+			arr[i] = 0
+		} else {
+			arr[i] = rng.Intn(100) + 1
+		}
+	}
+	exp := expectedD(arr)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), fmt.Sprintf("%d %d", exp, exp)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := genTestD(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", t+1, err, got)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1700-1799/1760-1769/1762/verifierE.go
+++ b/1000-1999/1700-1799/1760-1769/1762/verifierE.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func modPow(a, e int64) int64 {
+	a %= mod
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func expectedE(n int) int64 {
+	if n%2 == 1 {
+		return 0
+	}
+	fac := make([]int64, n+1)
+	ifac := make([]int64, n+1)
+	fac[0] = 1
+	for i := 1; i <= n; i++ {
+		fac[i] = fac[i-1] * int64(i) % mod
+	}
+	ifac[n] = modPow(fac[n], mod-2)
+	for i := n; i >= 1; i-- {
+		ifac[i-1] = ifac[i] * int64(i) % mod
+	}
+	ans := int64(0)
+	for s := 1; s <= n-1; s++ {
+		comb := fac[n-2]
+		comb = comb * ifac[s-1] % mod
+		comb = comb * ifac[n-1-s] % mod
+		term := comb
+		term = term * modPow(int64(s), int64(s-1)) % mod
+		term = term * modPow(int64(n-s), int64(n-s-1)) % mod
+		if s%2 == 1 {
+			ans = (ans - term) % mod
+		} else {
+			ans = (ans + term) % mod
+		}
+	}
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+func genTestE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	exp := expectedE(n)
+	input := fmt.Sprintf("%d\n", n)
+	return input, fmt.Sprintf("%d", exp)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := genTestE(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", t+1, err, got)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1700-1799/1760-1769/1762/verifierF.go
+++ b/1000-1999/1700-1799/1760-1769/1762/verifierF.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	refBin := "./1762F_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "1762F.go").Run(); err != nil {
+		return "", err
+	}
+	return refBin, nil
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testF struct {
+	n   int
+	k   int
+	arr []int
+}
+
+func genTestF(rng *rand.Rand) testF {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(10)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100000) + 1
+	}
+	return testF{n: n, k: k, arr: arr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	userBin := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		tc := genTestF(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+		for i, v := range tc.arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", t+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1700-1799/1760-1769/1762/verifierG.go
+++ b/1000-1999/1700-1799/1760-1769/1762/verifierG.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	refBin := "./1762G_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "1762G.go").Run(); err != nil {
+		return "", err
+	}
+	return refBin, nil
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testG struct {
+	n   int
+	arr []int
+}
+
+func genTestG(rng *rand.Rand) testG {
+	n := rng.Intn(8) + 3
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n) + 1
+	}
+	return testG{n: n, arr: arr}
+}
+
+func parseOutput(out string, tc testG, expectYes bool) error {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return fmt.Errorf("empty output")
+	}
+	first := strings.ToUpper(fields[0])
+	if first == "NO" {
+		if expectYes {
+			return fmt.Errorf("expected YES got NO")
+		}
+		return nil
+	}
+	if first != "YES" {
+		return fmt.Errorf("first token should be YES or NO")
+	}
+	if !expectYes {
+		return fmt.Errorf("expected NO got YES")
+	}
+	if len(fields) != 1+tc.n {
+		return fmt.Errorf("expected %d numbers, got %d", tc.n, len(fields)-1)
+	}
+	perm := make([]int, tc.n)
+	used := make([]bool, tc.n+1)
+	for i := 0; i < tc.n; i++ {
+		v, err := strconv.Atoi(fields[1+i])
+		if err != nil || v < 1 || v > tc.n || used[v] {
+			return fmt.Errorf("invalid permutation")
+		}
+		used[v] = true
+		perm[i] = v
+	}
+	for i := 1; i < tc.n; i++ {
+		if tc.arr[perm[i-1]-1] == tc.arr[perm[i]-1] {
+			return fmt.Errorf("adjacent equal values")
+		}
+	}
+	for i := 2; i < tc.n; i++ {
+		if perm[i-2] >= perm[i] {
+			return fmt.Errorf("order condition failed")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	userBin := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		tc := genTestG(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for i, v := range tc.arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		refOut, err := run(refBin, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		expectYes := strings.HasPrefix(strings.ToUpper(strings.TrimSpace(refOut)), "YES")
+		userOut, err := run(userBin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n%s", t+1, err, userOut)
+			os.Exit(1)
+		}
+		if err := parseOutput(userOut, tc, expectYes); err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%soutput:\n%s\n", t+1, err, input, userOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G of contest 1762
- verifiers generate 100 random tests each
- some verifiers compute expectations directly, others build the provided solutions
- output and runtime checks ensure candidate binaries are validated

## Testing
- `go build 1000-1999/1700-1799/1760-1769/1762/verifierA.go`
- `go build 1000-1999/1700-1799/1760-1769/1762/verifierB.go`
- `go build 1000-1999/1700-1799/1760-1769/1762/verifierC.go`
- `go build 1000-1999/1700-1799/1760-1769/1762/verifierD.go`
- `go build 1000-1999/1700-1799/1760-1769/1762/verifierE.go`
- `go build 1000-1999/1700-1799/1760-1769/1762/verifierF.go`
- `go build 1000-1999/1700-1799/1760-1769/1762/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68875c6c1af883249f26adf65b8f93f2