### PR TITLE
Add Go verifiers for contest 1777

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1777/verifierA.go
+++ b/1000-1999/1700-1799/1770-1779/1777/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveCase(a []int) int {
+	runs := 1
+	prev := a[0] % 2
+	for i := 1; i < len(a); i++ {
+		cur := a[i] % 2
+		if cur != prev {
+			runs++
+			prev = cur
+		}
+	}
+	return len(a) - runs
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(1_000_000_000) + 1
+	}
+	expected := solveCase(arr)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), fmt.Sprintf("%d\n", expected)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %s got %s", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1777/verifierB.go
+++ b/1000-1999/1700-1799/1770-1779/1777/verifierB.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1_000_000_007
+
+func solveCase(n int) int64 {
+	fact := int64(1)
+	for i := 2; i <= n; i++ {
+		fact = fact * int64(i) % mod
+	}
+	return fact * int64(n) % mod * int64(n-1) % mod
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	ans := solveCase(n)
+	input := fmt.Sprintf("1\n%d\n", n)
+	return input, fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %s got %s", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1777/verifierC.go
+++ b/1000-1999/1700-1799/1770-1779/1777/verifierC.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MaxA = 100000
+
+var preDivs = make([][]int, MaxA+1)
+
+func init() {
+	for d := 1; d <= MaxA; d++ {
+		for m := d; m <= MaxA; m += d {
+			preDivs[m] = append(preDivs[m], d)
+		}
+	}
+}
+
+func solveCase(n, m int, a []int) int {
+	sort.Ints(a)
+	allCnt := make([]int, m+1)
+	allCov := 0
+	for i := 0; i < n; i++ {
+		for _, d := range preDivs[a[i]] {
+			if d > m {
+				break
+			}
+			if allCnt[d] == 0 {
+				allCov++
+			}
+			allCnt[d]++
+		}
+	}
+	if allCov < m {
+		return -1
+	}
+	cnt := make([]int, m+1)
+	covered := 0
+	ans := int(1<<31 - 1)
+	l := 0
+	for r := 0; r < n; r++ {
+		for _, d := range preDivs[a[r]] {
+			if d > m {
+				break
+			}
+			cnt[d]++
+			if cnt[d] == 1 {
+				covered++
+			}
+		}
+		for covered == m {
+			if diff := a[r] - a[l]; diff < ans {
+				ans = diff
+			}
+			for _, d := range preDivs[a[l]] {
+				if d > m {
+					break
+				}
+				cnt[d]--
+				if cnt[d] == 0 {
+					covered--
+				}
+			}
+			l++
+		}
+	}
+	if ans == int(1<<31-1) {
+		return -1
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(100) + 1
+	}
+	ans := solveCase(n, m, a)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %s got %s", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1777/verifierD.go
+++ b/1000-1999/1700-1799/1770-1779/1777/verifierD.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		b >>= 1
+	}
+	return res
+}
+
+func solveCase(n int, edges [][2]int) int64 {
+	g := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	parent := make([]int, n+1)
+	order := make([]int, 0, n)
+	stack := []int{1}
+	parent[1] = 0
+	for len(stack) > 0 {
+		u := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, u)
+		for _, v := range g[u] {
+			if v == parent[u] {
+				continue
+			}
+			parent[v] = u
+			stack = append(stack, v)
+		}
+	}
+	height := make([]int, n+1)
+	for i := len(order) - 1; i >= 0; i-- {
+		u := order[i]
+		h := 0
+		for _, v := range g[u] {
+			if v == parent[u] {
+				continue
+			}
+			if height[v]+1 > h {
+				h = height[v] + 1
+			}
+		}
+		height[u] = h
+	}
+	var total int64
+	for i := 1; i <= n; i++ {
+		total += int64(height[i] + 1)
+	}
+	pow := modPow(2, int64(n-1))
+	ans := total % MOD * pow % MOD
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	edges := make([][2]int, n-1)
+	for i := 0; i < n-1; i++ {
+		u := i + 2
+		v := rng.Intn(i+1) + 1
+		edges[i] = [2]int{u, v}
+	}
+	ans := solveCase(n, edges)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String(), fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %s got %s", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1777/verifierE.go
+++ b/1000-1999/1700-1799/1770-1779/1777/verifierE.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type dsu struct {
+	p  []int
+	sz []int
+}
+
+func newDSU(n int) *dsu {
+	d := &dsu{p: make([]int, n), sz: make([]int, n)}
+	for i := 0; i < n; i++ {
+		d.p[i] = i
+		d.sz[i] = 1
+	}
+	return d
+}
+
+func (d *dsu) find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *dsu) union(a, b int) {
+	a = d.find(a)
+	b = d.find(b)
+	if a == b {
+		return
+	}
+	if d.sz[a] < d.sz[b] {
+		a, b = b, a
+	}
+	d.p[b] = a
+	d.sz[a] += d.sz[b]
+}
+
+type Edge struct {
+	u, v int
+	w    int
+}
+
+func can(edges []Edge, n int, x int) bool {
+	d := newDSU(n)
+	for _, e := range edges {
+		if e.w <= x {
+			d.union(e.u, e.v)
+		}
+	}
+	compID := make(map[int]int)
+	id := 0
+	for i := 0; i < n; i++ {
+		r := d.find(i)
+		if _, ok := compID[r]; !ok {
+			compID[r] = id
+			id++
+		}
+	}
+	indeg := make([]int, id)
+	for _, e := range edges {
+		if e.w > x {
+			a := compID[d.find(e.u)]
+			b := compID[d.find(e.v)]
+			if a != b {
+				indeg[b]++
+			}
+		}
+	}
+	cnt := 0
+	for i := 0; i < id; i++ {
+		if indeg[i] == 0 {
+			cnt++
+			if cnt > 1 {
+				return false
+			}
+		}
+	}
+	return cnt == 1
+}
+
+func solveCase(n, m int, edges []Edge) int {
+	d := newDSU(n)
+	for _, e := range edges {
+		d.union(e.u, e.v)
+	}
+	root := d.find(0)
+	for i := 1; i < n; i++ {
+		if d.find(i) != root {
+			return -1
+		}
+	}
+	lo, hi := 0, int(1e9)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if can(edges, n, mid) {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + n - 1
+	edges := make([]Edge, m)
+	// start with tree
+	for i := 0; i < n-1; i++ {
+		edges[i] = Edge{u: i, v: i + 1, w: rng.Intn(20)}
+	}
+	for i := n - 1; i < m; i++ {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		for u == v {
+			v = rng.Intn(n)
+		}
+		edges[i] = Edge{u: u, v: v, w: rng.Intn(20)}
+	}
+	ans := solveCase(n, m, edges)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u+1, e.v+1, e.w))
+	}
+	return sb.String(), fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %s got %s", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1777/verifierF.go
+++ b/1000-1999/1700-1799/1770-1779/1777/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const limit = 130
+
+func solveCase(a []int) int {
+	n := len(a)
+	prefix := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] ^ a[i]
+	}
+	ans := 0
+	for l := 0; l < n; l++ {
+		mx := 0
+		for r := l; r < n && r-l < limit; r++ {
+			if a[r] > mx {
+				mx = a[r]
+			}
+			x := prefix[r+1] ^ prefix[l]
+			val := mx ^ x
+			if val > ans {
+				ans = val
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(1000)
+	}
+	ans := solveCase(a)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %s got %s", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1777
- fix imports after build checks

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68876086bef08324af2658e4991e6f50