### PR TITLE
Add verifiers for contest 1807

### DIFF
--- a/1000-1999/1800-1899/1800-1809/1807/verifierA.go
+++ b/1000-1999/1800-1899/1800-1809/1807/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ a, b, c int }
+
+func genCases() []Case {
+	cases := make([]Case, 0, 162)
+	for a := 1; a <= 9; a++ {
+		for b := 1; b <= 9; b++ {
+			cases = append(cases, Case{a, b, a + b})
+			cases = append(cases, Case{a, b, a - b})
+		}
+	}
+	return cases
+}
+
+func expected(a, b, c int) string {
+	if a+b == c {
+		return "+"
+	}
+	return "-"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d %d %d\n", c.a, c.b, c.c)
+		exp := expected(c.a, c.b, c.c)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("case %d failed: expected %s got %s (input %d %d %d)\n", i+1, exp, got, c.a, c.b, c.c)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1800-1809/1807/verifierB.go
+++ b/1000-1999/1800-1899/1800-1809/1807/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct {
+	arr []int
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1807))
+	cases := make([]Case, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rng.Intn(20) + 1
+		}
+		cases[i] = Case{arr: a}
+	}
+	return cases
+}
+
+func expected(a []int) string {
+	even, odd := 0, 0
+	for _, x := range a {
+		if x%2 == 0 {
+			even += x
+		} else {
+			odd += x
+		}
+	}
+	if even > odd {
+		return "YES"
+	}
+	return "NO"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d\n", len(c.arr)))
+		for j, v := range c.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		exp := expected(c.arr)
+		got, err := runProg(bin, sb.String())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(strings.ToUpper(got)) != exp {
+			fmt.Printf("case %d failed: expected %s got %s (array %v)\n", i+1, exp, got, c.arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1800-1809/1807/verifierC.go
+++ b/1000-1999/1800-1899/1800-1809/1807/verifierC.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ s string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1807))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(10) + 1
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = byte(rng.Intn(26) + 'a')
+		}
+		cases[i] = Case{s: string(b)}
+	}
+	return cases
+}
+
+func expected(s string) string {
+	pos := make([]int, 26)
+	for i := range pos {
+		pos[i] = -1
+	}
+	for i, ch := range s {
+		idx := ch - 'a'
+		parity := i % 2
+		if pos[idx] == -1 {
+			pos[idx] = parity
+		} else if pos[idx] != parity {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d\n%s\n", len(c.s), c.s)
+		exp := expected(c.s)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(strings.ToUpper(got)) != exp {
+			fmt.Printf("case %d failed: expected %s got %s (string %s)\n", i+1, exp, got, c.s)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1800-1809/1807/verifierD.go
+++ b/1000-1999/1800-1899/1800-1809/1807/verifierD.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Query struct {
+	l, r int
+	k    int64
+}
+
+type Case struct {
+	n       int
+	a       []int64
+	queries []Query
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1807))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(6) + 1
+		q := rng.Intn(5) + 1
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = int64(rng.Intn(10) + 1)
+		}
+		queries := make([]Query, q)
+		for j := range queries {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			k := int64(rng.Intn(10) + 1)
+			queries[j] = Query{l, r, k}
+		}
+		cases[i] = Case{n: n, a: arr, queries: queries}
+	}
+	return cases
+}
+
+func expected(a []int64, qs []Query) []string {
+	prefix := make([]int64, len(a)+1)
+	for i := 1; i <= len(a); i++ {
+		prefix[i] = prefix[i-1] + a[i-1]
+	}
+	total := prefix[len(a)]
+	ans := make([]string, len(qs))
+	for i, qu := range qs {
+		newSum := total - (prefix[qu.r] - prefix[qu.l-1]) + int64(qu.r-qu.l+1)*qu.k
+		if newSum%2 == 1 {
+			ans[i] = "YES"
+		} else {
+			ans[i] = "NO"
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for idx, c := range cases {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d %d\n", c.n, len(c.queries)))
+		for i, v := range c.a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for _, qu := range c.queries {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", qu.l, qu.r, qu.k))
+		}
+		expList := expected(c.a, c.queries)
+		got, err := runProg(bin, sb.String())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		outputs := strings.Fields(got)
+		if len(outputs) != len(expList) {
+			fmt.Printf("case %d failed: expected %d lines got %d\n", idx+1, len(expList), len(outputs))
+			os.Exit(1)
+		}
+		for i, exp := range expList {
+			if strings.ToUpper(outputs[i]) != exp {
+				fmt.Printf("case %d failed on query %d: expected %s got %s\n", idx+1, i+1, exp, outputs[i])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1800-1809/1807/verifierE.go
+++ b/1000-1999/1800-1899/1800-1809/1807/verifierE.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem E is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1800-1899/1800-1809/1807/verifierF.go
+++ b/1000-1999/1800-1899/1800-1809/1807/verifierF.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct {
+	n, m   int
+	i1, j1 int
+	i2, j2 int
+	d      string
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1807))
+	dirs := []string{"DR", "DL", "UR", "UL"}
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(8) + 2
+		m := rng.Intn(8) + 2
+		i1 := rng.Intn(n) + 1
+		j1 := rng.Intn(m) + 1
+		i2 := rng.Intn(n) + 1
+		j2 := rng.Intn(m) + 1
+		d := dirs[rng.Intn(len(dirs))]
+		cases[i] = Case{n, m, i1, j1, i2, j2, d}
+	}
+	return cases
+}
+
+type state struct {
+	r, c, dx, dy int
+}
+
+func expected(c Case) int {
+	dir := map[string][2]int{"DR": {1, 1}, "DL": {1, -1}, "UR": {-1, 1}, "UL": {-1, -1}}
+	dx, dy := dir[c.d][0], dir[c.d][1]
+	r, curr := c.i1, c.j1
+	bounces := 0
+	visited := make(map[state]bool)
+	for {
+		if r == c.i2 && curr == c.j2 {
+			return bounces
+		}
+		st := state{r, curr, dx, dy}
+		if visited[st] {
+			return -1
+		}
+		visited[st] = true
+		nr, nc := r+dx, curr+dy
+		bounce := false
+		if nr < 1 || nr > c.n {
+			dx = -dx
+			bounce = true
+		}
+		if nc < 1 || nc > c.m {
+			dy = -dy
+			bounce = true
+		}
+		if bounce {
+			bounces++
+		}
+		r += dx
+		curr += dy
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d %d %d %d %d %d %s\n", c.n, c.m, c.i1, c.j1, c.i2, c.j2, c.d)
+		exp := fmt.Sprintf("%d", expected(c))
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("case %d failed: expected %s got %s (case %+v)\n", i+1, exp, got, c)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1800-1809/1807/verifierG1.go
+++ b/1000-1999/1800-1899/1800-1809/1807/verifierG1.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct {
+	arr []int
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1807))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(8) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rng.Intn(10) + 1
+		}
+		cases[i] = Case{arr: a}
+	}
+	return cases
+}
+
+func expected(a []int) string {
+	b := make([]int, len(a))
+	copy(b, a)
+	sort.Ints(b)
+	if b[0] != 1 {
+		return "NO"
+	}
+	sum := 1
+	for i := 1; i < len(b); i++ {
+		if b[i] > sum {
+			return "NO"
+		}
+		sum += b[i]
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d\n", len(c.arr)))
+		for j, v := range c.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		exp := expected(c.arr)
+		got, err := runProg(bin, sb.String())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(strings.ToUpper(got)) != exp {
+			fmt.Printf("case %d failed: expected %s got %s (arr %v)\n", i+1, exp, got, c.arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1800-1809/1807/verifierG2.go
+++ b/1000-1999/1800-1899/1800-1809/1807/verifierG2.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ arr []int }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(2023))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(15) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rng.Intn(20) + 1
+		}
+		cases[i] = Case{arr: a}
+	}
+	return cases
+}
+
+func expected(a []int) string {
+	b := make([]int, len(a))
+	copy(b, a)
+	sort.Ints(b)
+	if b[0] != 1 {
+		return "NO"
+	}
+	sum := 1
+	for i := 1; i < len(b); i++ {
+		if b[i] > sum {
+			return "NO"
+		}
+		sum += b[i]
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d\n", len(c.arr)))
+		for j, v := range c.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		exp := expected(c.arr)
+		got, err := runProg(bin, sb.String())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(strings.ToUpper(got)) != exp {
+			fmt.Printf("case %d failed: expected %s got %s (arr %v)\n", i+1, exp, got, c.arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–G of contest 1807
- each verifier generates 100+ test cases and checks any provided binary
- interactive problem E prints a stub message

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`


------
https://chatgpt.com/codex/tasks/task_e_688768bbc9088324b54a8cd1c509dd8b