### PR TITLE
Add verifiers for contest 1766

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1766/verifierA.go
+++ b/1000-1999/1700-1799/1760-1769/1766/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveA(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return ""
+	}
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		var n int
+		fmt.Fscan(in, &n)
+		pow := 1
+		for pow*10 <= n {
+			pow *= 10
+		}
+		digits := 0
+		for tmp := n; tmp > 0; tmp /= 10 {
+			digits++
+		}
+		ans := 9*(digits-1) + n/pow
+		fmt.Fprintf(&out, "%d\n", ans)
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func genTestA(rng *rand.Rand) string {
+	t := rng.Intn(10) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(999999) + 1
+		fmt.Fprintf(&buf, "%d\n", n)
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestA(rng)
+		expect := solveA(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1766/verifierB.go
+++ b/1000-1999/1700-1799/1760-1769/1766/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveB(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return ""
+	}
+	var out strings.Builder
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(in, &n, &s)
+		seen := make(map[string]int)
+		found := false
+		for i := 0; i < n-1 && !found; i++ {
+			pair := s[i : i+2]
+			if first, ok := seen[pair]; ok {
+				if i-first >= 2 {
+					found = true
+				}
+			} else {
+				seen[pair] = i
+			}
+		}
+		if found {
+			fmt.Fprintln(&out, "YES")
+		} else {
+			fmt.Fprintln(&out, "NO")
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func genTestB(rng *rand.Rand) string {
+	t := rng.Intn(10) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(20) + 2
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		fmt.Fprintf(&buf, "%d %s\n", n, sb.String())
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestB(rng)
+		expect := solveB(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1766/verifierC.go
+++ b/1000-1999/1700-1799/1760-1769/1766/verifierC.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func check(start int, row0, row1 string) bool {
+	n := len(row0)
+	visited := [2][]bool{make([]bool, n), make([]bool, n)}
+	r := start
+	c := 0
+	for {
+		if r == 0 {
+			if row0[c] != 'B' || visited[0][c] {
+				return false
+			}
+			visited[0][c] = true
+		} else {
+			if row1[c] != 'B' || visited[1][c] {
+				return false
+			}
+			visited[1][c] = true
+		}
+		other := 1 - r
+		if other == 0 {
+			if row0[c] == 'B' && !visited[0][c] {
+				r = other
+				continue
+			}
+		} else {
+			if row1[c] == 'B' && !visited[1][c] {
+				r = other
+				continue
+			}
+		}
+		if c+1 < n {
+			if r == 0 && row0[c+1] == 'B' {
+				c++
+				continue
+			}
+			if r == 1 && row1[c+1] == 'B' {
+				c++
+				continue
+			}
+		}
+		break
+	}
+	for i := 0; i < n; i++ {
+		if row0[i] == 'B' && !visited[0][i] {
+			return false
+		}
+		if row1[i] == 'B' && !visited[1][i] {
+			return false
+		}
+	}
+	return true
+}
+
+func solveCase(row0, row1 string) bool {
+	starts := []int{}
+	if row0[0] == 'B' {
+		starts = append(starts, 0)
+	}
+	if row1[0] == 'B' {
+		starts = append(starts, 1)
+	}
+	for _, st := range starts {
+		if check(st, row0, row1) {
+			return true
+		}
+	}
+	return false
+}
+
+func solveC(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(reader, &t)
+	var out strings.Builder
+	for ; t > 0; t-- {
+		var m int
+		fmt.Fscan(reader, &m)
+		var row0, row1 string
+		fmt.Fscan(reader, &row0)
+		fmt.Fscan(reader, &row1)
+		if solveCase(row0, row1) {
+			fmt.Fprintln(&out, "YES")
+		} else {
+			fmt.Fprintln(&out, "NO")
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func genTestC(rng *rand.Rand) string {
+	t := rng.Intn(10) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d\n", t)
+	for ; t > 0; t-- {
+		m := rng.Intn(20) + 1
+		fmt.Fprintf(&buf, "%d\n", m)
+		var r0, r1 strings.Builder
+		for i := 0; i < m; i++ {
+			if rng.Intn(2) == 0 {
+				r0.WriteByte('B')
+			} else {
+				r0.WriteByte('W')
+			}
+			if rng.Intn(2) == 0 {
+				r1.WriteByte('B')
+			} else {
+				r1.WriteByte('W')
+			}
+			// ensure at least one B per column
+			if r0.Bytes()[i] != 'B' && r1.Bytes()[i] != 'B' {
+				if rng.Intn(2) == 0 {
+					r0.Bytes()[i] = 'B'
+				} else {
+					r1.Bytes()[i] = 'B'
+				}
+			}
+		}
+		fmt.Fprintf(&buf, "%s\n%s\n", r0.String(), r1.String())
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestC(rng)
+		expect := solveC(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1766/verifierD.go
+++ b/1000-1999/1700-1799/1760-1769/1766/verifierD.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const maxA = 10000000
+
+var spf []int
+
+func sieve(n int) {
+	spf = make([]int, n+1)
+	primes := make([]int, 0, 664000)
+	for i := 2; i <= n; i++ {
+		if spf[i] == 0 {
+			spf[i] = i
+			primes = append(primes, i)
+		}
+		for _, p := range primes {
+			if p > spf[i] || p*i > n {
+				break
+			}
+			spf[p*i] = p
+		}
+	}
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveD(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	var out strings.Builder
+	first := true
+	for i := 0; i < n; i++ {
+		var x, y int
+		fmt.Fscan(in, &x, &y)
+		if !first {
+			out.WriteByte(' ')
+		}
+		first = false
+		if gcd(x, y) != 1 {
+			fmt.Fprint(&out, 0)
+			continue
+		}
+		d := y - x
+		if d == 1 {
+			fmt.Fprint(&out, -1)
+			continue
+		}
+		ans := int(1<<31 - 1)
+		tmp := d
+		for tmp > 1 {
+			p := spf[tmp]
+			if p == 0 {
+				p = tmp
+			}
+			if v := p - x%p; v < ans {
+				ans = v
+			}
+			for tmp%p == 0 {
+				tmp /= p
+			}
+		}
+		fmt.Fprint(&out, ans)
+	}
+	return out.String()
+}
+
+func genTestD(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d\n", n)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(10000000-2) + 1
+		y := x + rng.Intn(100) + 1
+		fmt.Fprintf(&buf, "%d %d\n", x, y)
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	sieve(maxA)
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestD(rng)
+		expect := solveD(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1766/verifierE.go
+++ b/1000-1999/1700-1799/1760-1769/1766/verifierE.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const stateCount = 16
+
+var states = [stateCount]int{0, 1, 2, 3, 5, 6, 7, 9, 10, 11, 25, 26, 27, 37, 38, 39}
+var indexMap = map[int]int{}
+var trans [stateCount][4]int
+var inc [stateCount][4]int
+
+func encode(m1, m2, m3 int) int { return m1 | (m2 << 2) | (m3 << 4) }
+
+func appendState(state, x int) (int, int) {
+	m1 := state & 3
+	m2 := (state >> 2) & 3
+	m3 := (state >> 4) & 3
+	if x == 0 {
+		return state, 1
+	}
+	if m1 != 0 && (m1&x) != 0 {
+		m1 = x
+		return encode(m1, m2, m3), 0
+	}
+	if m2 != 0 && (m2&x) != 0 {
+		m2 = x
+		return encode(m1, m2, m3), 0
+	}
+	if m3 != 0 && (m3&x) != 0 {
+		m3 = x
+		return encode(m1, m2, m3), 0
+	}
+	if m1 == 0 {
+		m1 = x
+		return encode(m1, m2, m3), 1
+	}
+	if m2 == 0 {
+		m2 = x
+		return encode(m1, m2, m3), 1
+	}
+	if m3 == 0 {
+		m3 = x
+		return encode(m1, m2, m3), 1
+	}
+	return state, 1
+}
+
+func init() {
+	for i, s := range states {
+		indexMap[s] = i
+	}
+	for i, s := range states {
+		for x := 0; x < 4; x++ {
+			ns, d := appendState(s, x)
+			trans[i][x] = indexMap[ns]
+			inc[i][x] = d
+		}
+	}
+}
+
+func solveE(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &arr[i])
+	}
+	var cnt [stateCount]int64
+	var sum [stateCount]int64
+	var ans int64
+	for _, v := range arr {
+		var nextCnt [stateCount]int64
+		var nextSum [stateCount]int64
+		ns := trans[0][v]
+		d := inc[0][v]
+		nextCnt[ns] += 1
+		nextSum[ns] += int64(d)
+		for i := 0; i < stateCount; i++ {
+			if cnt[i] == 0 {
+				continue
+			}
+			ns := trans[i][v]
+			dd := inc[i][v]
+			nextCnt[ns] += cnt[i]
+			nextSum[ns] += sum[i] + int64(dd)*cnt[i]
+		}
+		var partial int64
+		for i := 0; i < stateCount; i++ {
+			partial += nextSum[i]
+		}
+		ans += partial
+		cnt = nextCnt
+		sum = nextSum
+	}
+	return fmt.Sprint(ans)
+}
+
+func genTestE(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&buf, "%d ", rng.Intn(4))
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestE(rng)
+		expect := solveE(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1766/verifierF.go
+++ b/1000-1999/1700-1799/1760-1769/1766/verifierF.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	maxV = 105
+	maxE = 10000
+	inf  = 0x3f3f3f3f
+)
+
+var (
+	S, T, e int
+	fir     [maxV]int
+	to, nxt [maxE]int
+	w       [maxE]int
+	cost    [maxE]int
+	dis     [maxV]int64
+	q       [maxE]int
+	vis     [maxV]bool
+	cur     [maxV]int
+	fdem    [maxV]int
+	odd     []bool
+	ansEdge []int
+	sumNode []int
+	anss    int64
+)
+
+func adde(x, y, z, cst int) {
+	e++
+	to[e] = y
+	nxt[e] = fir[x]
+	fir[x] = e
+	w[e] = z
+	cost[e] = cst
+	e++
+	to[e] = x
+	nxt[e] = fir[y]
+	fir[y] = e
+	w[e] = 0
+	cost[e] = -cst
+}
+
+func spfa() bool {
+	for i := 1; i <= T; i++ {
+		dis[i] = 1 << 60
+		vis[i] = false
+	}
+	head, tail := 0, 0
+	q[tail] = T
+	dis[T] = 0
+	vis[T] = true
+	tail++
+	for head < tail {
+		u := q[head]
+		head++
+		vis[u] = false
+		for i := fir[u]; i > 0; i = nxt[i] {
+			rev := i ^ 1
+			v := to[i]
+			if w[rev] == 0 {
+				continue
+			}
+			nd := dis[u] + int64(cost[rev])
+			if dis[v] > nd {
+				dis[v] = nd
+				if !vis[v] {
+					vis[v] = true
+					q[tail] = v
+					tail++
+				}
+			}
+		}
+	}
+	return dis[S] < 0
+}
+
+func dfs(u, flow int) int {
+	if u == T || flow == 0 {
+		return flow
+	}
+	vis[u] = true
+	used := flow
+	for i := cur[u]; i > 0; i = nxt[i] {
+		cur[u] = i
+		v := to[i]
+		if vis[v] || dis[v]+int64(cost[i]) != dis[u] || w[i] == 0 {
+			continue
+		}
+		can := flow
+		if w[i] < can {
+			can = w[i]
+		}
+		if can > used {
+			can = used
+		}
+		f := dfs(v, can)
+		if f > 0 {
+			w[i] -= f
+			w[i^1] += f
+			used -= f
+			if used == 0 {
+				break
+			}
+		}
+	}
+	return flow - used
+}
+
+func MCMF() int64 {
+	var flow int
+	var res int64
+	for spfa() {
+		for i := 1; i <= T; i++ {
+			cur[i] = fir[i]
+			vis[i] = false
+		}
+		f := dfs(S, inf)
+		flow += f
+		res += dis[S] * int64(f)
+	}
+	return res
+}
+
+func solveF(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return ""
+	}
+	S, T = 1, n
+	e = 1
+	odd = make([]bool, m+1)
+	ansEdge = make([]int, m+1)
+	sumNode = make([]int, n+2)
+	for i := 1; i <= m; i++ {
+		var x, y, z, t int
+		fmt.Fscan(in, &x, &y, &z, &t)
+		adde(x, y, z>>1, t<<1)
+		if z&1 == 1 {
+			fdem[x]--
+			fdem[y]++
+			odd[i] = true
+			anss += int64(t)
+		}
+	}
+	for i := 2; i < n; i++ {
+		if fdem[i]&1 != 0 {
+			return "Impossible"
+		}
+		if fdem[i] > 0 {
+			adde(S, i, fdem[i]>>1, -inf)
+		} else if fdem[i] < 0 {
+			adde(i, T, (-fdem[i])>>1, -inf)
+		}
+	}
+	anss += MCMF()
+	for i := 1; i <= m; i++ {
+		flowUsed := w[2*i+1]
+		ans := flowUsed << 1
+		if odd[i] {
+			ans |= 1
+		}
+		ansEdge[i] = ans
+		u := to[2*i]
+		v := to[2*i+1]
+		sumNode[u] += ans
+		sumNode[v] -= ans
+	}
+	for i := 2; i < n; i++ {
+		if sumNode[i] != 0 {
+			return "Impossible"
+		}
+	}
+	var buf strings.Builder
+	buf.WriteString("Possible\n")
+	for i := 1; i <= m; i++ {
+		fmt.Fprintf(&buf, "%d ", ansEdge[i])
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func genTestF(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(6) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		x := rng.Intn(n-1) + 1
+		y := rng.Intn(n-x) + x + 1
+		if y > n {
+			y = n
+		}
+		if y == 1 {
+			y = n
+		}
+		c := rng.Intn(5) + 1
+		w := rng.Intn(11) - 5
+		fmt.Fprintf(&buf, "%d %d %d %d\n", x, y, c, w)
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestF(rng)
+		expect := solveF(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers `verifierA.go` through `verifierF.go` for contest 1766
- each verifier generates 100 random tests and checks output against a reference solver

## Testing
- `go build 1000-1999/1700-1799/1760-1769/1766/verifierA.go`
- `go build 1000-1999/1700-1799/1760-1769/1766/verifierB.go`
- `go build 1000-1999/1700-1799/1760-1769/1766/verifierC.go`
- `go build 1000-1999/1700-1799/1760-1769/1766/verifierD.go`
- `go build 1000-1999/1700-1799/1760-1769/1766/verifierE.go`
- `go build 1000-1999/1700-1799/1760-1769/1766/verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68875d83f6e08324b2a8bb33ce7a0bfe