### PR TITLE
Add verifiers for contest 1789

### DIFF
--- a/1000-1999/1700-1799/1780-1789/1789/verifierA.go
+++ b/1000-1999/1700-1799/1780-1789/1789/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(49) + 2 // 2..50
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(rand.Intn(1_000_000) + 1))
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refA.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1789A.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1780-1789/1789/verifierB.go
+++ b/1000-1999/1700-1799/1780-1789/1789/verifierB.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 2 // 2..21
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refB.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1789B.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1780-1789/1789/verifierC.go
+++ b/1000-1999/1700-1799/1780-1789/1789/verifierC.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genCase() string {
+	n := rand.Intn(3) + 1 // 1..3
+	m := rand.Intn(3) + 1 // 1..3
+	sb := &strings.Builder{}
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	arr := make([]int, n)
+	used := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		arr[i] = i + 1
+		used[arr[i]] = true
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(arr[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		p := rand.Intn(n)
+		v := rand.Intn(n+m) + 1
+		for used[v] {
+			v = rand.Intn(n+m) + 1
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", p+1, v))
+		delete(used, arr[p])
+		arr[p] = v
+		used[v] = true
+	}
+	return sb.String()
+}
+
+func genTest() []byte {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		sb.WriteString(genCase())
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refC.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1789C.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1780-1789/1789/verifierD.go
+++ b/1000-1999/1700-1799/1780-1789/1789/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(7) + 1 // 1..8
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		var a, b strings.Builder
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				a.WriteByte('0')
+			} else {
+				a.WriteByte('1')
+			}
+			if rand.Intn(2) == 0 {
+				b.WriteByte('0')
+			} else {
+				b.WriteByte('1')
+			}
+		}
+		sb.WriteString(a.String())
+		sb.WriteByte('\n')
+		sb.WriteString(b.String())
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refD.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1789D.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1780-1789/1789/verifierE.go
+++ b/1000-1999/1700-1799/1780-1789/1789/verifierE.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genCase() string {
+	n := rand.Intn(4) + 1 // 1..4
+	sb := &strings.Builder{}
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	val := rand.Intn(3) + 1
+	sb.WriteString(fmt.Sprint(val))
+	for i := 1; i < n; i++ {
+		val += rand.Intn(3) + 1
+		sb.WriteByte(' ')
+		sb.WriteString(fmt.Sprint(val))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func genTest() []byte {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		sb.WriteString(genCase())
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refE.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1789E.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1780-1789/1789/verifierF.go
+++ b/1000-1999/1700-1799/1780-1789/1789/verifierF.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 1 // 1..20
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + rand.Intn(26)))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refF.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1789F.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1789
- each verifier generates random tests and checks results against the reference solution

## Testing
- `gofmt -w 1000-1999/1700-1799/1780-1789/1789/verifier*.go`
- `go vet ./...` *(fails: directory does not contain module)*

------
https://chatgpt.com/codex/tasks/task_e_688763ced0008324a28c2adefee0290b