### PR TITLE
Add Go verifiers for contest 1792

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1792/verifierA.go
+++ b/1000-1999/1700-1799/1790-1799/1792/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func solveCaseA(n int, arr []int) int {
+	ones := 0
+	for _, x := range arr {
+		if x == 1 {
+			ones++
+		}
+	}
+	return n - ones/2
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	const t = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, t)
+	expected := make([]int, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(100) + 1
+		fmt.Fprintln(&input, n)
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rand.Intn(100) + 1
+		}
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, arr[j])
+		}
+		input.WriteByte('\n')
+		expected[i] = solveCaseA(n, arr)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	outBytes, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "binary execution failed:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(outBytes))
+	scanner.Split(bufio.ScanWords)
+	for i := 0; i < t; i++ {
+		if !scanner.Scan() {
+			fmt.Printf("not enough output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Printf("invalid integer on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected[i] {
+			fmt.Printf("mismatch on test %d: expected %d got %d\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1790-1799/1792/verifierB.go
+++ b/1000-1999/1700-1799/1790-1799/1792/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func solveCaseB(a1, a2, a3, a4 int) int {
+	if a1 == 0 {
+		return 1
+	}
+	pair := a2
+	if a3 < pair {
+		pair = a3
+	}
+	ans := a1 + 2*pair
+	diff := a2 - a3
+	if diff < 0 {
+		diff = -diff
+	}
+	extra := diff + a4
+	if a1+1 < extra {
+		ans += a1 + 1
+	} else {
+		ans += extra
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(43)
+	const t = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, t)
+	expected := make([]int, t)
+	for i := 0; i < t; i++ {
+		a1 := rand.Intn(10)
+		a2 := rand.Intn(10)
+		a3 := rand.Intn(10)
+		a4 := rand.Intn(10)
+		fmt.Fprintf(&input, "%d %d %d %d\n", a1, a2, a3, a4)
+		expected[i] = solveCaseB(a1, a2, a3, a4)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	outBytes, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "binary execution failed:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(outBytes))
+	scanner.Split(bufio.ScanWords)
+	for i := 0; i < t; i++ {
+		if !scanner.Scan() {
+			fmt.Printf("not enough output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Printf("invalid integer on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected[i] {
+			fmt.Printf("mismatch on test %d: expected %d got %d\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1790-1799/1792/verifierC.go
+++ b/1000-1999/1700-1799/1790-1799/1792/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func solveCaseC(p []int) int {
+	n := len(p)
+	pre := 0
+	for pre < n && p[pre] == pre+1 {
+		pre++
+	}
+	suf := 0
+	for suf < n-pre && p[n-1-suf] == n-suf {
+		suf++
+	}
+	rem := n - pre - suf
+	if rem < 0 {
+		rem = 0
+	}
+	return (rem + 1) / 2
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(44)
+	const t = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, t)
+	expected := make([]int, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(50) + 1
+		fmt.Fprintln(&input, n)
+		p := rand.Perm(n)
+		for j := 0; j < n; j++ {
+			p[j]++
+		}
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, p[j])
+		}
+		input.WriteByte('\n')
+		expected[i] = solveCaseC(p)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	outBytes, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "binary execution failed:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(outBytes))
+	scanner.Split(bufio.ScanWords)
+	for i := 0; i < t; i++ {
+		if !scanner.Scan() {
+			fmt.Printf("not enough output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Printf("invalid integer on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected[i] {
+			fmt.Printf("mismatch on test %d: expected %d got %d\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1790-1799/1792/verifierD.go
+++ b/1000-1999/1700-1799/1790-1799/1792/verifierD.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func compose(a, b []int) []int {
+	m := len(a)
+	r := make([]int, m)
+	for i := 0; i < m; i++ {
+		r[i] = b[a[i]-1]
+	}
+	return r
+}
+
+func beauty(p []int) int {
+	k := 0
+	for k < len(p) && p[k] == k+1 {
+		k++
+	}
+	return k
+}
+
+func solveCaseD(perms [][]int) []int {
+	n := len(perms)
+	m := len(perms[0])
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		best := 0
+		for j := 0; j < n; j++ {
+			r := compose(perms[i], perms[j])
+			b := beauty(r)
+			if b > best {
+				best = b
+			}
+		}
+		res[i] = best
+	}
+	_ = m
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(45)
+	const t = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, t)
+	var expected [][]int
+	for i := 0; i < t; i++ {
+		n := rand.Intn(4) + 1
+		m := rand.Intn(5) + 1
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		perms := make([][]int, n)
+		for j := 0; j < n; j++ {
+			perm := rand.Perm(m)
+			for k := 0; k < m; k++ {
+				perm[k]++
+			}
+			perms[j] = perm
+			for k := 0; k < m; k++ {
+				if k > 0 {
+					input.WriteByte(' ')
+				}
+				fmt.Fprint(&input, perm[k])
+			}
+			input.WriteByte('\n')
+		}
+		expected = append(expected, solveCaseD(perms))
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	outBytes, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "binary execution failed:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(outBytes))
+	scanner.Split(bufio.ScanWords)
+	for caseIdx := 0; caseIdx < t; caseIdx++ {
+		exp := expected[caseIdx]
+		for j := 0; j < len(exp); j++ {
+			if !scanner.Scan() {
+				fmt.Printf("not enough output on case %d value %d\n", caseIdx+1, j+1)
+				os.Exit(1)
+			}
+			got, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Printf("invalid integer on case %d value %d: %v\n", caseIdx+1, j+1, err)
+				os.Exit(1)
+			}
+			if got != exp[j] {
+				fmt.Printf("mismatch on case %d value %d: expected %d got %d\n", caseIdx+1, j+1, exp[j], got)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1790-1799/1792/verifierE.go
+++ b/1000-1999/1700-1799/1790-1799/1792/verifierE.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+)
+
+func factorize(x int64) map[int64]int {
+	res := make(map[int64]int)
+	for p := int64(2); p*p <= x; p++ {
+		for x%p == 0 {
+			res[p]++
+			x /= p
+		}
+	}
+	if x > 1 {
+		res[x]++
+	}
+	return res
+}
+
+func factorWithPrimes(d int64, primes []int64) []int {
+	exps := make([]int, len(primes))
+	for i, p := range primes {
+		for d%p == 0 {
+			exps[i]++
+			d /= p
+		}
+	}
+	return exps
+}
+
+func findMinDiv(primes []int64, exps []int, idx int, cur, lo, hi int64, best *int64) {
+	if cur > hi || cur >= *best {
+		return
+	}
+	if idx == len(primes) {
+		if cur >= lo && cur < *best {
+			*best = cur
+		}
+		return
+	}
+	val := int64(1)
+	for i := 0; i <= exps[idx]; i++ {
+		findMinDiv(primes, exps, idx+1, cur*val, lo, hi, best)
+		val *= primes[idx]
+		if cur*val > hi {
+			break
+		}
+	}
+}
+
+func minimalRow(n int64, primes []int64, d int64) int64 {
+	if d > n*n {
+		return 0
+	}
+	if d <= n {
+		return 1
+	}
+	lo := (d + n - 1) / n
+	exps := factorWithPrimes(d, primes)
+	best := int64(1<<63 - 1)
+	findMinDiv(primes, exps, 0, 1, lo, n, &best)
+	if best == int64(1<<63-1) {
+		return 0
+	}
+	return best
+}
+
+func solveCaseE(n, m1, m2 int64) (int64, int64) {
+	fac := factorize(m1)
+	for p, e := range factorize(m2) {
+		fac[p] += e
+	}
+	type pe struct {
+		p int64
+		e int
+	}
+	pes := make([]pe, 0, len(fac))
+	for p, e := range fac {
+		pes = append(pes, pe{p, e})
+	}
+	sort.Slice(pes, func(i, j int) bool { return pes[i].p < pes[j].p })
+	primes := make([]int64, len(pes))
+	exps := make([]int, len(pes))
+	for i, v := range pes {
+		primes[i] = v.p
+		exps[i] = v.e
+	}
+	divisors := []int64{1}
+	for i, p := range primes {
+		cnt := exps[i]
+		curSize := len(divisors)
+		pow := int64(1)
+		for e := 1; e <= cnt; e++ {
+			pow *= p
+			for j := 0; j < curSize; j++ {
+				divisors = append(divisors, divisors[j]*pow)
+			}
+		}
+	}
+	var present int64
+	var xorVal int64
+	for _, d := range divisors {
+		row := minimalRow(n, primes, d)
+		if row != 0 {
+			present++
+		}
+		xorVal ^= row
+	}
+	return present, xorVal
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(46)
+	const t = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, t)
+	expected := make([][2]int64, t)
+	for i := 0; i < t; i++ {
+		n := int64(rand.Intn(50) + 1)
+		m1 := int64(rand.Intn(50) + 1)
+		m2 := int64(rand.Intn(50) + 1)
+		fmt.Fprintf(&input, "%d %d %d\n", n, m1, m2)
+		a, b := solveCaseE(n, m1, m2)
+		expected[i][0] = a
+		expected[i][1] = b
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	outBytes, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "binary execution failed:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(outBytes))
+	scanner.Split(bufio.ScanWords)
+	for i := 0; i < t; i++ {
+		for j := 0; j < 2; j++ {
+			if !scanner.Scan() {
+				fmt.Printf("not enough output on test %d value %d\n", i+1, j+1)
+				os.Exit(1)
+			}
+			got, err := strconv.ParseInt(scanner.Text(), 10, 64)
+			if err != nil {
+				fmt.Printf("invalid integer on test %d value %d: %v\n", i+1, j+1, err)
+				os.Exit(1)
+			}
+			if got != expected[i][j] {
+				fmt.Printf("mismatch on test %d value %d: expected %d got %d\n", i+1, j+1, expected[i][j], got)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1790-1799/1792/verifierF1.go
+++ b/1000-1999/1700-1799/1790-1799/1792/verifierF1.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+const mod int64 = 998244353
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func solveF(n int) int64 {
+	fact := make([]int64, n+1)
+	invFact := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[n] = modPow(fact[n], mod-2)
+	for i := n; i >= 1; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+	comb := func(a, b int) int64 {
+		if b < 0 || b > a {
+			return 0
+		}
+		return fact[a] * invFact[b] % mod * invFact[a-b] % mod
+	}
+	h := make([]int64, n+1)
+	bArr := make([]int64, n+1)
+	h[1] = 1
+	bArr[1] = 1
+	for i := 2; i <= n; i++ {
+		var val int64
+		for s := 1; s < i; s++ {
+			k := i - s
+			bk := h[k]
+			if k != 1 {
+				bk = bk * 2 % mod
+			}
+			val = (val + comb(i-1, s-1)*h[s]%mod*bk) % mod
+		}
+		h[i] = val % mod
+		bArr[i] = 2 * h[i] % mod
+	}
+	ans := bArr[n] - 2
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(47)
+	const t = 100
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 3
+		var input bytes.Buffer
+		fmt.Fprintln(&input, n)
+		expected := solveF(n)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		outBytes, err := cmd.Output()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "binary execution failed on test", i+1, err)
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(outBytes))
+		scanner.Split(bufio.ScanWords)
+		if !scanner.Scan() {
+			fmt.Printf("no output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			fmt.Printf("invalid output on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("mismatch on test %d: expected %d got %d\n", i+1, expected, got)
+			os.Exit(1)
+		}
+		if scanner.Scan() {
+			fmt.Printf("extra output on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1700-1799/1790-1799/1792/verifierF2.go
+++ b/1000-1999/1700-1799/1790-1799/1792/verifierF2.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+const mod int64 = 998244353
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func solveF(n int) int64 {
+	fact := make([]int64, n+1)
+	invFact := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[n] = modPow(fact[n], mod-2)
+	for i := n; i >= 1; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+	comb := func(a, b int) int64 {
+		if b < 0 || b > a {
+			return 0
+		}
+		return fact[a] * invFact[b] % mod * invFact[a-b] % mod
+	}
+	h := make([]int64, n+1)
+	bArr := make([]int64, n+1)
+	h[1] = 1
+	bArr[1] = 1
+	for i := 2; i <= n; i++ {
+		var val int64
+		for s := 1; s < i; s++ {
+			k := i - s
+			bk := h[k]
+			if k != 1 {
+				bk = bk * 2 % mod
+			}
+			val = (val + comb(i-1, s-1)*h[s]%mod*bk) % mod
+		}
+		h[i] = val % mod
+		bArr[i] = 2 * h[i] % mod
+	}
+	ans := bArr[n] - 2
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(48)
+	const t = 100
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 3
+		var input bytes.Buffer
+		fmt.Fprintln(&input, n)
+		expected := solveF(n)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		outBytes, err := cmd.Output()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "binary execution failed on test", i+1, err)
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(outBytes))
+		scanner.Split(bufio.ScanWords)
+		if !scanner.Scan() {
+			fmt.Printf("no output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			fmt.Printf("invalid output on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("mismatch on test %d: expected %d got %d\n", i+1, expected, got)
+			os.Exit(1)
+		}
+		if scanner.Scan() {
+			fmt.Printf("extra output on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to test binaries for problem A
- add verifierB.go to test binaries for problem B
- add verifierC.go to test binaries for problem C
- add verifierD.go to test binaries for problem D
- add verifierE.go to test binaries for problem E
- add verifierF1.go to test binaries for problem F1
- add verifierF2.go to test binaries for problem F2

## Testing
- `for f in verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF1.go verifierF2.go; do go build 1000-1999/1700-1799/1790-1799/1792/$f; done`

------
https://chatgpt.com/codex/tasks/task_e_688764a0dae88324b95307490d64141a