### PR TITLE
Add Go solution verifiers for contest 1768

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1768/verifierA.go
+++ b/1000-1999/1700-1799/1760-1769/1768/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func solve(k int) int { return k - 1 }
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []int{2, 3, 4, 5, 10, 100, 1000000000}
+	for len(tests) < 100 {
+		k := rng.Intn(1_000_000_000-1) + 2
+		tests = append(tests, k)
+	}
+	for i, k := range tests {
+		input := fmt.Sprintf("1\n%d\n", k)
+		expected := solve(k)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != 1 {
+			fmt.Fprintf(os.Stderr, "test %d: expected single integer got %q\n", i+1, out)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(fields[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: cannot parse integer\n", i+1)
+			os.Exit(1)
+		}
+		if val != expected {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %d got %d (k=%d)\n", i+1, expected, val, k)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1768/verifierB.go
+++ b/1000-1999/1700-1799/1760-1769/1768/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func solveB(n, k int, p []int) int {
+	expected := 1
+	for _, v := range p {
+		if v == expected {
+			expected++
+		}
+	}
+	m := expected - 1
+	remaining := n - m
+	if remaining <= 0 {
+		return 0
+	}
+	return (remaining + k - 1) / k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		n, k int
+		p    []int
+	}
+
+	var cases []test
+	// deterministic cases
+	cases = append(cases, test{n: 2, k: 1, p: []int{1, 2}})
+	cases = append(cases, test{n: 3, k: 1, p: []int{2, 1, 3}})
+	cases = append(cases, test{n: 5, k: 2, p: []int{2, 5, 1, 3, 4}})
+
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 2
+		k := rng.Intn(n) + 1
+		perm := rand.Perm(n)
+		for i := range perm {
+			perm[i]++
+		}
+		cases = append(cases, test{n: n, k: k, p: perm})
+	}
+
+	for i, tc := range cases {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+		for j, v := range tc.p {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		expected := solveB(tc.n, tc.k, tc.p)
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		if len(fields) != 1 {
+			fmt.Fprintf(os.Stderr, "case %d: expected single integer got %q\n", i+1, out)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(fields[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse integer\n", i+1)
+			os.Exit(1)
+		}
+		if val != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, expected, val, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1768/verifierC.go
+++ b/1000-1999/1700-1799/1760-1769/1768/verifierC.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func solveC(n int, v []int) (bool, []int, []int) {
+	c := make([]int, n+1)
+	for _, x := range v {
+		c[x]++
+	}
+	pq := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		if c[i] == 0 {
+			pq = append(pq, i)
+		}
+	}
+	sort.Ints(pq)
+	pair := make([]int, n+1)
+	f := false
+	for i := n; i >= 1; i-- {
+		switch c[i] {
+		case 1:
+			pair[i] = i
+		case 2:
+			if len(pq) == 0 {
+				f = true
+				break
+			}
+			m := pq[len(pq)-1]
+			if m < i {
+				pq = pq[:len(pq)-1]
+				pair[i] = m
+				pair[m] = i
+			} else {
+				f = true
+			}
+		default:
+			if c[i] > 2 {
+				f = true
+			}
+		}
+		if f {
+			break
+		}
+	}
+	if f {
+		return false, nil, nil
+	}
+	vis := make([]bool, n+1)
+	p := make([]int, n)
+	q := make([]int, n)
+	for i, x := range v {
+		if !vis[x] {
+			p[i] = x
+			q[i] = pair[x]
+			vis[x] = true
+		} else {
+			p[i] = pair[x]
+			q[i] = x
+		}
+	}
+	return true, p, q
+}
+
+func isPermutation(arr []int, n int) bool {
+	seen := make([]bool, n+1)
+	for _, v := range arr {
+		if v < 1 || v > n || seen[v] {
+			return false
+		}
+		seen[v] = true
+	}
+	for i := 1; i <= n; i++ {
+		if !seen[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		n int
+		a []int
+	}
+
+	var cases []test
+	// deterministic cases
+	cases = append(cases, test{n: 1, a: []int{1}})
+	cases = append(cases, test{n: 2, a: []int{2, 1}})
+	cases = append(cases, test{n: 3, a: []int{3, 3, 1}})
+
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(n) + 1
+		}
+		cases = append(cases, test{n: n, a: arr})
+	}
+
+	for idx, tc := range cases {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for i, v := range tc.a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+
+		ok, _, _ := solveC(tc.n, append([]int(nil), tc.a...))
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 0 {
+			fmt.Fprintf(os.Stderr, "case %d: empty output\n", idx+1)
+			os.Exit(1)
+		}
+		ans := strings.ToUpper(fields[0])
+		if ans == "NO" {
+			if ok {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected YES got NO\n", idx+1)
+				os.Exit(1)
+			}
+			continue
+		}
+		if ans != "YES" {
+			fmt.Fprintf(os.Stderr, "case %d: expected YES/NO got %q\n", idx+1, fields[0])
+			os.Exit(1)
+		}
+		if len(fields)-1 != 2*tc.n {
+			fmt.Fprintf(os.Stderr, "case %d: wrong number of integers\n", idx+1)
+			os.Exit(1)
+		}
+		p := make([]int, tc.n)
+		q := make([]int, tc.n)
+		for i := 0; i < tc.n; i++ {
+			val, err := strconv.Atoi(fields[1+i])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d: cannot parse p\n", idx+1)
+				os.Exit(1)
+			}
+			p[i] = val
+		}
+		for i := 0; i < tc.n; i++ {
+			val, err := strconv.Atoi(fields[1+tc.n+i])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d: cannot parse q\n", idx+1)
+				os.Exit(1)
+			}
+			q[i] = val
+		}
+		if !isPermutation(p, tc.n) || !isPermutation(q, tc.n) {
+			fmt.Fprintf(os.Stderr, "case %d: output is not permutation\n", idx+1)
+			os.Exit(1)
+		}
+		for i := 0; i < tc.n; i++ {
+			m := p[i]
+			if q[i] > m {
+				m = q[i]
+			}
+			if m != tc.a[i] {
+				fmt.Fprintf(os.Stderr, "case %d: condition failed\n", idx+1)
+				os.Exit(1)
+			}
+		}
+		if !ok {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected NO got YES\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1768/verifierD.go
+++ b/1000-1999/1700-1799/1760-1769/1768/verifierD.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func solveD(n int, p []int) int {
+	visited := make([]bool, n+1)
+	cycleID := make([]int, n+1)
+	cid := 0
+	for i := 1; i <= n; i++ {
+		if !visited[i] {
+			cid++
+			j := i
+			for !visited[j] {
+				visited[j] = true
+				cycleID[j] = cid
+				j = p[j]
+			}
+		}
+	}
+	base := n - cid
+	same := false
+	for i := 1; i < n; i++ {
+		if cycleID[i] == cycleID[i+1] {
+			same = true
+			break
+		}
+	}
+	ans := base + 1
+	if same {
+		ans = base - 1
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		n int
+		p []int
+	}
+
+	var cases []test
+	cases = append(cases, test{n: 2, p: []int{1, 2}})
+	cases = append(cases, test{n: 2, p: []int{2, 1}})
+	cases = append(cases, test{n: 3, p: []int{2, 3, 1}})
+
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 2
+		perm := rand.Perm(n)
+		for i := range perm {
+			perm[i]++
+		}
+		cases = append(cases, test{n: n, p: perm})
+	}
+
+	for i, tc := range cases {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j, v := range tc.p {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		expected := solveD(tc.n, tc.p)
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		if len(fields) != 1 {
+			fmt.Fprintf(os.Stderr, "case %d: expected single integer got %q\n", i+1, out)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(fields[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse integer\n", i+1)
+			os.Exit(1)
+		}
+		if val != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, expected, val, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1768/verifierE.go
+++ b/1000-1999/1700-1799/1760-1769/1768/verifierE.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func modPow(a, e, mod int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func solveE(n int, mod int64) int64 {
+	max := 3 * n
+	fact := make([]int64, max+1)
+	invFact := make([]int64, max+1)
+	fact[0] = 1
+	for i := 1; i <= max; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[max] = modPow(fact[max], mod-2, mod)
+	for i := max; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+	comb := func(n, k int) int64 {
+		if k < 0 || k > n {
+			return 0
+		}
+		return fact[n] * invFact[k] % mod * invFact[n-k] % mod
+	}
+	factN := fact[n]
+	fact2N := fact[2*n]
+	fact3N := fact[3*n]
+	pow3FactN := factN * factN % mod * factN % mod
+	c2n := comb(2*n, n)
+	countNoA := c2n * c2n % mod * pow3FactN % mod
+	var s int64
+	for k := 0; k <= n; k++ {
+		term := comb(n, k) * comb(n, k) % mod * comb(2*n-k, n) % mod
+		s = (s + term) % mod
+	}
+	intersection := s * pow3FactN % mod
+	ans := (3*fact3N%mod - 2*fact2N%mod - 2*countNoA%mod + factN%mod + intersection%mod - 1) % mod
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+var primes = []int64{998244353, 1000000007, 1000000009, 1000000033}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		n   int
+		mod int64
+	}
+
+	var cases []test
+	cases = append(cases, test{n: 1, mod: 998244353})
+	cases = append(cases, test{n: 2, mod: 1000000007})
+	cases = append(cases, test{n: 3, mod: 1000000009})
+
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 1
+		mod := primes[rng.Intn(len(primes))]
+		cases = append(cases, test{n: n, mod: mod})
+	}
+
+	for i, tc := range cases {
+		input := fmt.Sprintf("%d %d\n", tc.n, tc.mod)
+		expected := solveE(tc.n, tc.mod)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		if len(fields) != 1 {
+			fmt.Fprintf(os.Stderr, "case %d: expected single integer got %q\n", i+1, out)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse integer\n", i+1)
+			os.Exit(1)
+		}
+		if val%tc.mod != expected%tc.mod {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\n", i+1, expected%tc.mod, val%tc.mod)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1760-1769/1768/verifierF.go
+++ b/1000-1999/1700-1799/1760-1769/1768/verifierF.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func solveF(n int, a []int) []int64 {
+	log := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		log[i] = log[i/2] + 1
+	}
+	K := log[n] + 1
+	st := make([][]int, K)
+	st[0] = make([]int, n)
+	copy(st[0], a)
+	for k := 1; k < K; k++ {
+		size := n - (1 << k) + 1
+		st[k] = make([]int, size)
+		for i := 0; i < size; i++ {
+			x := st[k-1][i]
+			y := st[k-1][i+(1<<(k-1))]
+			if x < y {
+				st[k][i] = x
+			} else {
+				st[k][i] = y
+			}
+		}
+	}
+	query := func(l, r int) int {
+		if l > r {
+			l, r = r, l
+		}
+		k := log[r-l+1]
+		x := st[k][l]
+		y := st[k][r-(1<<k)+1]
+		if x < y {
+			return x
+		}
+		return y
+	}
+
+	dp := make([]int64, n)
+	const INF int64 = 1 << 60
+	for i := 1; i < n; i++ {
+		dp[i] = INF
+	}
+	for i := 1; i < n; i++ {
+		for j := 0; j < i; j++ {
+			m := query(j, i)
+			d := int64(i - j)
+			cost := int64(m) * d * d
+			if dp[j]+cost < dp[i] {
+				dp[i] = dp[j] + cost
+			}
+		}
+	}
+	return dp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		n int
+		a []int
+	}
+
+	var cases []test
+	cases = append(cases, test{n: 2, a: []int{1, 2}})
+	cases = append(cases, test{n: 3, a: []int{2, 1, 3}})
+	cases = append(cases, test{n: 4, a: []int{4, 4, 4, 4}})
+
+	for len(cases) < 100 {
+		n := rng.Intn(8) + 2
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(n) + 1
+		}
+		cases = append(cases, test{n: n, a: arr})
+	}
+
+	for i, tc := range cases {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j, v := range tc.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		expected := solveF(tc.n, tc.a)
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		if len(fields) != tc.n {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d numbers got %q\n", i+1, tc.n, out)
+			os.Exit(1)
+		}
+		for idx := 0; idx < tc.n; idx++ {
+			val, err := strconv.ParseInt(fields[idx], 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d: cannot parse integer\n", i+1)
+				os.Exit(1)
+			}
+			if val != expected[idx] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, expected[idx], val, sb.String())
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go-verifierF.go under contest 1768
- each verifier runs any candidate binary and checks 100+ random test cases
- reference implementations derived from contest solutions

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68875e1060208324a598a866a4e8b52b