### PR TITLE
Add Go verifiers for contest 1780

### DIFF
--- a/1000-1999/1700-1799/1780-1789/1780/verifierA.go
+++ b/1000-1999/1700-1799/1780-1789/1780/verifierA.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsA = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binA*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleA*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1780A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 3
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(100000)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsA; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1780/verifierB.go
+++ b/1000-1999/1700-1799/1780-1789/1780/verifierB.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsB = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binB*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleB*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1780B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(1000000000)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsB; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1780/verifierD.go
+++ b/1000-1999/1700-1799/1780-1789/1780/verifierD.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem D is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1700-1799/1780-1789/1780/verifierE.go
+++ b/1000-1999/1700-1799/1780-1789/1780/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsE = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binE*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleE*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1780E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	l := rng.Int63n(1_000_000) + 1
+	r := l + rng.Int63n(1_000_000)
+	return fmt.Sprintf("1\n%d %d\n", l, r)
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsE; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1780/verifierF.go
+++ b/1000-1999/1700-1799/1780-1789/1780/verifierF.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsF = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binF*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleF*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1780F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(100)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsF; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1780-1789/1780/verifierG.go
+++ b/1000-1999/1700-1799/1780-1789/1780/verifierG.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const numTestsG = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "binG*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("go", "build", "-o", tmp.Name(), path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp, err := os.CreateTemp("", "oracleG*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), "1780G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(40) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + rng.Intn(26)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println("oracle compile error:", err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsG; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for contest 1780 problems A, B, D, E, F, G
- verifiers compile a contestant binary, compile the reference solution as an oracle, run 100 random tests and compare outputs
- for interactive problem D, print a helpful notice

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierD.go`

------
https://chatgpt.com/codex/tasks/task_e_6887615894808324a41c62b21058bd7d