### PR TITLE
Add Go verifiers for contest 1799

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1799/verifierA.go
+++ b/1000-1999/1700-1799/1790-1799/1799/verifierA.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const numTestsA = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binA")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleA")
+	cmd := exec.Command("go", "build", "-o", tmp, "1799A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", n+1+rng.Intn(m))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := prepareBinary(binPath)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsA; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1799/verifierB.go
+++ b/1000-1999/1700-1799/1790-1799/1799/verifierB.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const numTestsB = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binB")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleB")
+	cmd := exec.Command("go", "build", "-o", tmp, "1799B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(9)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func simulate(arr []int, ops [][2]int) ([]int, bool) {
+	for _, op := range ops {
+		i, j := op[0]-1, op[1]-1
+		if i < 0 || i >= len(arr) || j < 0 || j >= len(arr) || i == j || arr[j] == 0 {
+			return nil, false
+		}
+		arr[i] = (arr[i] + arr[j] - 1) / arr[j]
+	}
+	return arr, true
+}
+
+func parseOutput(out string, n int) (int, [][2]int, error) {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	if !scanner.Scan() {
+		return 0, nil, fmt.Errorf("no output")
+	}
+	var q int
+	if _, err := fmt.Sscan(scanner.Text(), &q); err != nil {
+		return 0, nil, fmt.Errorf("bad q")
+	}
+	if q == -1 {
+		if scanner.Scan() {
+			return 0, nil, fmt.Errorf("extra output after -1")
+		}
+		return -1, nil, nil
+	}
+	if q > 30*n {
+		return 0, nil, fmt.Errorf("too many operations")
+	}
+	ops := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		if !scanner.Scan() {
+			return 0, nil, fmt.Errorf("missing op")
+		}
+		var x, y int
+		if _, err := fmt.Sscan(scanner.Text(), &x, &y); err != nil {
+			return 0, nil, fmt.Errorf("bad op line")
+		}
+		ops[i] = [2]int{x, y}
+	}
+	if scanner.Scan() {
+		return 0, nil, fmt.Errorf("extra output")
+	}
+	return q, ops, nil
+}
+
+func runCase(bin, oracle, input string) error {
+	expectStr, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	// parse input
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	scanner.Scan() // t=1
+	var n int
+	fmt.Sscan(scanner.Text())
+	scanner.Scan()
+	arr := []int{}
+	for _, s := range strings.Fields(scanner.Text()) {
+		var v int
+		fmt.Sscan(s, &v)
+		arr = append(arr, v)
+	}
+	gotStr, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	q, ops, err := parseOutput(gotStr, n)
+	if err != nil {
+		return err
+	}
+	if q == -1 {
+		if expectStr != "-1" {
+			return fmt.Errorf("expected solution but got -1")
+		}
+		return nil
+	}
+	if expectStr == "-1" {
+		return fmt.Errorf("expected -1 but provided operations")
+	}
+	final, ok := simulate(append([]int(nil), arr...), ops)
+	if !ok {
+		return fmt.Errorf("invalid operations")
+	}
+	eq := true
+	for i := 1; i < len(final); i++ {
+		if final[i] != final[0] {
+			eq = false
+			break
+		}
+	}
+	if !eq {
+		return fmt.Errorf("array not equal after operations")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := prepareBinary(binPath)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsB; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1799/verifierC.go
+++ b/1000-1999/1700-1799/1790-1799/1799/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const numTestsC = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binC")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleC")
+	cmd := exec.Command("go", "build", "-o", tmp, "1799C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		l := rng.Intn(5) + 1
+		for j := 0; j < l; j++ {
+			sb.WriteByte(byte('a' + rng.Intn(3)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := prepareBinary(binPath)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsC; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1799/verifierD1.go
+++ b/1000-1999/1700-1799/1790-1799/1799/verifierD1.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const numTestsD1 = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binD1")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleD1")
+	cmd := exec.Command("go", "build", "-o", tmp, "1799D1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(4) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(k)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(9)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		cold := rng.Intn(9) + 1
+		hot := rng.Intn(cold) + 1
+		fmt.Fprintf(&sb, "%d", hot)
+		if i < k-1 {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		return
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := prepareBinary(binPath)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsD1; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1799/verifierD2.go
+++ b/1000-1999/1700-1799/1790-1799/1799/verifierD2.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const numTestsD2 = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binD2")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleD2")
+	cmd := exec.Command("go", "build", "-o", tmp, "1799D2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(4) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(k)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(9)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		cold := rng.Intn(9) + 1
+		hot := rng.Intn(cold) + 1
+		fmt.Fprintf(&sb, "%d", hot)
+		if i < k-1 {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		return
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := prepareBinary(binPath)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsD2; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1799/verifierE.go
+++ b/1000-1999/1700-1799/1790-1799/1799/verifierE.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const numTestsE = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binE")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleE")
+	cmd := exec.Command("go", "build", "-o", tmp, "1799E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+type gridCase struct {
+	n, m int
+	grid [][]byte
+}
+
+func generateCase(rng *rand.Rand) gridCase {
+	n := rng.Intn(3) + 3
+	m := rng.Intn(3) + 3
+	grid := make([][]byte, n)
+	for i := range grid {
+		grid[i] = make([]byte, m)
+		for j := range grid[i] {
+			grid[i][j] = '.'
+		}
+	}
+	// place two cities as single cells
+	r1, c1 := rng.Intn(n), rng.Intn(m)
+	r2, c2 := rng.Intn(n), rng.Intn(m)
+	for r1 == r2 && c1 == c2 {
+		r2, c2 = rng.Intn(n), rng.Intn(m)
+	}
+	grid[r1][c1] = '#'
+	grid[r2][c2] = '#'
+	return gridCase{n, m, grid}
+}
+
+func formatInput(tc gridCase) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", tc.n, tc.m)
+	for i := 0; i < tc.n; i++ {
+		sb.Write(tc.grid[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func parseGrid(out string, n, m int) ([][]byte, error) {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		if !scanner.Scan() {
+			return nil, fmt.Errorf("missing row")
+		}
+		line := scanner.Text()
+		if len(line) != m {
+			return nil, fmt.Errorf("bad row length")
+		}
+		grid[i] = []byte(line)
+	}
+	if scanner.Scan() {
+		return nil, fmt.Errorf("extra output")
+	}
+	return grid, nil
+}
+
+func cost(orig, ans [][]byte) int {
+	n := len(orig)
+	m := len(orig[0])
+	cnt := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if orig[i][j] == '.' && ans[i][j] == '#' {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func connected(grid [][]byte) bool {
+	n := len(grid)
+	m := len(grid[0])
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	visited := make([][]bool, n)
+	for i := range visited {
+		visited[i] = make([]bool, m)
+	}
+	var q [][2]int
+	found := false
+	for i := 0; i < n && !found; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '#' {
+				q = append(q, [2]int{i, j})
+				visited[i][j] = true
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		return true
+	}
+	idx := 0
+	for idx < len(q) {
+		x, y := q[idx][0], q[idx][1]
+		idx++
+		for _, d := range dirs {
+			nx, ny := x+d[0], y+d[1]
+			if nx >= 0 && nx < n && ny >= 0 && ny < m && grid[nx][ny] == '#' && !visited[nx][ny] {
+				visited[nx][ny] = true
+				q = append(q, [2]int{nx, ny})
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '#' && !visited[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func manhattanOK(grid [][]byte) bool {
+	n := len(grid)
+	m := len(grid[0])
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	cells := [][2]int{}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '#' {
+				cells = append(cells, [2]int{i, j})
+			}
+		}
+	}
+	dist := make([][]int, n)
+	for i := range dist {
+		dist[i] = make([]int, m)
+	}
+	for _, c := range cells {
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				dist[i][j] = -1
+			}
+		}
+		q := [][2]int{c}
+		dist[c[0]][c[1]] = 0
+		idx := 0
+		for idx < len(q) {
+			x, y := q[idx][0], q[idx][1]
+			idx++
+			for _, d := range dirs {
+				nx, ny := x+d[0], y+d[1]
+				if nx >= 0 && nx < n && ny >= 0 && ny < m && grid[nx][ny] == '#' && dist[nx][ny] == -1 {
+					dist[nx][ny] = dist[x][y] + 1
+					q = append(q, [2]int{nx, ny})
+				}
+			}
+		}
+		for _, c2 := range cells {
+			md := abs(c[0]-c2[0]) + abs(c[1]-c2[1])
+			if dist[c2[0]][c2[1]] != md {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func validate(orig, ans [][]byte) error {
+	n := len(orig)
+	m := len(orig[0])
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if orig[i][j] == '#' && ans[i][j] != '#' {
+				return fmt.Errorf("removed filled cell")
+			}
+		}
+	}
+	if !connected(ans) {
+		return fmt.Errorf("not connected")
+	}
+	if !manhattanOK(ans) {
+		return fmt.Errorf("manhattan property failed")
+	}
+	return nil
+}
+
+func runCase(bin, oracle string, tc gridCase) error {
+	input := formatInput(tc)
+	oracleOut, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	oracleGrid, err := parseGrid(oracleOut, tc.n, tc.m)
+	if err != nil {
+		return fmt.Errorf("oracle output bad: %v", err)
+	}
+	expectCost := cost(tc.grid, oracleGrid)
+	gotOut, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	gotGrid, err := parseGrid(gotOut, tc.n, tc.m)
+	if err != nil {
+		return err
+	}
+	if err := validate(tc.grid, gotGrid); err != nil {
+		return err
+	}
+	gotCost := cost(tc.grid, gotGrid)
+	if gotCost != expectCost {
+		return fmt.Errorf("expected cost %d got %d", expectCost, gotCost)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := prepareBinary(binPath)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsE; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, formatInput(tc))
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1799/verifierF.go
+++ b/1000-1999/1700-1799/1790-1799/1799/verifierF.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const numTestsF = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binF")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleF")
+	cmd := exec.Command("go", "build", "-o", tmp, "1799F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	b := rng.Intn(10) + 1
+	k1 := rng.Intn(n + 1)
+	k2 := rng.Intn(n + 1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d %d\n", n, b, k1, k2)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(10)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := prepareBinary(binPath)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsF; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1799/verifierG.go
+++ b/1000-1999/1700-1799/1790-1799/1799/verifierG.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const numTestsG = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binG")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleG")
+	cmd := exec.Command("go", "build", "-o", tmp, "1799G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	c := make([]int, n)
+	sum := 0
+	for i := 0; i < n; i++ {
+		c[i] = rng.Intn(n) + 1
+		sum += c[i]
+	}
+	// normalize sum to n
+	for sum > n {
+		idx := rng.Intn(n)
+		if c[idx] > 0 {
+			c[idx]--
+			sum--
+		}
+	}
+	for sum < n {
+		idx := rng.Intn(n)
+		c[idx]++
+		sum++
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", c[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(n)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := prepareBinary(binPath)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsG; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1700-1799/1790-1799/1799/verifierH.go
+++ b/1000-1999/1700-1799/1790-1799/1799/verifierH.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const numTestsH = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binH")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleH")
+	cmd := exec.Command("go", "build", "-o", tmp, "1799H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	edges := generateTree(rng, n)
+	k := rng.Intn(min(6, n-1)) + 1
+	s := make([]int, k)
+	cur := n - 1
+	for i := 0; i < k; i++ {
+		s[i] = cur
+		cur--
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	fmt.Fprintf(&sb, "%d\n", k)
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", s[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func runCase(bin, oracle, input string) error {
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	binPath := os.Args[1]
+	bin, cleanup, err := prepareBinary(binPath)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < numTestsH; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces contest 1799 problems A–H
- each verifier compiles the user program and reference solution
- generate 100 random test cases per problem
- verify candidate binaries by comparing outputs or checking validity

## Testing
- `go build 1000-1999/1700-1799/1790-1799/1799/verifierA.go`
- `go build 1000-1999/1700-1799/1790-1799/1799/verifierB.go`
- `go build 1000-1999/1700-1799/1790-1799/1799/verifierC.go`
- `go build 1000-1999/1700-1799/1790-1799/1799/verifierD1.go`
- `go build 1000-1999/1700-1799/1790-1799/1799/verifierD2.go`
- `go build 1000-1999/1700-1799/1790-1799/1799/verifierE.go`
- `go build 1000-1999/1700-1799/1790-1799/1799/verifierF.go`
- `go build 1000-1999/1700-1799/1790-1799/1799/verifierG.go`
- `go build 1000-1999/1700-1799/1790-1799/1799/verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_6887668b26d48324b2d911ffdce54917