### PR TITLE
Add solution verifiers for CF contest 1797

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1797/verifierA.go
+++ b/1000-1999/1700-1799/1790-1799/1797/verifierA.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func degree(n, m, x, y int) int {
+	d := 4
+	if x == 1 {
+		d--
+	}
+	if x == n {
+		d--
+	}
+	if y == 1 {
+		d--
+	}
+	if y == m {
+		d--
+	}
+	return d
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierA.go path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if b, err := filepath.Abs(bin); err == nil {
+		bin = b
+	}
+
+	rand.Seed(1)
+	const T = 100
+	type test struct {
+		n, m   int
+		x1, y1 int
+		x2, y2 int
+	}
+	tests := make([]test, T)
+	var input strings.Builder
+	input.WriteString(strconv.Itoa(T) + "\n")
+	for i := 0; i < T; i++ {
+		n := rand.Intn(7) + 4 // 4..10
+		m := rand.Intn(7) + 4
+		x1 := rand.Intn(n) + 1
+		y1 := rand.Intn(m) + 1
+		var x2, y2 int
+		for {
+			x2 = rand.Intn(n) + 1
+			y2 = rand.Intn(m) + 1
+			if abs(x1-x2)+abs(y1-y2) >= 2 {
+				break
+			}
+		}
+		tests[i] = test{n, m, x1, y1, x2, y2}
+		input.WriteString(fmt.Sprintf("%d %d\n%d %d %d %d\n", n, m, x1, y1, x2, y2))
+	}
+
+	out, err := runBinary(bin, input.String())
+	if err != nil {
+		fmt.Println("binary error:", err)
+		os.Exit(1)
+	}
+	fields := strings.Fields(out)
+	if len(fields) != T {
+		fmt.Printf("wrong number of outputs: got %d want %d\n", len(fields), T)
+		os.Exit(1)
+	}
+
+	for i := 0; i < T; i++ {
+		expect := degree(tests[i].n, tests[i].m, tests[i].x1, tests[i].y1)
+		d2 := degree(tests[i].n, tests[i].m, tests[i].x2, tests[i].y2)
+		if d2 < expect {
+			expect = d2
+		}
+		got, err := strconv.Atoi(fields[i])
+		if err != nil {
+			fmt.Println("invalid output")
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed: expected %d got %d\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/1000-1999/1700-1799/1790-1799/1797/verifierB.go
+++ b/1000-1999/1700-1799/1790-1799/1797/verifierB.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solve(n, k int, grid [][]int) string {
+	mismatches := 0
+	for i := 0; i < n; i++ {
+		ni := n - 1 - i
+		for j := 0; j < n; j++ {
+			nj := n - 1 - j
+			if i < ni || (i == ni && j < nj) {
+				if grid[i][j] != grid[ni][nj] {
+					mismatches++
+				}
+			}
+		}
+	}
+	if k < mismatches {
+		return "NO"
+	}
+	if n%2 == 1 || (k-mismatches)%2 == 0 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierB.go path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if b, err := filepath.Abs(bin); err == nil {
+		bin = b
+	}
+
+	rand.Seed(2)
+	const T = 100
+	type test struct {
+		n    int
+		k    int
+		grid [][]int
+	}
+	tests := make([]test, T)
+	var input strings.Builder
+	input.WriteString(strconv.Itoa(T) + "\n")
+	for i := 0; i < T; i++ {
+		n := rand.Intn(4) + 1 // 1..4
+		k := rand.Intn(11)    // 0..10
+		g := make([][]int, n)
+		for r := 0; r < n; r++ {
+			g[r] = make([]int, n)
+			for c := 0; c < n; c++ {
+				g[r][c] = rand.Intn(2)
+			}
+		}
+		tests[i] = test{n, k, g}
+		input.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for r := 0; r < n; r++ {
+			for c := 0; c < n; c++ {
+				if c > 0 {
+					input.WriteByte(' ')
+				}
+				input.WriteString(strconv.Itoa(g[r][c]))
+			}
+			input.WriteByte('\n')
+		}
+	}
+
+	out, err := runBinary(bin, input.String())
+	if err != nil {
+		fmt.Println("binary error:", err)
+		os.Exit(1)
+	}
+	fields := strings.Fields(out)
+	if len(fields) != T {
+		fmt.Printf("wrong number of outputs: got %d want %d\n", len(fields), T)
+		os.Exit(1)
+	}
+	for i := 0; i < T; i++ {
+		expect := solve(tests[i].n, tests[i].k, tests[i].grid)
+		if fields[i] != expect {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expect, fields[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1797/verifierC.go
+++ b/1000-1999/1700-1799/1790-1799/1797/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func runInteractive(bin string, n, m, hx, hy int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// send n m
+	fmt.Fprintf(stdin, "%d %d\n", n, m)
+	reader := bufio.NewReader(stdout)
+
+	var r1, c1 int
+	if _, err := fmt.Fscan(reader, &r1, &c1); err != nil {
+		return fmt.Errorf("failed to read query1: %v", err)
+	}
+	fmt.Fprintf(stdin, "%d\n", abs(r1-hx)+abs(c1-hy))
+
+	var r2, c2 int
+	if _, err := fmt.Fscan(reader, &r2, &c2); err != nil {
+		return fmt.Errorf("failed to read query2: %v", err)
+	}
+	fmt.Fprintf(stdin, "%d\n", abs(r2-hx)+abs(c2-hy))
+
+	var fr, fc int
+	if _, err := fmt.Fscan(reader, &fr, &fc); err != nil {
+		return fmt.Errorf("failed to read final: %v", err)
+	}
+
+	stdin.Close()
+	err = cmd.Wait()
+	if err != nil {
+		return fmt.Errorf("binary error: %v", err)
+	}
+
+	if fr != hx || fc != hy {
+		return fmt.Errorf("expected %d %d got %d %d", hx, hy, fr, fc)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierC.go path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if b, err := filepath.Abs(bin); err == nil {
+		bin = b
+	}
+
+	rand.Seed(3)
+	const T = 100
+	for i := 0; i < T; i++ {
+		n := rand.Intn(4) + 2 // 2..5
+		m := rand.Intn(4) + 2
+		hx := rand.Intn(n) + 1
+		hy := rand.Intn(m) + 1
+		if err := runInteractive(bin, n, m, hx, hy); err != nil {
+			fmt.Printf("test %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1797/verifierD.go
+++ b/1000-1999/1700-1799/1790-1799/1797/verifierD.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type Tree struct {
+	parent   []int
+	children [][]int
+	value    []int64
+}
+
+func newTree(n int) *Tree {
+	return &Tree{
+		parent:   make([]int, n+1),
+		children: make([][]int, n+1),
+		value:    make([]int64, n+1),
+	}
+}
+
+func (t *Tree) orient(root int, edges [][2]int) {
+	g := make([][]int, len(t.parent))
+	for _, e := range edges {
+		g[e[0]] = append(g[e[0]], e[1])
+		g[e[1]] = append(g[e[1]], e[0])
+	}
+	stack := []int{root}
+	t.parent[root] = 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, to := range g[v] {
+			if to == t.parent[v] {
+				continue
+			}
+			t.parent[to] = v
+			t.children[v] = append(t.children[v], to)
+			stack = append(stack, to)
+		}
+	}
+}
+
+func (t *Tree) subtreeSum(v int) (int64, int) {
+	sum := t.value[v]
+	size := 1
+	for _, c := range t.children[v] {
+		s, sz := t.subtreeSum(c)
+		sum += s
+		size += sz
+	}
+	return sum, size
+}
+
+func (t *Tree) rotate(x int) {
+	if len(t.children[x]) == 0 {
+		return
+	}
+	maxSize := -1
+	hvIdx := -1
+	hv := 0
+	for idx, c := range t.children[x] {
+		_, sz := t.subtreeSum(c)
+		if sz > maxSize || (sz == maxSize && c < hv) {
+			maxSize = sz
+			hv = c
+			hvIdx = idx
+		}
+	}
+	if hvIdx == -1 {
+		return
+	}
+	p := t.parent[x]
+	t.children[x] = append(t.children[x][:hvIdx], t.children[x][hvIdx+1:]...)
+	if p != 0 {
+		for i, c := range t.children[p] {
+			if c == x {
+				t.children[p][i] = hv
+				break
+			}
+		}
+	}
+	t.parent[hv] = p
+	t.parent[x] = hv
+	t.children[hv] = append(t.children[hv], x)
+}
+
+func naive(n, m int, vals []int64, edges [][2]int, ops [][2]int) []int64 {
+	tr := newTree(n)
+	copy(tr.value[1:], vals)
+	tr.orient(1, edges)
+	res := []int64{}
+	for _, op := range ops {
+		if op[0] == 1 {
+			s, _ := tr.subtreeSum(op[1])
+			res = append(res, s)
+		} else {
+			tr.rotate(op[1])
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierD.go path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if b, err := filepath.Abs(bin); err == nil {
+		bin = b
+	}
+
+	rand.Seed(4)
+	const T = 100
+	for tc := 0; tc < T; tc++ {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(4) + 1
+		vals := make([]int64, n)
+		for i := 0; i < n; i++ {
+			vals[i] = int64(rand.Intn(5) + 1)
+		}
+		edges := make([][2]int, n-1)
+		for i := 0; i < n-1; i++ {
+			u := i + 2
+			v := rand.Intn(i+1) + 1
+			edges[i] = [2]int{u, v}
+		}
+		ops := make([][2]int, m)
+		for i := 0; i < m; i++ {
+			typ := rand.Intn(2) + 1
+			x := rand.Intn(n) + 1
+			ops[i] = [2]int{typ, x}
+		}
+
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(strconv.FormatInt(vals[i], 10))
+		}
+		input.WriteByte('\n')
+		for _, e := range edges {
+			input.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		for _, op := range ops {
+			input.WriteString(fmt.Sprintf("%d %d\n", op[0], op[1]))
+		}
+
+		expected := naive(n, m, vals, edges, ops)
+		out, err := runBinary(bin, input.String())
+		if err != nil {
+			fmt.Printf("test %d binary error: %v\n", tc+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != len(expected) {
+			fmt.Printf("test %d wrong number of outputs\n", tc+1)
+			os.Exit(1)
+		}
+		for i, exp := range expected {
+			got, err := strconv.ParseInt(fields[i], 10, 64)
+			if err != nil || got != exp {
+				fmt.Printf("test %d failed at output %d: expected %d got %s\n", tc+1, i+1, exp, fields[i])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1797/verifierE.go
+++ b/1000-1999/1700-1799/1790-1799/1797/verifierE.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func phi(n int) int {
+	res := n
+	p := 2
+	x := n
+	for p*p <= x {
+		if x%p == 0 {
+			for x%p == 0 {
+				x /= p
+			}
+			res -= res / p
+		}
+		p++
+	}
+	if x > 1 {
+		res -= res / x
+	}
+	return res
+}
+
+func seq(x int) []int {
+	s := []int{x}
+	for x > 1 {
+		x = phi(x)
+		s = append(s, x)
+	}
+	return s
+}
+
+func minChanges(arr []int) int {
+	lists := make([][]int, len(arr))
+	for i, v := range arr {
+		lists[i] = seq(v)
+	}
+	best := int(^uint(0) >> 1)
+	for _, l := range lists {
+		for idx, val := range l {
+			cost := idx
+			for j, other := range lists {
+				if j == 0 {
+					continue
+				}
+				pos := -1
+				for k, vv := range other {
+					if vv == val {
+						pos = k
+						break
+					}
+				}
+				if pos == -1 {
+					cost = best + 1
+					break
+				}
+				cost += pos
+			}
+			if cost < best {
+				best = cost
+			}
+		}
+	}
+	return best
+}
+
+func naive(n, m int, arr []int, ops [][3]int) []int {
+	res := []int{}
+	for _, op := range ops {
+		if op[0] == 1 {
+			for i := op[1] - 1; i < op[2]; i++ {
+				arr[i] = phi(arr[i])
+			}
+		} else {
+			seg := make([]int, op[2]-op[1]+1)
+			copy(seg, arr[op[1]-1:op[2]])
+			res = append(res, minChanges(seg))
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierE.go path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if b, err := filepath.Abs(bin); err == nil {
+		bin = b
+	}
+
+	rand.Seed(5)
+	const T = 100
+	for tc := 0; tc < T; tc++ {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(4) + 1
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rand.Intn(10) + 1
+		}
+		ops := make([][3]int, m)
+		for i := 0; i < m; i++ {
+			t := rand.Intn(2) + 1
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			ops[i] = [3]int{t, l, r}
+		}
+
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i, v := range arr {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(strconv.Itoa(v))
+		}
+		input.WriteByte('\n')
+		for _, op := range ops {
+			input.WriteString(fmt.Sprintf("%d %d %d\n", op[0], op[1], op[2]))
+		}
+
+		expected := naive(n, m, append([]int(nil), arr...), ops)
+		out, err := runBinary(bin, input.String())
+		if err != nil {
+			fmt.Printf("test %d binary error: %v\n", tc+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != len(expected) {
+			fmt.Printf("test %d wrong number of outputs\n", tc+1)
+			os.Exit(1)
+		}
+		for i, exp := range expected {
+			got, err := strconv.Atoi(fields[i])
+			if err != nil || got != exp {
+				fmt.Printf("test %d failed at output %d: expected %d got %s\n", tc+1, i+1, exp, fields[i])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1797/verifierF.go
+++ b/1000-1999/1700-1799/1790-1799/1797/verifierF.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func getPath(u, v int, g [][]int, t int) []int {
+	parent := make([]int, t+1)
+	for i := range parent {
+		parent[i] = -1
+	}
+	q := []int{u}
+	parent[u] = 0
+	for len(q) > 0 {
+		x := q[0]
+		q = q[1:]
+		if x == v {
+			break
+		}
+		for _, y := range g[x] {
+			if y < 1 || y > t {
+				continue
+			}
+			if parent[y] == -1 {
+				parent[y] = x
+				q = append(q, y)
+			}
+		}
+	}
+	if parent[v] == -1 {
+		return nil
+	}
+	var path []int
+	cur := v
+	for cur != 0 {
+		path = append([]int{cur}, path...)
+		cur = parent[cur]
+	}
+	return path
+}
+
+func countCute(t int, g [][]int) int {
+	res := 0
+	for u := 1; u <= t; u++ {
+		for v := u + 1; v <= t; v++ {
+			path := getPath(u, v, g, t)
+			if len(path) == 0 {
+				continue
+			}
+			minIdx, maxIdx := path[0], path[0]
+			for _, x := range path[1:] {
+				if x < minIdx {
+					minIdx = x
+				}
+				if x > maxIdx {
+					maxIdx = x
+				}
+			}
+			cond1 := u == minIdx
+			cond2 := v == maxIdx
+			if (cond1 && !cond2) || (!cond1 && cond2) {
+				res++
+			}
+		}
+	}
+	return res
+}
+
+func naive(n int, edges [][2]int, ops []int) []int {
+	maxN := 2*n + len(ops) + 5
+	g := make([][]int, maxN)
+	for _, e := range edges {
+		g[e[0]] = append(g[e[0]], e[1])
+		g[e[1]] = append(g[e[1]], e[0])
+	}
+	results := make([]int, 0, len(ops)+1)
+	cur := n
+	results = append(results, countCute(cur, g))
+	for _, p := range ops {
+		cur++
+		g[p] = append(g[p], cur)
+		g[cur] = append(g[cur], p)
+		results = append(results, countCute(cur, g))
+	}
+	return results
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierF.go path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if b, err := filepath.Abs(bin); err == nil {
+		bin = b
+	}
+
+	rand.Seed(6)
+	const T = 100
+	for tc := 0; tc < T; tc++ {
+		n := rand.Intn(4) + 2
+		edges := make([][2]int, n-1)
+		for i := 0; i < n-1; i++ {
+			u := i + 2
+			v := rand.Intn(i+1) + 1
+			edges[i] = [2]int{u, v}
+		}
+		m := rand.Intn(3) + 1
+		ops := make([]int, m)
+		for i := 0; i < m; i++ {
+			ops[i] = rand.Intn(n+i) + 1
+		}
+
+		var input strings.Builder
+		input.WriteString(strconv.Itoa(n) + "\n")
+		for _, e := range edges {
+			input.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input.WriteString(strconv.Itoa(m) + "\n")
+		for _, k := range ops {
+			input.WriteString(strconv.Itoa(k) + "\n")
+		}
+
+		expected := naive(n, edges, ops)
+		out, err := runBinary(bin, input.String())
+		if err != nil {
+			fmt.Printf("test %d binary error: %v\n", tc+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != len(expected) {
+			fmt.Printf("test %d wrong number of outputs\n", tc+1)
+			os.Exit(1)
+		}
+		for i, exp := range expected {
+			got, err := strconv.Atoi(fields[i])
+			if err != nil || got != exp {
+				fmt.Printf("test %d failed at output %d: expected %d got %s\n", tc+1, i+1, exp, fields[i])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go`..`verifierF.go` to check binaries for contest 1797
- each verifier generates 100 deterministic random tests
- verifiers run provided binaries (Go files or executables) and compare outputs using naive reference implementations
- interactive verifier implemented for problem C

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688765ff1dec8324abfbf6641a92081d