### PR TITLE
Add verifiers for contest 1763

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1763/verifierA.go
+++ b/1000-1999/1700-1799/1760-1769/1763/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(nums []int) string {
+	orVal := nums[0]
+	andVal := nums[0]
+	for i := 1; i < len(nums); i++ {
+		orVal |= nums[i]
+		andVal &= nums[i]
+	}
+	return fmt.Sprintf("%d", orVal-andVal)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 3
+	nums := make([]int, n)
+	for i := 0; i < n; i++ {
+		nums[i] = rng.Intn(1024)
+	}
+	var input strings.Builder
+	input.WriteString("1\n")
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range nums {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprintf("%d", v))
+	}
+	input.WriteString("\n")
+	return input.String(), expected(nums)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1763/verifierB.go
+++ b/1000-1999/1700-1799/1760-1769/1763/verifierB.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Monster struct {
+	h int64
+	p int64
+}
+
+func expected(n int, k int64, h []int64, p []int64) string {
+	monsters := make([]Monster, n)
+	for i := 0; i < n; i++ {
+		monsters[i] = Monster{h: h[i], p: p[i]}
+	}
+	sort.Slice(monsters, func(i, j int) bool { return monsters[i].h < monsters[j].h })
+	suf := make([]int64, n)
+	suf[n-1] = monsters[n-1].p
+	for i := n - 2; i >= 0; i-- {
+		if monsters[i].p < suf[i+1] {
+			suf[i] = monsters[i].p
+		} else {
+			suf[i] = suf[i+1]
+		}
+	}
+	damage := int64(0)
+	cur := k
+	idx := 0
+	for cur > 0 {
+		damage += cur
+		for idx < n && monsters[idx].h <= damage {
+			idx++
+		}
+		if idx == n {
+			break
+		}
+		cur -= suf[idx]
+	}
+	if idx == n {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	k := int64(rng.Intn(20) + 1)
+	h := make([]int64, n)
+	p := make([]int64, n)
+	for i := 0; i < n; i++ {
+		h[i] = int64(rng.Intn(50) + 1)
+	}
+	for i := 0; i < n; i++ {
+		p[i] = int64(rng.Intn(20) + 1)
+	}
+	var input strings.Builder
+	input.WriteString("1\n")
+	input.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprintf("%d", h[i]))
+	}
+	input.WriteString("\n")
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprintf("%d", p[i]))
+	}
+	input.WriteString("\n")
+	return input.String(), expected(n, k, h, p)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1763/verifierC.go
+++ b/1000-1999/1700-1799/1760-1769/1763/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func absInt64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func expected(n int, a []int64) string {
+	if n == 2 {
+		return fmt.Sprintf("%d", 2*absInt64(a[0]-a[1]))
+	}
+	if n == 3 {
+		maxVal, minVal := a[0], a[0]
+		for i := 1; i < 3; i++ {
+			if a[i] > maxVal {
+				maxVal = a[i]
+			}
+			if a[i] < minVal {
+				minVal = a[i]
+			}
+		}
+		boundaryMax := a[0]
+		if a[2] > boundaryMax {
+			boundaryMax = a[2]
+		}
+		diff := maxVal - minVal
+		v := boundaryMax
+		if diff > v {
+			v = diff
+		}
+		ans := int64(3) * v
+		return fmt.Sprintf("%d", ans)
+	}
+	maxVal := a[0]
+	for i := 1; i < n; i++ {
+		if a[i] > maxVal {
+			maxVal = a[i]
+		}
+	}
+	ans := int64(n) * maxVal
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(30) + 1)
+	}
+	var input strings.Builder
+	input.WriteString("1\n")
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprintf("%d", v))
+	}
+	input.WriteString("\n")
+	return input.String(), expected(n, arr)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1763/verifierD.go
+++ b/1000-1999/1700-1799/1760-1769/1763/verifierD.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1_000_000_007
+
+var fact [105]int64
+var invFact [105]int64
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func init() {
+	fact[0] = 1
+	for i := 1; i < len(fact); i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	invFact[len(fact)-1] = modPow(fact[len(fact)-1], MOD-2)
+	for i := len(fact) - 1; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % MOD
+	}
+}
+
+func comb(n, k int) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	return fact[n] * invFact[k] % MOD * invFact[n-k] % MOD
+}
+
+func solveOne(n, i, j, x, y int) int64 {
+	ans := int64(0)
+	for k := 2; k <= n-1; k++ {
+		if x == n && i != k {
+			continue
+		}
+		if y == n && j != k {
+			continue
+		}
+		if i == k && x != n {
+			continue
+		}
+		if j == k && y != n {
+			continue
+		}
+		var posX, posY byte
+		if i == k {
+			posX = 'P'
+		} else if i < k {
+			posX = 'L'
+		} else {
+			posX = 'R'
+		}
+		if j == k {
+			posY = 'P'
+		} else if j < k {
+			posY = 'L'
+		} else {
+			posY = 'R'
+		}
+		L := k - 1
+		switch {
+		case posX == 'L' && posY == 'L':
+			if x >= n || y >= n || x >= y || j > k-1 {
+				continue
+			}
+			a := x - 1
+			b := y - x - 1
+			c := n - 1 - y
+			if a < i-1 || b < j-i-1 || c < L-j {
+				continue
+			}
+			val := comb(a, i-1) * comb(b, j-i-1) % MOD * comb(c, L-j) % MOD
+			ans = (ans + val) % MOD
+		case posX == 'L' && posY == 'P':
+			if x >= n || j != k || y != n || L < i {
+				continue
+			}
+			a := x - 1
+			b := n - 1 - x
+			if a < i-1 || b < L-i {
+				continue
+			}
+			val := comb(a, i-1) * comb(b, L-i) % MOD
+			ans = (ans + val) % MOD
+		case posX == 'L' && posY == 'R':
+			if x >= n || y >= n || L < i || j <= k {
+				continue
+			}
+			p := L - i
+			if x < y {
+				a := x - 1
+				b := y - x - 1
+				c := n - 1 - y
+				s := n - y - j + k
+				if s < 0 || s > p || s > c || p-s > b || i-1 > a {
+					continue
+				}
+				val := comb(a, i-1) * comb(b, p-s) % MOD * comb(c, s) % MOD
+				ans = (ans + val) % MOD
+			} else if x > y {
+				a := y - 1
+				b := x - y - 1
+				c := n - 1 - x
+				r := n - j - y + i
+				if r < 0 || r > b || r > i-1 || i-1-r > a || p > c {
+					continue
+				}
+				val := comb(a, i-1-r) * comb(b, r) % MOD * comb(c, p) % MOD
+				ans = (ans + val) % MOD
+			}
+		case posX == 'P' && posY == 'R':
+			if x != n || j <= k {
+				continue
+			}
+			a := y - 1
+			b := n - 1 - y
+			aa := a - (n - j)
+			bb := b - (j - k - 1)
+			if aa < 0 || aa > a || bb < 0 || bb > b || aa+bb != L {
+				continue
+			}
+			val := comb(a, aa) * comb(b, bb) % MOD
+			ans = (ans + val) % MOD
+		case posX == 'R' && posY == 'R':
+			if x >= n || y >= n || k >= i || i >= j || x <= y {
+				continue
+			}
+			a := y - 1
+			b := x - y - 1
+			c := n - 1 - x
+			aa := a - (n - j)
+			bb := b - (j - i - 1)
+			cc := c - (i - k - 1)
+			if aa < 0 || aa > a || bb < 0 || bb > b || cc < 0 || cc > c || aa+bb+cc != L {
+				continue
+			}
+			val := comb(a, aa) * comb(b, bb) % MOD * comb(c, cc) % MOD
+			ans = (ans + val) % MOD
+		}
+	}
+	return ans % MOD
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 3
+	i := rng.Intn(n-2) + 1
+	j := rng.Intn(n-i-1) + i + 1
+	x := rng.Intn(n) + 1
+	y := rng.Intn(n) + 1
+	for y == x {
+		y = rng.Intn(n) + 1
+	}
+	var input strings.Builder
+	input.WriteString("1\n")
+	input.WriteString(fmt.Sprintf("%d %d %d %d %d\n", n, i, j, x, y))
+	ans := solveOne(n, i, j, x, y)
+	return input.String(), fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1763/verifierE.go
+++ b/1000-1999/1700-1799/1760-1769/1763/verifierE.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(p int) string {
+	const INF int = 1 << 30
+	dp := make([]int, p+1)
+	for i := 1; i <= p; i++ {
+		dp[i] = INF
+	}
+	for s := 2; ; s++ {
+		t := s * (s - 1) / 2
+		if t > p {
+			break
+		}
+		for j := t; j <= p; j++ {
+			if v := dp[j-t] + s; v < dp[j] {
+				dp[j] = v
+			}
+		}
+	}
+	n := dp[p]
+	unidir := n*(n-1)/2 - p
+	return fmt.Sprintf("%d %d", n, unidir)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	p := rng.Intn(50)
+	input := fmt.Sprintf("%d\n", p)
+	return input, expected(p)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1763/verifierF.go
+++ b/1000-1999/1700-1799/1760-1769/1763/verifierF.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ u, v int }
+
+func key(u, v int) pair {
+	if u > v {
+		u, v = v, u
+	}
+	return pair{u, v}
+}
+
+func edgesOnPaths(n int, edges []pair, a, b int) map[pair]bool {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	res := map[pair]bool{}
+	visited := make([]bool, n+1)
+	var dfs func(int, []pair)
+	dfs = func(u int, path []pair) {
+		if u == b {
+			for _, e := range path {
+				res[e] = true
+			}
+			return
+		}
+		visited[u] = true
+		for _, v := range adj[u] {
+			if !visited[v] {
+				dfs(v, append(path, key(u, v)))
+			}
+		}
+		visited[u] = false
+	}
+	dfs(a, nil)
+	return res
+}
+
+func reachable(n int, edges []pair, a, b int, rem pair) bool {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		if e == rem {
+			continue
+		}
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	q := []int{a}
+	vis := make([]bool, n+1)
+	vis[a] = true
+	for len(q) > 0 {
+		u := q[0]
+		q = q[1:]
+		if u == b {
+			return true
+		}
+		for _, v := range adj[u] {
+			if !vis[v] {
+				vis[v] = true
+				q = append(q, v)
+			}
+		}
+	}
+	return false
+}
+
+func queryAns(n int, edges []pair, a, b int) int {
+	use := edgesOnPaths(n, edges, a, b)
+	cnt := 0
+	for _, e := range edges {
+		if use[e] && reachable(n, edges, a, b, e) {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func expected(n int, edges []pair, queries [][2]int) string {
+	var sb strings.Builder
+	for i, q := range queries {
+		ans := queryAns(n, edges, q[0], q[1])
+		sb.WriteString(fmt.Sprintf("%d", ans))
+		if i+1 < len(queries) {
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-(n-1)+1) + (n - 1)
+	edgesMap := map[pair]bool{}
+	edges := make([]pair, 0, m)
+	// ensure connected by building a tree first
+	for i := 2; i <= n; i++ {
+		v := rng.Intn(i-1) + 1
+		p := key(i, v)
+		edges = append(edges, p)
+		edgesMap[p] = true
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		p := key(u, v)
+		if edgesMap[p] {
+			continue
+		}
+		edgesMap[p] = true
+		edges = append(edges, p)
+	}
+	q := rng.Intn(5) + 1
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		queries[i] = [2]int{a, b}
+	}
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		input.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	input.WriteString(fmt.Sprintf("%d\n", q))
+	for _, qu := range queries {
+		input.WriteString(fmt.Sprintf("%d %d\n", qu[0], qu[1]))
+	}
+	return input.String(), expected(n, edges, queries)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go solution verifiers for all six problems in contest 1763
- each verifier generates 100 random test cases and checks the given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68875cb1ea6c8324a2c69b366ee5947f