### PR TITLE
Add Go verifiers for contest 1776

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1776/verifierA.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	set := map[int]struct{}{}
+	for len(set) < n {
+		set[rng.Intn(1440)] = struct{}{}
+	}
+	arr := make([]int, 0, n)
+	for v := range set {
+		arr = append(arr, v)
+	}
+	sort.Ints(arr)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(strconv.Itoa(len(arr)))
+	sb.WriteByte('\n')
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refA.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776A.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierB.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierB.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	h := rng.Int63n(50) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, h))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(rng.Int63n(200), 10))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refB.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776B.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierC.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierC.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(50) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(30) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refC.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776C.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierD.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierD.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	cnt0 := rng.Intn(4)
+	cnt1 := rng.Intn(4)
+	cnt2 := rng.Intn(4)
+	l := rng.Intn(20) + 1
+	return fmt.Sprintf("%d %d %d %d\n", cnt0, cnt1, cnt2, l)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refD.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776D.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierE.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierE.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	s := rng.Intn(20) + 10
+	v := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, s, v))
+	for i := 0; i < n; i++ {
+		a := rng.Intn(s)
+		b := a + rng.Intn(s-a+1)
+		r := rng.Intn(m) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refE.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776E.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierF.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierF.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	maxE := n * (n - 1) / 2
+	m := rng.Intn(maxE) + 1
+	edges := make(map[[2]int]struct{})
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		edges[[2]int{u, v}] = struct{}{}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refF.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776F.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierG.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierG.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < 2*n-1; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('R')
+		} else {
+			sb.WriteByte('W')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refG.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776G.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierH.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierH.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	perm1 := rng.Perm(n)
+	perm2 := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range perm1 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v + 1))
+	}
+	sb.WriteByte('\n')
+	for i, v := range perm2 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refH.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776H.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierI.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierI.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 3
+	angles := make([]float64, n)
+	for i := range angles {
+		angles[i] = rng.Float64() * 2 * math.Pi
+	}
+	sort.Float64s(angles)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, ang := range angles {
+		r := rng.Float64()*5 + 1
+		x := r * math.Cos(ang)
+		y := r * math.Sin(ang)
+		sb.WriteString(fmt.Sprintf("%.2f %.2f\n", x, y))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refI.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776I.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierJ.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierJ.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	maxE := n * (n - 1) / 2
+	m := rng.Intn(maxE-n+1) + (n - 1)
+	k := rng.Intn(5)
+	colors := make([]int, n)
+	for i := range colors {
+		colors[i] = rng.Intn(3) + 1
+	}
+	edges := make(map[[2]int]struct{})
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		edges[[2]int{u, v}] = struct{}{}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i, c := range colors {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c))
+	}
+	sb.WriteByte('\n')
+	for e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refJ.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776J.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierK.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierK.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	T := int64(rng.Intn(20) + 1)
+	m := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", T, m))
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(int64(rng.Intn(int(T)+1)), 10))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierK.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refK.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776K.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierL.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierL.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('+')
+		} else {
+			sb.WriteByte('-')
+		}
+	}
+	sb.WriteByte('\n')
+	q := rng.Intn(5) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		a := rng.Intn(5) + 1
+		b := rng.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierL.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refL.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776L.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierM.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierM.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	edges := make(map[[2]int]struct{})
+	for len(edges) < n-1 {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		edges[[2]int{u, v}] = struct{}{}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierM.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refM.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776M.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1770-1779/1776/verifierN.go
+++ b/1000-1999/1700-1799/1770-1779/1776/verifierN.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n-1; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('<')
+		} else {
+			sb.WriteByte('>')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierN.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./_refN.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1776N.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifiers A–N for contest 1776 so any binary can be checked
- each verifier builds the reference solution and runs 100 random tests

## Testing
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierA.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierB.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierC.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierD.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierE.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierF.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierG.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierH.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierI.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierJ.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierK.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierL.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierM.go`
- `go build 1000-1999/1700-1799/1770-1779/1776/verifierN.go`


------
https://chatgpt.com/codex/tasks/task_e_688760404b7883248ef01ef9bb858281