### PR TITLE
Add verifier utilities for contest 1800

### DIFF
--- a/1000-1999/1800-1899/1800-1809/1800/verifierA.go
+++ b/1000-1999/1800-1899/1800-1809/1800/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isMeow(s string) bool {
+	s = strings.ToLower(s)
+	letters := []byte{'m', 'e', 'o', 'w'}
+	idx := 0
+	for _, ch := range letters {
+		if idx >= len(s) || s[idx] != ch {
+			return false
+		}
+		for idx < len(s) && s[idx] == ch {
+			idx++
+		}
+	}
+	return idx == len(s)
+}
+
+func solveA(n int, s string) string {
+	if isMeow(s) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	s := sb.String()
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	expected := solveA(n, s)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1800/verifierB.go
+++ b/1000-1999/1800-1899/1800-1809/1800/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(n, k int, s string) string {
+	lower := make([]int, 26)
+	upper := make([]int, 26)
+	for _, ch := range s {
+		if ch >= 'a' && ch <= 'z' {
+			lower[ch-'a']++
+		} else if ch >= 'A' && ch <= 'Z' {
+			upper[ch-'A']++
+		}
+	}
+	ans := 0
+	for i := 0; i < 26; i++ {
+		pairs := min(lower[i], upper[i])
+		ans += pairs
+		diff := abs(lower[i] - upper[i])
+		extra := min(k, diff/2)
+		ans += extra
+		k -= extra
+	}
+	return fmt.Sprint(ans)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	k := rng.Intn(n + 1)
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	s := sb.String()
+	input := fmt.Sprintf("1\n%d %d\n%s\n", n, k, s)
+	expected := solveB(n, k, s)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1800/verifierC1.go
+++ b/1000-1999/1800-1899/1800-1809/1800/verifierC1.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type MaxHeap struct{ sort.IntSlice }
+
+func (h MaxHeap) Less(i, j int) bool  { return h.IntSlice[i] > h.IntSlice[j] }
+func (h *MaxHeap) Push(x interface{}) { h.IntSlice = append(h.IntSlice, x.(int)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := h.IntSlice
+	x := old[len(old)-1]
+	h.IntSlice = old[:len(old)-1]
+	return x
+}
+func (h *MaxHeap) Peek() int { return h.IntSlice[0] }
+
+func solveC1(arr []int) string {
+	h := &MaxHeap{}
+	heap.Init(h)
+	var ans int64
+	for _, x := range arr {
+		if x == 0 {
+			if h.Len() > 0 {
+				ans += int64(h.Peek())
+				heap.Pop(h)
+			}
+		} else {
+			heap.Push(h, x)
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		if rng.Intn(2) == 0 {
+			arr[i] = 0
+		} else {
+			arr[i] = rng.Intn(100) + 1
+		}
+	}
+	sb := strings.Builder{}
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprint(n))
+	sb.WriteByte('\n')
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	expected := solveC1(arr)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1800/verifierC2.go
+++ b/1000-1999/1800-1899/1800-1809/1800/verifierC2.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type MaxHeap []int
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func solveC2(arr []int) string {
+	h := &MaxHeap{}
+	var ans int64
+	for _, x := range arr {
+		if x > 0 {
+			heap.Push(h, x)
+		} else {
+			if h.Len() > 0 {
+				ans += int64(heap.Pop(h).(int))
+			}
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		if rng.Intn(2) == 0 {
+			arr[i] = 0
+		} else {
+			if rng.Intn(2) == 0 {
+				arr[i] = -rng.Intn(5)
+			} else {
+				arr[i] = rng.Intn(100) + 1
+			}
+		}
+	}
+	sb := strings.Builder{}
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprint(n))
+	sb.WriteByte('\n')
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	expected := solveC2(arr)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1800/verifierD.go
+++ b/1000-1999/1800-1899/1800-1809/1800/verifierD.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(n int, s string) string {
+	dup := 0
+	for i := 0; i < n-2; i++ {
+		if s[i] == s[i+2] {
+			dup++
+		}
+	}
+	return fmt.Sprint(n - 1 - dup)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	s := sb.String()
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	expected := solveD(n, s)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1800/verifierE1.go
+++ b/1000-1999/1800-1899/1800-1809/1800/verifierE1.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent []int
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n)
+	for i := range p {
+		p[i] = i
+	}
+	return &DSU{parent: p}
+}
+
+func (d *DSU) Find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.Find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) Union(a, b int) {
+	ra := d.Find(a)
+	rb := d.Find(b)
+	if ra != rb {
+		d.parent[ra] = rb
+	}
+}
+
+func solveE1(n int, s, t string) string {
+	k := 3
+	dsu := NewDSU(n)
+	for i := 0; i+k < n; i++ {
+		dsu.Union(i, i+k)
+	}
+	for i := 0; i+k+1 < n; i++ {
+		dsu.Union(i, i+k+1)
+	}
+	countsS := make(map[int][26]int)
+	countsT := make(map[int][26]int)
+	for i := 0; i < n; i++ {
+		r := dsu.Find(i)
+		cs := countsS[r]
+		cs[int(s[i]-'a')]++
+		countsS[r] = cs
+		ct := countsT[r]
+		ct[int(t[i]-'a')]++
+		countsT[r] = ct
+	}
+	for r, cs := range countsS {
+		ct := countsT[r]
+		for j := 0; j < 26; j++ {
+			if cs[j] != ct[j] {
+				return "NO"
+			}
+		}
+	}
+	return "YES"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	var sb1, sb2 strings.Builder
+	for i := 0; i < n; i++ {
+		sb1.WriteByte(letters[rng.Intn(len(letters))])
+		sb2.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	s := sb1.String()
+	t := sb2.String()
+	input := fmt.Sprintf("1\n%d 3\n%s\n%s\n", n, s, t)
+	expected := solveE1(n, s, t)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1800/verifierE2.go
+++ b/1000-1999/1800-1899/1800-1809/1800/verifierE2.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent []int
+	size   []int
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n)
+	sz := make([]int, n)
+	for i := range p {
+		p[i] = i
+		sz[i] = 1
+	}
+	return &DSU{parent: p, size: sz}
+}
+
+func (d *DSU) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) union(a, b int) {
+	ra := d.find(a)
+	rb := d.find(b)
+	if ra == rb {
+		return
+	}
+	if d.size[ra] < d.size[rb] {
+		ra, rb = rb, ra
+	}
+	d.parent[rb] = ra
+	d.size[ra] += d.size[rb]
+}
+
+func solveE2(n, k int, s, t string) string {
+	dsu := NewDSU(n)
+	for i := 0; i < n; i++ {
+		if i+k < n {
+			dsu.union(i, i+k)
+		}
+		if i+k+1 < n {
+			dsu.union(i, i+k+1)
+		}
+	}
+	counts := make(map[int][]int)
+	for i := 0; i < n; i++ {
+		r := dsu.find(i)
+		arr, ok := counts[r]
+		if !ok {
+			arr = make([]int, 26)
+			counts[r] = arr
+		}
+		arr[s[i]-'a']++
+		arr[t[i]-'a']--
+	}
+	for _, arr := range counts {
+		for j := 0; j < 26; j++ {
+			if arr[j] != 0 {
+				return "NO"
+			}
+		}
+	}
+	return "YES"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	var sb1, sb2 strings.Builder
+	for i := 0; i < n; i++ {
+		sb1.WriteByte(letters[rng.Intn(len(letters))])
+		sb2.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	s := sb1.String()
+	t := sb2.String()
+	input := fmt.Sprintf("1\n%d %d\n%s\n%s\n", n, k, s, t)
+	expected := solveE2(n, k, s, t)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1800/verifierF.go
+++ b/1000-1999/1800-1899/1800-1809/1800/verifierF.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1800F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func randomWord(rng *rand.Rand) string {
+	l := rng.Intn(10) + 1
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	var sb strings.Builder
+	for i := 0; i < l; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	words := make([]string, n)
+	for i := range words {
+		words[i] = randomWord(rng)
+	}
+	input := fmt.Sprintf("%d\n%s\n", n, strings.Join(words, "\n"))
+
+	oracle, err := buildOracle()
+	if err != nil {
+		return "", ""
+	}
+	defer os.Remove(oracle)
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return "", ""
+	}
+	expected := strings.TrimSpace(outO.String())
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if exp == "" {
+			fmt.Fprintln(os.Stderr, "failed to build oracle")
+			os.Exit(1)
+		}
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1800/verifierG.go
+++ b/1000-1999/1800-1899/1800-1809/1800/verifierG.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleG")
+	cmd := exec.Command("go", "build", "-o", oracle, "1800G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateTree(rng *rand.Rand) (int, [][2]int) {
+	n := rng.Intn(10) + 1
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	return n, edges
+}
+
+func buildInput(n int, edges [][2]int) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprint(n))
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func oracleAnswer(oracle, input string) (string, error) {
+	cmd := exec.Command(oracle)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, edges := generateTree(rng)
+		input := buildInput(n, edges)
+		exp, err := oracleAnswer(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for contest 1800 problems A–G
- each verifier runs 100 randomly generated test cases
- verifiers use embedded solutions or build an oracle from the reference implementation when needed

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC1.go verifierC2.go verifierD.go verifierE1.go verifierE2.go verifierF.go verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_688766d175e88324973ddcdf97dfcd26