### PR TITLE
Add solution verifiers for contest 1811

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1811/verifierA.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+type testA struct {
+	n int
+	d int
+	s string
+}
+
+func genTests() []testA {
+	rand.Seed(181101)
+	tests := make([]testA, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		d := rand.Intn(10)
+		digits := make([]byte, n)
+		digits[0] = byte('1' + rand.Intn(9))
+		for j := 1; j < n; j++ {
+			digits[j] = byte('0' + rand.Intn(10))
+		}
+		tests[i] = testA{n: n, d: d, s: string(digits)}
+	}
+	return tests
+}
+
+func solve(tc testA) string {
+	res := make([]byte, 0, tc.n+1)
+	inserted := false
+	for i := 0; i < tc.n; i++ {
+		if !inserted && int(tc.s[i]-'0') < tc.d {
+			res = append(res, byte('0'+tc.d))
+			inserted = true
+		}
+		res = append(res, tc.s[i])
+	}
+	if !inserted {
+		res = append(res, byte('0'+tc.d))
+	}
+	return string(res)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n%s\n", tc.n, tc.d, tc.s)
+	}
+
+	expected := make([]string, len(tests))
+	for i, tc := range tests {
+		expected[i] = solve(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=1")
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got := scanner.Text()
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %s got %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1810-1819/1811/verifierB.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierB.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testB struct {
+	n  int64
+	x1 int64
+	y1 int64
+	x2 int64
+	y2 int64
+}
+
+func genTests() []testB {
+	rand.Seed(181102)
+	tests := make([]testB, 100)
+	for i := range tests {
+		n := rand.Int63n(1_000_000) + 2
+		if n%2 == 1 {
+			n++
+		}
+		x1 := rand.Int63n(n) + 1
+		y1 := rand.Int63n(n) + 1
+		x2 := rand.Int63n(n) + 1
+		y2 := rand.Int63n(n) + 1
+		tests[i] = testB{n, x1, y1, x2, y2}
+	}
+	return tests
+}
+
+func ring(n, x, y int64) int64 {
+	if x > n+1-x {
+		x = n + 1 - x
+	}
+	if y > n+1-y {
+		y = n + 1 - y
+	}
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func solve(tc testB) int64 {
+	r1 := ring(tc.n, tc.x1, tc.y1)
+	r2 := ring(tc.n, tc.x2, tc.y2)
+	diff := r1 - r2
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d %d %d %d\n", tc.n, tc.x1, tc.y1, tc.x2, tc.y2)
+	}
+
+	expected := make([]int64, len(tests))
+	for i, tc := range tests {
+		expected[i] = solve(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1810-1819/1811/verifierC.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testC struct {
+	n int
+	b []int64
+}
+
+func genTests() []testC {
+	rand.Seed(181103)
+	tests := make([]testC, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 2
+		a := make([]int64, n)
+		for j := range a {
+			a[j] = rand.Int63n(1000)
+		}
+		b := make([]int64, n-1)
+		for j := 0; j < n-1; j++ {
+			if a[j] > a[j+1] {
+				b[j] = a[j]
+			} else {
+				b[j] = a[j+1]
+			}
+		}
+		tests[i] = testC{n: n, b: b}
+	}
+	return tests
+}
+
+func solve(tc testC) []int64 {
+	a := make([]int64, tc.n)
+	a[0] = tc.b[0]
+	for i := 1; i <= tc.n-2; i++ {
+		if tc.b[i] < tc.b[i-1] {
+			a[i] = tc.b[i]
+		} else {
+			a[i] = tc.b[i-1]
+		}
+	}
+	a[tc.n-1] = tc.b[tc.n-2]
+	return a
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for i, v := range tc.b {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([][]int64, len(tests))
+	for i, tc := range tests {
+		expected[i] = solve(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, expArr := range expected {
+		for j, exp := range expArr {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if val != exp {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1810-1819/1811/verifierD.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierD.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+var fib [45]int64
+
+func init() {
+	fib[0], fib[1] = 1, 1
+	for i := 2; i < len(fib); i++ {
+		fib[i] = fib[i-1] + fib[i-2]
+	}
+}
+
+type testD struct {
+	n int
+	x int64
+	y int64
+}
+
+func genTests() []testD {
+	rand.Seed(181104)
+	tests := make([]testD, 100)
+	for i := range tests {
+		n := rand.Intn(40) + 1
+		x := rand.Int63n(fib[n]) + 1
+		y := rand.Int63n(fib[n+1]) + 1
+		tests[i] = testD{n: n, x: x, y: y}
+	}
+	return tests
+}
+
+func possible(n int, x, y int64) bool {
+	for n > 1 {
+		if fib[n-1] < y && y <= fib[n] {
+			return false
+		}
+		if y <= fib[n-1] {
+			x, y = y, fib[n]-x+1
+		} else {
+			y -= fib[n]
+			x, y = y, fib[n]-x+1
+		}
+		n--
+	}
+	return true
+}
+
+func solve(tc testD) string {
+	if possible(tc.n, tc.x, tc.y) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d %d\n", tc.n, tc.x, tc.y)
+	}
+
+	expected := make([]string, len(tests))
+	for i, tc := range tests {
+		expected[i] = solve(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got := scanner.Text()
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1810-1819/1811/verifierE.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierE.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testE struct {
+	k int64
+}
+
+func genTests() []testE {
+	rand.Seed(181105)
+	tests := make([]testE, 100)
+	for i := range tests {
+		tests[i] = testE{k: rand.Int63n(1_000_000_000_000)}
+	}
+	return tests
+}
+
+func solve(tc testE) string {
+	k := tc.k
+	if k == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for k > 0 {
+		d := k % 9
+		if d >= 4 {
+			digits = append(digits, byte('0'+d+1))
+		} else {
+			digits = append(digits, byte('0'+d))
+		}
+		k /= 9
+	}
+	for i, j := 0, len(digits)-1; i < j; i, j = i+1, j-1 {
+		digits[i], digits[j] = digits[j], digits[i]
+	}
+	return string(digits)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.k)
+	}
+
+	expected := make([]string, len(tests))
+	for i, tc := range tests {
+		expected[i] = solve(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got := scanner.Text()
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1810-1819/1811/verifierF.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierF.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+type testF struct {
+	n     int
+	m     int
+	edges [][2]int
+}
+
+func genTests() []testF {
+	rand.Seed(181106)
+	tests := make([]testF, 100)
+	for i := range tests {
+		k := rand.Intn(4) + 3 // k from 3..6
+		n := k * k
+		m := n + k
+		edgeSet := make(map[[2]int]struct{})
+		edges := make([][2]int, 0, m)
+		for len(edges) < m {
+			u := rand.Intn(n)
+			v := rand.Intn(n)
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			pair := [2]int{u, v}
+			if _, ok := edgeSet[pair]; ok {
+				continue
+			}
+			edgeSet[pair] = struct{}{}
+			edges = append(edges, pair)
+		}
+		tests[i] = testF{n: n, m: m, edges: edges}
+	}
+	return tests
+}
+
+func solve(tc testF) string {
+	n := tc.n
+	m := tc.m
+	adj := make([][]int, n)
+	for _, e := range tc.edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+
+	k := int(math.Round(math.Sqrt(float64(n))))
+	if k*k != n || k < 3 || m != n+k {
+		return "NO"
+	}
+
+	deg := make([]int, n)
+	for i := 0; i < n; i++ {
+		deg[i] = len(adj[i])
+	}
+	central := []int{}
+	isCentral := make([]bool, n)
+	valid := true
+	for i, d := range deg {
+		if d == 4 {
+			central = append(central, i)
+			isCentral[i] = true
+		} else if d != 2 {
+			valid = false
+			break
+		}
+	}
+	if !valid || len(central) != k {
+		return "NO"
+	}
+
+	centralEdges := map[[2]int]struct{}{}
+	for _, u := range central {
+		cnt := 0
+		for _, v := range adj[u] {
+			if isCentral[v] {
+				cnt++
+				if u < v {
+					centralEdges[[2]int{u, v}] = struct{}{}
+				}
+			}
+		}
+		if cnt != 2 {
+			valid = false
+			break
+		}
+	}
+	if !valid || len(centralEdges) != k {
+		return "NO"
+	}
+
+	visited := make([]bool, n)
+	queue := []int{central[0]}
+	visited[central[0]] = true
+	for len(queue) > 0 {
+		u := queue[0]
+		queue = queue[1:]
+		for _, v := range adj[u] {
+			if isCentral[v] && !visited[v] {
+				visited[v] = true
+				queue = append(queue, v)
+			}
+		}
+	}
+	cntVisited := 0
+	for _, u := range central {
+		if visited[u] {
+			cntVisited++
+		}
+	}
+	if cntVisited != k {
+		return "NO"
+	}
+
+	visitedAll := make([]bool, n)
+	compCount := 0
+	for i := 0; i < n; i++ {
+		if !visitedAll[i] {
+			compCount++
+			q := []int{i}
+			visitedAll[i] = true
+			size := 0
+			centralCnt := 0
+			for len(q) > 0 {
+				u := q[0]
+				q = q[1:]
+				size++
+				if isCentral[u] {
+					centralCnt++
+				}
+				for _, v := range adj[u] {
+					if isCentral[u] && isCentral[v] {
+						continue
+					}
+					if !visitedAll[v] {
+						visitedAll[v] = true
+						q = append(q, v)
+					}
+				}
+			}
+			if centralCnt != 1 || size != k {
+				valid = false
+				break
+			}
+		}
+	}
+	if !valid || compCount != k {
+		return "NO"
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.m)
+		for _, e := range tc.edges {
+			fmt.Fprintf(&input, "%d %d\n", e[0]+1, e[1]+1)
+		}
+	}
+
+	expected := make([]string, len(tests))
+	for i, tc := range tests {
+		expected[i] = solve(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		got := scanner.Text()
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1810-1819/1811/verifierG1.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierG1.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+const MOD int = 1_000_000_007
+const NEG_INF int = -1_000_000_000
+
+type testG1 struct {
+	n      int
+	k      int
+	colors []int
+}
+
+func genTests() []testG1 {
+	rand.Seed(181107)
+	tests := make([]testG1, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(n) + 1
+		colors := make([]int, n)
+		for j := range colors {
+			colors[j] = rand.Intn(n) + 1
+		}
+		tests[i] = testG1{n: n, k: k, colors: colors}
+	}
+	return tests
+}
+
+type state struct {
+	len int
+	cnt int
+}
+
+func solve(tc testG1) int {
+	n := tc.n
+	k := tc.k
+	colors := tc.colors
+	dpPrev := make([][]state, k)
+	dpCur := make([][]state, k)
+	for r := 0; r < k; r++ {
+		dpPrev[r] = make([]state, n+1)
+		dpCur[r] = make([]state, n+1)
+		for c := 0; c <= n; c++ {
+			dpPrev[r][c].len = NEG_INF
+			dpCur[r][c].len = NEG_INF
+		}
+	}
+	dpPrev[0][0] = state{0, 1}
+
+	for idx := n - 1; idx >= 0; idx-- {
+		for r := 0; r < k; r++ {
+			for c := 0; c <= n; c++ {
+				dpCur[r][c].len = NEG_INF
+				dpCur[r][c].cnt = 0
+			}
+		}
+		color := colors[idx]
+		for r := 0; r < k; r++ {
+			for c := 0; c <= n; c++ {
+				best := dpPrev[r][c]
+				if best.len == NEG_INF {
+					dpCur[r][c] = best
+					continue
+				}
+				curLen := best.len
+				curCnt := best.cnt
+				if r == 0 {
+					nr := 1
+					nc := color
+					if nr == k {
+						nr = 0
+						nc = 0
+					}
+					cand := dpPrev[nr][nc]
+					if cand.len != NEG_INF {
+						candLen := cand.len + 1
+						candCnt := cand.cnt
+						if candLen > curLen {
+							curLen = candLen
+							curCnt = candCnt
+						} else if candLen == curLen {
+							curCnt = (curCnt + candCnt) % MOD
+						}
+					}
+				} else if c == color {
+					nr := r + 1
+					nc := c
+					if nr == k {
+						nr = 0
+						nc = 0
+					}
+					cand := dpPrev[nr][nc]
+					if cand.len != NEG_INF {
+						candLen := cand.len + 1
+						candCnt := cand.cnt
+						if candLen > curLen {
+							curLen = candLen
+							curCnt = candCnt
+						} else if candLen == curLen {
+							curCnt = (curCnt + candCnt) % MOD
+						}
+					}
+				}
+				dpCur[r][c].len = curLen
+				dpCur[r][c].cnt = curCnt % MOD
+			}
+		}
+		dpPrev, dpCur = dpCur, dpPrev
+	}
+	return dpPrev[0][0].cnt % MOD
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for i, v := range tc.colors {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solve(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1810-1819/1811/verifierG2.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierG2.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+const MOD int = 1000000007
+
+type testG2 struct {
+	n      int
+	k      int
+	colors []int
+}
+
+func genTests() []testG2 {
+	rand.Seed(181108)
+	tests := make([]testG2, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(n) + 1
+		colors := make([]int, n)
+		for j := range colors {
+			colors[j] = rand.Intn(n) + 1
+		}
+		tests[i] = testG2{n: n, k: k, colors: colors}
+	}
+	return tests
+}
+
+func solveCase(n, k int, colors []int) int {
+	freq := make([]int, n+1)
+	for _, c := range colors {
+		freq[c]++
+	}
+	lens := make([][]int, n+1)
+	cnts := make([][]int, n+1)
+	for c := 1; c <= n; c++ {
+		if freq[c] > 0 {
+			size := k
+			if freq[c] < size {
+				size = freq[c]
+			}
+			lens[c] = make([]int, size+1)
+			cnts[c] = make([]int, size+1)
+			for i := 1; i <= size; i++ {
+				lens[c][i] = -1
+			}
+		}
+	}
+	bestLen := 0
+	bestCnt := 1
+	for _, col := range colors {
+		arrLen := lens[col]
+		arrCnt := cnts[col]
+		size := len(arrLen) - 1
+		oldKLen, oldKCnt := 0, 0
+		if k <= size {
+			oldKLen = arrLen[k]
+			oldKCnt = arrCnt[k]
+		}
+		for r := size; r >= 1; r-- {
+			baseLen := -1
+			baseCnt := 0
+			if r == 1 {
+				baseLen = bestLen
+				baseCnt = bestCnt
+			} else if arrLen[r-1] != -1 {
+				baseLen = arrLen[r-1]
+				baseCnt = arrCnt[r-1]
+			}
+			if baseLen != -1 {
+				newLen := baseLen + 1
+				if newLen > arrLen[r] {
+					arrLen[r] = newLen
+					arrCnt[r] = baseCnt
+				} else if newLen == arrLen[r] {
+					arrCnt[r] += baseCnt
+					if arrCnt[r] >= MOD {
+						arrCnt[r] -= MOD
+					}
+				}
+			}
+		}
+		if k <= size {
+			if arrLen[k] > bestLen {
+				bestLen = arrLen[k]
+				bestCnt = arrCnt[k] % MOD
+			} else if arrLen[k] == bestLen {
+				added := arrCnt[k]
+				if oldKLen == bestLen {
+					added -= oldKCnt
+					added %= MOD
+					if added < 0 {
+						added += MOD
+					}
+				}
+				bestCnt += added
+				bestCnt %= MOD
+			}
+		}
+	}
+	return bestCnt % MOD
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for i, v := range tc.colors {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveCase(tc.n, tc.k, tc.colors)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for Codeforces contest 1811 problems A through G2
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `gofmt -w 1000-1999/1800-1899/1810-1819/1811/verifierA.go 1000-1999/1800-1899/1810-1819/1811/verifierB.go 1000-1999/1800-1899/1810-1819/1811/verifierC.go 1000-1999/1800-1899/1810-1819/1811/verifierD.go 1000-1999/1800-1899/1810-1819/1811/verifierE.go 1000-1999/1800-1899/1810-1819/1811/verifierF.go 1000-1999/1800-1899/1810-1819/1811/verifierG1.go 1000-1999/1800-1899/1810-1819/1811/verifierG2.go`


------
https://chatgpt.com/codex/tasks/task_e_688769d3aea88324a348e8d6ecd89323