### PR TITLE
Fix verifier for problem 1108C

### DIFF
--- a/1000-1999/1100-1199/1100-1109/1108/verifierC.go
+++ b/1000-1999/1100-1199/1100-1109/1108/verifierC.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 )
 
+// Test represents a single generated test case input.
 type Test struct {
 	input string
 }
 
+// runExe runs the binary at path with the given input and returns its output.
 func runExe(path, input string) (string, error) {
 	cmd := exec.Command(path)
 	cmd.Stdin = strings.NewReader(input)
@@ -24,15 +26,7 @@ func runExe(path, input string) (string, error) {
 	return out.String(), err
 }
 
-func buildRef() (string, error) {
-	ref := "./refC.bin"
-	cmd := exec.Command("go", "build", "-o", ref, "1108C.go")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
-	}
-	return ref, nil
-}
-
+// genTests generates random test cases.
 func genTests() []Test {
 	rand.Seed(2)
 	tests := make([]Test, 0, 100)
@@ -40,7 +34,6 @@ func genTests() []Test {
 	for i := 0; i < 100; i++ {
 		n := rand.Intn(20) + 1
 		var sb strings.Builder
-		sb.WriteString("1\n")
 		sb.WriteString(strconv.Itoa(n))
 		sb.WriteByte('\n')
 		for j := 0; j < n; j++ {
@@ -52,33 +45,104 @@ func genTests() []Test {
 	return tests
 }
 
+// parseInput extracts n and s from the generated input.
+func parseInput(in string) (int, string, error) {
+	fields := strings.Fields(in)
+	if len(fields) != 2 {
+		return 0, "", fmt.Errorf("unexpected input: %q", in)
+	}
+	n, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, "", err
+	}
+	return n, fields[1], nil
+}
+
+// bestPatterns returns the minimal number of changes and all valid patterns.
+func bestPatterns(s string) (int, []string) {
+	perms := []string{"RGB", "RBG", "GRB", "GBR", "BRG", "BGR"}
+	n := len(s)
+	min := n + 1
+	var patterns []string
+	for _, p := range perms {
+		diff := 0
+		var b strings.Builder
+		b.Grow(n)
+		for i := 0; i < n; i++ {
+			ch := p[i%3]
+			if s[i] != ch {
+				diff++
+			}
+			b.WriteByte(ch)
+		}
+		pat := b.String()
+		if diff < min {
+			min = diff
+			patterns = []string{pat}
+		} else if diff == min {
+			patterns = append(patterns, pat)
+		}
+	}
+	return min, patterns
+}
+
 func main() {
 	if len(os.Args) != 2 {
 		fmt.Println("Usage: go run verifierC.go /path/to/binary")
 		return
 	}
 	bin := os.Args[1]
-	ref, err := buildRef()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	defer os.Remove(ref)
-
 	tests := genTests()
 	for i, tc := range tests {
-		exp, err := runExe(ref, tc.input)
+		n, s, err := parseInput(tc.input)
 		if err != nil {
-			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			fmt.Fprintf(os.Stderr, "bad generated test: %v\n", err)
 			os.Exit(1)
 		}
+		expMin, patterns := bestPatterns(s)
 		got, err := runExe(bin, tc.input)
 		if err != nil {
 			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
 			os.Exit(1)
 		}
-		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
-			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+		fields := strings.Fields(got)
+		if len(fields) < 2 {
+			fmt.Printf("Test %d invalid output format:\n%s\n", i+1, got)
+			os.Exit(1)
+		}
+		r, err := strconv.Atoi(fields[0])
+		if err != nil {
+			fmt.Printf("Test %d invalid integer: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		t := fields[1]
+		if len(t) != n {
+			fmt.Printf("Test %d wrong length. Expected %d got %d\n", i+1, n, len(t))
+			os.Exit(1)
+		}
+		diff := 0
+		for j := 0; j < n; j++ {
+			if s[j] != t[j] {
+				diff++
+			}
+		}
+		if diff != r {
+			fmt.Printf("Test %d inconsistent changes count. got %d expected %d\n", i+1, r, diff)
+			os.Exit(1)
+		}
+		if r != expMin {
+			fmt.Printf("Test %d non optimal answer. expected %d got %d\n", i+1, expMin, r)
+			os.Exit(1)
+		}
+		valid := false
+		for _, pat := range patterns {
+			if t == pat {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			fmt.Printf("Test %d produced invalid pattern\nInput:\n%sGot:\n%s %s\n", i+1, tc.input, fields[0], t)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Summary
- update 1108C verifier to compute expected answers directly
- remove extra leading `1` in generated input
- verify candidate output by checking optimal cost and pattern

## Testing
- `go build -o /tmp/1108C.bin 1000-1999/1100-1199/1100-1109/1108/1108C.go`
- `go run 1000-1999/1100-1199/1100-1109/1108/verifierC.go /tmp/1108C.bin`

------
https://chatgpt.com/codex/tasks/task_e_68876a26883c8324bd2243c38d19d15c