### PR TITLE
Add verifier suite for contest 1809

### DIFF
--- a/1000-1999/1800-1899/1800-1809/1809/verifierA.go
+++ b/1000-1999/1800-1899/1800-1809/1809/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	s string
+}
+
+func generateCaseA(rng *rand.Rand) (string, testCaseA) {
+	b := make([]byte, 4)
+	digits := "0123456789"
+	for i := 0; i < 4; i++ {
+		b[i] = digits[rng.Intn(10)]
+	}
+	s := string(b)
+	input := fmt.Sprintf("1\n%s\n", s)
+	return input, testCaseA{s: s}
+}
+
+func expectedA(tc testCaseA) string {
+	count := make(map[rune]int)
+	for _, ch := range tc.s {
+		count[ch]++
+	}
+	if len(count) == 1 {
+		return "-1"
+	}
+	ans := 4
+	for _, c := range count {
+		if c == 3 {
+			ans = 6
+			break
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, tc := generateCaseA(rng)
+		expect := expectedA(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1809/verifierB.go
+++ b/1000-1999/1800-1899/1800-1809/1809/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct{ n int64 }
+
+func generateCaseB(rng *rand.Rand) (string, testCaseB) {
+	n := rng.Int63n(1_000_000_000_000) // up to 1e12
+	input := fmt.Sprintf("1\n%d\n", n)
+	return input, testCaseB{n: n}
+}
+
+func isqrt(x int64) int64 {
+	r := int64(math.Sqrt(float64(x)))
+	for (r+1)*(r+1) <= x {
+		r++
+	}
+	for r*r > x {
+		r--
+	}
+	return r
+}
+
+func expectedB(tc testCaseB) string {
+	if tc.n == 0 {
+		return "0"
+	}
+	res := isqrt(tc.n - 1)
+	return fmt.Sprintf("%d", res)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, tc := generateCaseB(rng)
+		expect := expectedB(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1809/verifierC.go
+++ b/1000-1999/1800-1899/1800-1809/1809/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	n int
+	k int
+}
+
+func generateCaseC(rng *rand.Rand) (string, testCaseC) {
+	n := rng.Intn(29) + 2 // 2..30
+	maxK := n * (n + 1) / 2
+	k := rng.Intn(maxK + 1)
+	input := fmt.Sprintf("1\n%d %d\n", n, k)
+	return input, testCaseC{n: n, k: k}
+}
+
+func solveCaseC(n, k int) []int {
+	a := make([]int, n)
+	for i := range a {
+		a[i] = -1000
+	}
+	temp := 0
+	for i := 1; i <= n; i++ {
+		if i*(i+1)/2 <= k {
+			temp = i
+		}
+	}
+	remK := k - temp*(temp+1)/2
+	for i := 0; i < temp; i++ {
+		a[i] = i + 2
+	}
+	if remK > 0 {
+		sum := 0
+		for i := remK - 1; i < temp; i++ {
+			sum += a[i]
+		}
+		a[temp] = -(sum - 1)
+	}
+	return a
+}
+
+func expectedC(tc testCaseC) string {
+	arr := solveCaseC(tc.n, tc.k)
+	var sb strings.Builder
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, tc := generateCaseC(rng)
+		expect := expectedC(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1809/verifierD.go
+++ b/1000-1999/1800-1899/1800-1809/1809/verifierD.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseD struct {
+	s string
+}
+
+func generateCaseD(rng *rand.Rand) (string, testCaseD) {
+	n := rng.Intn(7) + 1 // length 1..7
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	s := string(b)
+	input := fmt.Sprintf("1\n%s\n", s)
+	return input, testCaseD{s: s}
+}
+
+func isSorted(s string) bool {
+	for i := 1; i < len(s); i++ {
+		if s[i-1] > s[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func minCost(s string) int64 {
+	const base = 1_000_000
+	type state struct {
+		cost int
+		str  string
+	}
+	pq := &statePQ{}
+	heap.Push(pq, state{0, s})
+	dist := map[string]int{s: 0}
+	for pq.Len() > 0 {
+		cur := heap.Pop(pq).(state)
+		if cur.cost != dist[cur.str] {
+			continue
+		}
+		if isSorted(cur.str) {
+			ops := cur.cost / base
+			rem := cur.cost % base
+			return int64(ops)*1_000_000_000_000 + int64(rem)
+		}
+		// swaps
+		for i := 0; i+1 < len(cur.str); i++ {
+			t := []byte(cur.str)
+			t[i], t[i+1] = t[i+1], t[i]
+			ns := string(t)
+			nc := cur.cost + base
+			if old, ok := dist[ns]; !ok || nc < old {
+				dist[ns] = nc
+				heap.Push(pq, state{nc, ns})
+			}
+		}
+		// removals
+		for i := 0; i < len(cur.str); i++ {
+			ns := cur.str[:i] + cur.str[i+1:]
+			nc := cur.cost + base + 1
+			if old, ok := dist[ns]; !ok || nc < old {
+				dist[ns] = nc
+				heap.Push(pq, state{nc, ns})
+			}
+		}
+	}
+	return 0
+}
+
+type statePQ []state
+
+func (p statePQ) Len() int            { return len(p) }
+func (p statePQ) Less(i, j int) bool  { return p[i].cost < p[j].cost }
+func (p statePQ) Swap(i, j int)       { p[i], p[j] = p[j], p[i] }
+func (p *statePQ) Push(x interface{}) { *p = append(*p, x.(state)) }
+func (p *statePQ) Pop() interface{} {
+	old := *p
+	v := old[len(old)-1]
+	*p = old[:len(old)-1]
+	return v
+}
+
+func expectedD(tc testCaseD) string {
+	res := minCost(tc.s)
+	return fmt.Sprintf("%d", res)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, tc := generateCaseD(rng)
+		expect := expectedD(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1809/verifierE.go
+++ b/1000-1999/1800-1899/1800-1809/1809/verifierE.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func simulate(start, T, a, b int, ops []int) int {
+	c := start
+	d := T - c
+	for _, v := range ops {
+		if v > 0 {
+			move := v
+			if move > c {
+				move = c
+			}
+			free := b - d
+			if move > free {
+				move = free
+			}
+			c -= move
+			d += move
+		} else {
+			move := -v
+			if move > d {
+				move = d
+			}
+			space := a - c
+			if move > space {
+				move = space
+			}
+			c += move
+			d -= move
+		}
+	}
+	return c
+}
+
+type testCaseE struct {
+	n   int
+	a   int
+	b   int
+	ops []int
+}
+
+func generateCaseE(rng *rand.Rand) (string, testCaseE) {
+	n := rng.Intn(4) + 1
+	a := rng.Intn(5) + 1
+	b := rng.Intn(5) + 1
+	ops := make([]int, n)
+	for i := 0; i < n; i++ {
+		v := rng.Intn(5) + 1
+		if rng.Intn(2) == 0 {
+			v = -v
+		}
+		ops[i] = v
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, a, b))
+	for i, v := range ops {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), testCaseE{n, a, b, ops}
+}
+
+func solveCaseE(n, a, b int, ops []int) [][]int {
+	adds := make([]int, n)
+	prefix := 0
+	minPref := 0
+	maxPref := 0
+	for i := 0; i < n; i++ {
+		adds[i] = -ops[i]
+		prefix += adds[i]
+		if prefix < minPref {
+			minPref = prefix
+		}
+		if prefix > maxPref {
+			maxPref = prefix
+		}
+	}
+	total := prefix
+	res := make([][]int, a+1)
+	for i := 0; i <= a; i++ {
+		res[i] = make([]int, b+1)
+	}
+	for T := 0; T <= a+b; T++ {
+		L := max(0, T-b)
+		U := min(a, T)
+		if L > U {
+			continue
+		}
+		resL := simulate(L, T, a, b, ops)
+		resU := simulate(U, T, a, b, ops)
+		thrLow := L - minPref
+		thrHigh := U - maxPref
+		for c := L; c <= U; c++ {
+			var val int
+			if c <= thrLow {
+				val = resL
+			} else if c >= thrHigh {
+				val = resU
+			} else {
+				val = c + total
+				if val < L {
+					val = L
+				} else if val > U {
+					val = U
+				}
+			}
+			d := T - c
+			if d >= 0 && d <= b {
+				res[c][d] = val
+			}
+		}
+	}
+	return res
+}
+
+func expectedE(tc testCaseE) string {
+	res := solveCaseE(tc.n, tc.a, tc.b, tc.ops)
+	var sb strings.Builder
+	for i := 0; i <= tc.a; i++ {
+		for j := 0; j <= tc.b; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", res[i][j]))
+		}
+		if i < tc.a {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, tc := generateCaseE(rng)
+		expect := expectedE(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1809/verifierF.go
+++ b/1000-1999/1800-1899/1800-1809/1809/verifierF.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseF struct {
+	n int
+	k int64
+	a []int64
+	b []int
+}
+
+func generateCaseF(rng *rand.Rand) (string, testCaseF) {
+	n := rng.Intn(5) + 3
+	k := int64(rng.Intn(20) + 1)
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(int(k)) + 1)
+	}
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = 1
+		} else {
+			b[i] = 2
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d %d\n", n, k))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), testCaseF{n, k, a, b}
+}
+
+func solveCaseF(n int, k int64, a []int64, b []int) []int64 {
+	pref := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		pref[i+1] = pref[i] + a[i]
+	}
+	L := pref[n]
+	cost1 := []int{}
+	for i := 0; i < n; i++ {
+		if b[i] == 1 {
+			cost1 = append(cost1, i)
+		}
+	}
+	if len(cost1) == 0 {
+		ans := make([]int64, n)
+		for i := range ans {
+			ans[i] = 2 * L
+		}
+		return ans
+	}
+	dist := func(i, j int) int64 {
+		if j >= i {
+			return pref[j] - pref[i]
+		}
+		return L - (pref[i] - pref[j])
+	}
+	base := int64(0)
+	m := len(cost1)
+	for idx := 0; idx < m; idx++ {
+		i := cost1[idx]
+		j := cost1[(idx+1)%m]
+		var D int64
+		if m == 1 {
+			D = L
+		} else {
+			D = dist(i, j)
+		}
+		if D > k {
+			base += D - k
+		}
+	}
+	cost1Cost := L + base
+	ans := make([]int64, n)
+	for s := 0; s < n; s++ {
+		if b[s] == 1 {
+			ans[s] = cost1Cost
+			continue
+		}
+		pos := sort.SearchInts(cost1, s)
+		prev := cost1[(pos-1+len(cost1))%len(cost1)]
+		nxt := cost1[0]
+		if pos < len(cost1) {
+			nxt = cost1[pos]
+		}
+		var D int64
+		if prev == nxt {
+			D = L
+		} else {
+			D = dist(prev, nxt)
+		}
+		x := dist(prev, s)
+		var add int64
+		if D <= k {
+			add = D - x
+		} else if k > x {
+			add = k - x
+		}
+		ans[s] = cost1Cost + add
+	}
+	return ans
+}
+
+func expectedF(tc testCaseF) string {
+	arr := solveCaseF(tc.n, tc.k, tc.a, tc.b)
+	var sb strings.Builder
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, tc := generateCaseF(rng)
+		expect := expectedF(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1800-1809/1809/verifierG.go
+++ b/1000-1999/1800-1899/1800-1809/1809/verifierG.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 998244353
+
+type testCaseG struct {
+	n int
+	k int64
+	a []int64
+}
+
+func generateCaseG(rng *rand.Rand) (string, testCaseG) {
+	n := rng.Intn(5) + 2
+	k := int64(rng.Intn(10))
+	a := make([]int64, n)
+	cur := int64(0)
+	for i := 0; i < n; i++ {
+		cur += int64(rng.Intn(5))
+		a[i] = cur
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), testCaseG{n, k, a}
+}
+
+func solveCaseG(n int, k int64, a []int64) int64 {
+	if n == 1 {
+		return 1
+	}
+	groups := []int{}
+	start := 0
+	for i := 1; i < n; i++ {
+		if a[i]-a[i-1] > k {
+			groups = append(groups, i-start)
+			start = i
+		}
+	}
+	groups = append(groups, n-start)
+	if len(groups) == 1 {
+		return 0
+	}
+	fact := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	sumBad := int64(0)
+	for _, s := range groups {
+		sumBad = (sumBad + int64(s)*(int64(s)-1)) % MOD
+	}
+	ans := (fact[n] - fact[n-2]*sumBad) % MOD
+	if ans < 0 {
+		ans += MOD
+	}
+	return ans
+}
+
+func expectedG(tc testCaseG) string {
+	ans := solveCaseG(tc.n, tc.k, tc.a)
+	return fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, tc := generateCaseG(rng)
+		expect := expectedG(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–G of contest 1809
- each verifier generates 100 random test cases and checks a given binary
- includes a BFS based checker for problem D

## Testing
- `go vet` *(not run: no directives)*


------
https://chatgpt.com/codex/tasks/task_e_688769479c348324a01f30a4d0638be1