### PR TITLE
Add solution verifiers for contest 1808

### DIFF
--- a/1000-1999/1800-1899/1800-1809/1808/verifierA.go
+++ b/1000-1999/1800-1899/1800-1809/1808/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1808A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	l := rng.Int63n(1_000_000) + 1
+	r := l + rng.Int63n(1_000_000-l+1)
+	return fmt.Sprintf("1\n%d %d\n", l, r)
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1808/verifierB.go
+++ b/1000-1999/1800-1899/1800-1809/1808/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1808B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(1000))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1808/verifierC.go
+++ b/1000-1999/1800-1899/1800-1809/1808/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1808C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	limit := int64(1_000_000_000_000)
+	a := rng.Int63n(limit) + 1
+	b := a + rng.Int63n(limit-a+1)
+	return fmt.Sprintf("1\n%d %d\n", a, b)
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1808/verifierD.go
+++ b/1000-1999/1800-1899/1800-1809/1808/verifierD.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1808D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n)
+	if k%2 == 0 {
+		if k == 0 {
+			k = 1
+		} else {
+			k--
+		}
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(10)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1808/verifierE1.go
+++ b/1000-1999/1800-1899/1800-1809/1808/verifierE1.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE1")
+	cmd := exec.Command("go", "build", "-o", oracle, "1808E1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+var primes = []int64{3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Int63n(10) + 1
+	k := rng.Int63n(6) + 2
+	m := primes[rng.Intn(len(primes))]
+	return fmt.Sprintf("%d %d %d\n", n, k, m)
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1808/verifierE2.go
+++ b/1000-1999/1800-1899/1800-1809/1808/verifierE2.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE2")
+	cmd := exec.Command("go", "build", "-o", oracle, "1808E2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+var primes = []int64{3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Int63n(50) + 1
+	k := rng.Int63n(8) + 2
+	m := primes[rng.Intn(len(primes))]
+	return fmt.Sprintf("%d %d %d\n", n, k, m)
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1808/verifierE3.go
+++ b/1000-1999/1800-1899/1800-1809/1808/verifierE3.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE3")
+	cmd := exec.Command("go", "build", "-o", oracle, "1808E3.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+var primes = []int64{3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Int63n(50) + 1
+	k := rng.Int63n(8) + 2
+	m := primes[rng.Intn(len(primes))]
+	return fmt.Sprintf("%d %d %d\n", n, k, m)
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE3.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1808 (problems A–E3)
- each verifier builds the reference solution as an oracle and runs 100 random tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE1.go`
- `go build verifierE2.go`
- `go build verifierE3.go`


------
https://chatgpt.com/codex/tasks/task_e_6887690187b48324bd6bf5d1abf2ab3d