### PR TITLE
Add verifiers for contest 1781

### DIFF
--- a/1000-1999/1700-1799/1780-1789/1781/verifierA.go
+++ b/1000-1999/1700-1799/1780-1789/1781/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	w := rand.Intn(999) + 2
+	d := rand.Intn(999) + 2
+	h := rand.Intn(999) + 2
+	a := rand.Intn(w-1) + 1
+	f := rand.Intn(w-1) + 1
+	b := rand.Intn(d-1) + 1
+	g := rand.Intn(d-1) + 1
+	return fmt.Sprintf("1\n%d %d %d\n%d %d %d %d\n", w, d, h, a, b, f, g)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refA_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1781A.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1781/verifierB.go
+++ b/1000-1999/1700-1799/1780-1789/1781/verifierB.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(n+1)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refB_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1781B.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1781/verifierC.go
+++ b/1000-1999/1700-1799/1780-1789/1781/verifierC.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + rand.Intn(26)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refC_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1781C.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1781/verifierD.go
+++ b/1000-1999/1700-1799/1780-1789/1781/verifierD.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(7) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(51)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refD_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1781D.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1781/verifierE.go
+++ b/1000-1999/1700-1799/1780-1789/1781/verifierE.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		u := rand.Intn(2) + 1
+		d := rand.Intn(2) + 1
+		if u > d {
+			u, d = d, u
+		}
+		l := rand.Intn(5) + 1
+		r := l + rand.Intn(5)
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", u, l, d, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refE_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1781E.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1781/verifierF.go
+++ b/1000-1999/1700-1799/1780-1789/1781/verifierF.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(1000) + 1
+	q := rand.Intn(10001)
+	return fmt.Sprintf("%d %d\n", n, q)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refF_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1781F.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1781/verifierG.go
+++ b/1000-1999/1700-1799/1780-1789/1781/verifierG.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		parent := rand.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", parent))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refG_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1781G.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1781/verifierH1.go
+++ b/1000-1999/1700-1799/1780-1789/1781/verifierH1.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	h := rand.Intn(4) + 1
+	w := rand.Intn(4) + 1
+	maxK := h * w
+	if maxK > 4 {
+		maxK = 4
+	}
+	k := rand.Intn(maxK + 1)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", h, w, k))
+	for i := 0; i < k; i++ {
+		r := rand.Intn(h) + 1
+		c := rand.Intn(w) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", r, c))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH1.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refH1_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1781H1.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1781/verifierH2.go
+++ b/1000-1999/1700-1799/1780-1789/1781/verifierH2.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	h := rand.Intn(4) + 1
+	w := rand.Intn(4) + 1
+	maxK := h * w
+	if maxK > 4 {
+		maxK = 4
+	}
+	k := rand.Intn(maxK + 1)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", h, w, k))
+	for i := 0; i < k; i++ {
+		r := rand.Intn(h) + 1
+		c := rand.Intn(w) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", r, c))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH2.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refH2_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1781H2.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1781 problems A-H2
- generate 100 random tests per verifier and compare against provided reference solutions

## Testing
- `go build verifierA.go`
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go vet verifierF.go`
- `go vet verifierG.go`
- `go vet verifierH1.go`
- `go vet verifierH2.go`


------
https://chatgpt.com/codex/tasks/task_e_6887619ecbe88324a36e5d064cf67054