### PR TITLE
Add Go verifiers for Codeforces contest 1798

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1798/verifierA.go
+++ b/1000-1999/1700-1799/1790-1799/1798/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refA_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1798A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(10) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(100) + 1
+		b[i] = rand.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%sactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1798/verifierB.go
+++ b/1000-1999/1700-1799/1790-1799/1798/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refB_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1798B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	m := rand.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		n := rand.Intn(3) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		used := make(map[int]bool)
+		for j := 0; j < n; j++ {
+			x := rand.Intn(9) + 1
+			for used[x] {
+				x = rand.Intn(9) + 1
+			}
+			used[x] = true
+			sb.WriteString(fmt.Sprintf("%d", x))
+			if j+1 < n {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%sactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1798/verifierC.go
+++ b/1000-1999/1700-1799/1790-1799/1798/verifierC.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refC_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1798C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(4) + 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		a := rand.Intn(100) + 1
+		b := rand.Intn(20) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%sactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1798/verifierD.go
+++ b/1000-1999/1700-1799/1790-1799/1798/verifierD.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refD_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1798D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(5) + 1
+	arr := make([]int, n)
+	sum := 0
+	for i := 0; i < n-1; i++ {
+		arr[i] = rand.Intn(21) - 10
+		sum += arr[i]
+	}
+	arr[n-1] = -sum
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%sactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1798/verifierE.go
+++ b/1000-1999/1700-1799/1790-1799/1798/verifierE.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refE_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1798E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(4) + 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		v := rand.Intn(10) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%sactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1798/verifierF.go
+++ b/1000-1999/1700-1799/1790-1799/1798/verifierF.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refF_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1798F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(5) + 2
+	k := rand.Intn(n) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(20) + 1
+	}
+	s := make([]int, k)
+	remaining := n + 1
+	for i := 0; i < k-1; i++ {
+		maxv := remaining - (k - i - 1)
+		s[i] = rand.Intn(maxv) + 1
+		remaining -= s[i]
+	}
+	s[k-1] = remaining
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range s {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%sactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1798
- each verifier builds the reference solution, generates 100 random tests, and compares outputs

## Testing
- `go build 1000-1999/1700-1799/1790-1799/1798/verifierA.go`
- `go build 1000-1999/1700-1799/1790-1799/1798/verifierB.go`
- `go build 1000-1999/1700-1799/1790-1799/1798/verifierC.go`
- `go build 1000-1999/1700-1799/1790-1799/1798/verifierD.go`
- `go build 1000-1999/1700-1799/1790-1799/1798/verifierE.go`
- `go build 1000-1999/1700-1799/1790-1799/1798/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688766451e3c832498b6bc0b53e1407a