### PR TITLE
Add verifiers for CF 1771 solutions

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1771/verifierA.go
+++ b/1000-1999/1700-1799/1770-1779/1771/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	arr []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.arr)))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleA"
+	cmd := exec.Command("go", "build", "-o", ref, "1771A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(9) + 2 // 2..10
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(100) + 1
+		}
+		tests[i] = Test{arr: arr}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1771/verifierB.go
+++ b/1000-1999/1700-1799/1770-1779/1771/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n, m  int
+	pairs [][2]int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.m))
+	for _, p := range t.pairs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleB"
+	cmd := exec.Command("go", "build", "-o", ref, "1771B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 2 // 2..9
+		maxPairs := n * (n - 1) / 2
+		m := rng.Intn(maxPairs + 1)
+		pairs := make([][2]int, m)
+		for j := 0; j < m; j++ {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			for a == b {
+				b = rng.Intn(n) + 1
+			}
+			pairs[j] = [2]int{a, b}
+		}
+		tests[i] = Test{n: n, m: m, pairs: pairs}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1771/verifierC.go
+++ b/1000-1999/1700-1799/1770-1779/1771/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	arr []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.arr)))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleC"
+	cmd := exec.Command("go", "build", "-o", ref, "1771C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(9) + 2 // 2..10
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(1000) + 1
+		}
+		tests[i] = Test{arr: arr}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1771/verifierD.go
+++ b/1000-1999/1700-1799/1770-1779/1771/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n     int
+	s     string
+	edges [][2]int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", t.n))
+	sb.WriteString(fmt.Sprintf("%s\n", t.s))
+	for _, e := range t.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleD"
+	cmd := exec.Command("go", "build", "-o", ref, "1771D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	letters := []rune("abcde")
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(7) + 1 // 1..7
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteRune(letters[rng.Intn(len(letters))])
+		}
+		edges := make([][2]int, 0, n-1)
+		for v := 2; v <= n; v++ {
+			u := rng.Intn(v-1) + 1
+			edges = append(edges, [2]int{u, v})
+		}
+		tests[i] = Test{n: n, s: sb.String(), edges: edges}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1771/verifierE.go
+++ b/1000-1999/1700-1799/1770-1779/1771/verifierE.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n, m int
+	grid []string
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.m))
+	for _, row := range t.grid {
+		sb.WriteString(fmt.Sprintf("%s\n", row))
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleE"
+	cmd := exec.Command("go", "build", "-o", ref, "1771E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 100)
+	cells := []rune{'.', 'm', '#'}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 3 // 3..7
+		m := rng.Intn(5) + 3 // 3..7
+		grid := make([]string, n)
+		for r := 0; r < n; r++ {
+			row := make([]rune, m)
+			for c := 0; c < m; c++ {
+				row[c] = cells[rng.Intn(len(cells))]
+			}
+			grid[r] = string(row)
+		}
+		tests[i] = Test{n: n, m: m, grid: grid}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1771/verifierF.go
+++ b/1000-1999/1700-1799/1770-1779/1771/verifierF.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Query struct {
+	a, b int
+}
+
+type Test struct {
+	arr     []int
+	queries []Query
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.arr)))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.queries)))
+	for _, q := range t.queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", q.a, q.b))
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	ref := "oracleF"
+	cmd := exec.Command("go", "build", "-o", ref, "1771F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests(ref string) []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(50) + 1
+		}
+		q := rng.Intn(8) + 1
+		queries := make([]Query, q)
+		prev := 0
+		base := fmt.Sprintf("%d\n", n)
+		for j, v := range arr {
+			if j > 0 {
+				base += " "
+			}
+			base += fmt.Sprintf("%d", v)
+		}
+		base += "\n"
+		for j := 0; j < q; j++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			a := l ^ prev
+			b := r ^ prev
+			queries[j] = Query{a: a, b: b}
+			// build partial input to get new answer from oracle
+			var sb strings.Builder
+			sb.WriteString(base)
+			sb.WriteString(fmt.Sprintf("%d\n", j+1))
+			for k := 0; k <= j; k++ {
+				sb.WriteString(fmt.Sprintf("%d %d\n", queries[k].a, queries[k].b))
+			}
+			out, err := runExe(ref, sb.String())
+			if err != nil {
+				// if oracle fails, just keep prev as 0
+				prev = 0
+			} else {
+				lines := strings.Split(strings.TrimSpace(out), "\n")
+				val, err := strconv.Atoi(lines[len(lines)-1])
+				if err != nil {
+					prev = 0
+				} else {
+					prev = val
+				}
+			}
+		}
+		tests[i] = Test{arr: arr, queries: queries}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests(ref)
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("oracle runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- provide Go verifiers for contest 1771 problems A–F
- each verifier builds the reference solution and runs 100 randomized tests
- `verifierF.go` uses the built oracle to encode queries correctly

## Testing
- `go run verifierA.go ./candA`
- `go run verifierB.go ./candB`
- `go run verifierC.go ./candC`
- `go run verifierD.go ./candD`
- `go run verifierE.go ./candE`
- `go run verifierF.go ./candF`


------
https://chatgpt.com/codex/tasks/task_e_68875ee22b088324ad233f860044cd27