### PR TITLE
Add verifiers for CF 1793

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1793/verifierA.go
+++ b/1000-1999/1700-1799/1790-1799/1793/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refA-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1793A.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		a := rng.Int63n(1_000_000_000) + 1
+		b := rng.Int63n(1_000_000_000) + 1
+		n := rng.Int63n(1_000_000_000) + 1
+		m := rng.Int63n(1_000_000_000) + 1
+		fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, n, m)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		out, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nactual: %s\ninput:\n%s", t+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1793/verifierB.go
+++ b/1000-1999/1700-1799/1790-1799/1793/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refB-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1793B.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		y := rng.Int63n(2_000_001) - 1_000_000
+		x := y + 1 + rng.Int63n(1_000_000)
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		out, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nactual: %s\ninput:\n%s", t+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1793/verifierC.go
+++ b/1000-1999/1700-1799/1790-1799/1793/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refC-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1793C.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(8) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		perm := rng.Perm(n)
+		for j, v := range perm {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v+1)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		out, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nactual: %s\ninput:\n%s", t+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1793/verifierD.go
+++ b/1000-1999/1700-1799/1790-1799/1793/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refD-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1793D.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	p := rng.Perm(n)
+	q := rng.Perm(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	for i, v := range q {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		out, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nactual: %s\ninput:\n%s", t+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1793/verifierE.go
+++ b/1000-1999/1700-1799/1790-1799/1793/verifierE.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refE-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1793E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(n)+1)
+	}
+	sb.WriteByte('\n')
+	q := rng.Intn(8) + 1
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < q; i++ {
+		k := rng.Intn(n-1) + 2
+		fmt.Fprintf(&sb, "%d\n", k)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		out, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nactual: %s\ninput:\n%s", t+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1793/verifierF.go
+++ b/1000-1999/1700-1799/1790-1799/1793/verifierF.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	exe, err := os.CreateTemp("", "refF-*.bin")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, filepath.Join(dir, "1793F.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	q := rng.Intn(8) + 1
+	perm := rng.Perm(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n-1) + 1
+		r := l + rng.Intn(n-l) + 1
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		out, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\nactual: %s\ninput:\n%s", t+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 1793 problems A–F
- each verifier builds the reference solution, generates 100 random test cases and compares output

## Testing
- `go build 1000-1999/1700-1799/1790-1799/1793/verifierA.go`
- `go build 1000-1999/1700-1799/1790-1799/1793/verifierB.go`
- `go build 1000-1999/1700-1799/1790-1799/1793/verifierC.go`
- `go build 1000-1999/1700-1799/1790-1799/1793/verifierD.go`
- `go build 1000-1999/1700-1799/1790-1799/1793/verifierE.go`
- `go build 1000-1999/1700-1799/1790-1799/1793/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688764e6e88c832491d9590e09fed4b2