### PR TITLE
Add verifiers for CF contest 1810

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1810/verifierA.go
+++ b/1000-1999/1800-1899/1810-1819/1810/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func expected(tc testCase) string {
+	for i, v := range tc.arr {
+		if v <= i+1 {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func runCase(exe string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprint(len(tc.arr)))
+	sb.WriteByte('\n')
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expected(tc)
+	if strings.ToUpper(got) != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(100) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(200) + 1
+		}
+		tc := testCase{arr: arr}
+		if err := runCase(exe, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1810/verifierB.go
+++ b/1000-1999/1800-1899/1810-1819/1810/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) string {
+	if n%2 == 0 {
+		return "-1"
+	}
+	ops := make([]int, 0)
+	for n > 1 {
+		if n%4 == 1 {
+			ops = append(ops, 1)
+			n = (n + 1) / 2
+		} else {
+			ops = append(ops, 2)
+			n = (n - 1) / 2
+		}
+	}
+	// reverse ops
+	for i, j := 0, len(ops)-1; i < j; i, j = i+1, j-1 {
+		ops[i], ops[j] = ops[j], ops[i]
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprint(len(ops)))
+	if len(ops) > 0 {
+		sb.WriteByte('\n')
+		for i, v := range ops {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+	}
+	return sb.String()
+}
+
+func runCase(exe string, n int) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected(n))
+	if got != exp {
+		return fmt.Errorf("n=%d expected %q got %q", n, exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		var n int
+		if rng.Intn(2) == 0 {
+			n = rng.Intn(1_000_000_000) + 1
+		} else {
+			n = rng.Intn(1_000_000_000/2)*2 + 1
+		}
+		if err := runCase(exe, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1810/verifierC.go
+++ b/1000-1999/1800-1899/1810-1819/1810/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	c   int64
+	d   int64
+	arr []int
+}
+
+func expected(tc testCase) string {
+	n := len(tc.arr)
+	arr := append([]int(nil), tc.arr...)
+	sort.Ints(arr)
+	uniq := make([]int, 0, n)
+	last := -1
+	for _, v := range arr {
+		if v != last {
+			uniq = append(uniq, v)
+			last = v
+		}
+	}
+	cost := func(m int) int64 {
+		p := sort.Search(len(uniq), func(i int) bool { return uniq[i] > m })
+		del := n - p
+		ins := m - p
+		return int64(del)*tc.c + int64(ins)*tc.d
+	}
+	best := cost(1)
+	for _, v := range uniq {
+		if c := cost(v); c < best {
+			best = c
+		}
+	}
+	return fmt.Sprint(best)
+}
+
+func runCase(exe string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", len(tc.arr), tc.c, tc.d))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expected(tc)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		c := int64(rng.Intn(5) + 1)
+		d := int64(rng.Intn(5) + 1)
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(10) + 1
+		}
+		tc := testCase{c: c, d: d, arr: arr}
+		if err := runCase(exe, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1810/verifierD.go
+++ b/1000-1999/1800-1899/1810-1819/1810/verifierD.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func days(a, b, h int64) int64 {
+	if h <= a {
+		return 1
+	}
+	return 1 + (h-a+(a-b-1))/(a-b)
+}
+
+type query struct {
+	typ int
+	a   int64
+	b   int64
+	n   int64
+}
+
+type testCase struct {
+	queries []query
+}
+
+func expected(tc testCase) string {
+	low, high := int64(1), int64(1e18)
+	var res []string
+	for _, q := range tc.queries {
+		if q.typ == 1 {
+			var L, R int64
+			if q.n == 1 {
+				L, R = 1, q.a
+			} else {
+				L = (q.n-1)*q.a - (q.n-2)*q.b + 1
+				R = q.n*q.a - (q.n-1)*q.b
+			}
+			if L > high || R < low {
+				res = append(res, "0")
+			} else {
+				if L > low {
+					low = L
+				}
+				if R < high {
+					high = R
+				}
+				res = append(res, "1")
+			}
+		} else {
+			d1 := days(q.a, q.b, low)
+			d2 := days(q.a, q.b, high)
+			if d1 == d2 {
+				res = append(res, fmt.Sprint(d1))
+			} else {
+				res = append(res, "-1")
+			}
+		}
+	}
+	return strings.Join(res, " ")
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprint(len(tc.queries)))
+	sb.WriteByte('\n')
+	for i, q := range tc.queries {
+		sb.WriteString(fmt.Sprint(q.typ))
+		if q.typ == 1 {
+			sb.WriteString(fmt.Sprintf(" %d %d %d", q.a, q.b, q.n))
+		} else {
+			sb.WriteString(fmt.Sprintf(" %d %d", q.a, q.b))
+		}
+		if i+1 == len(tc.queries) {
+			sb.WriteByte('\n')
+		} else {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func runCase(exe string, tc testCase) error {
+	input := buildInput(tc)
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected(tc))
+	if got != exp {
+		return fmt.Errorf("expected %q got %q\ninput:\n%s", exp, got, input)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		q := rng.Intn(10) + 1
+		queries := make([]query, q)
+		for j := 0; j < q; j++ {
+			typ := rng.Intn(2) + 1
+			if typ == 1 {
+				a := int64(rng.Intn(5) + 2)
+				b := int64(rng.Intn(int(a-1)) + 1)
+				n := int64(rng.Intn(5) + 1)
+				queries[j] = query{typ: 1, a: a, b: b, n: n}
+			} else {
+				a := int64(rng.Intn(5) + 2)
+				b := int64(rng.Intn(int(a-1)) + 1)
+				queries[j] = query{typ: 2, a: a, b: b}
+			}
+		}
+		tc := testCase{queries: queries}
+		if err := runCase(exe, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1810/verifierE.go
+++ b/1000-1999/1800-1899/1810-1819/1810/verifierE.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refE")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1810E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(n*(n-1)/2 + 1)
+		a := make([]int, n)
+		for i := range a {
+			if rng.Intn(4) == 0 {
+				a[i] = 0
+			} else {
+				a[i] = rng.Intn(n) + 1
+			}
+		}
+		edges := make([][2]int, m)
+		seen := map[[2]int]bool{}
+		idx := 0
+		for idx < m {
+			u := rng.Intn(n)
+			v := rng.Intn(n)
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			e := [2]int{u, v}
+			if seen[e] {
+				continue
+			}
+			seen[e] = true
+			edges[idx] = e
+			idx++
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+		}
+		input := sb.String()
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d candidate error: %v\n%s", t+1, cErr, candOut)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d reference error: %v\n%s", t+1, rErr, refOut)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sactual:%s", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1810/verifierF.go
+++ b/1000-1999/1800-1899/1810-1819/1810/verifierF.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refF")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1810F.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(3) + 1
+		q := rng.Intn(5) + 1
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rng.Intn(5) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < q; i++ {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(5) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		}
+		input := sb.String()
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d candidate error: %v\n%s", t+1, cErr, candOut)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d reference error: %v\n%s", t+1, rErr, refOut)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sactual:%s", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1810/verifierG.go
+++ b/1000-1999/1800-1899/1810-1819/1810/verifierG.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refG")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1810G.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprint(n))
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			x := rng.Int63n(10) + 1
+			y := x + rng.Int63n(10) + 1
+			if i > 0 {
+				sb.WriteByte('\n')
+			}
+			sb.WriteString(fmt.Sprintf("%d %d", x, y))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i <= n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(rng.Int63n(100)))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d candidate error: %v\n%s", t+1, cErr, candOut)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d reference error: %v\n%s", t+1, rErr, refOut)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sactual:%s", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1810/verifierH.go
+++ b/1000-1999/1800-1899/1810-1819/1810/verifierH.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func simulate(n int) int {
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = i + 1
+	}
+	sort.Ints(arr)
+	for len(arr) > 1 {
+		mn := arr[0]
+		mx := arr[len(arr)-1]
+		arr = arr[1 : len(arr)-1]
+		d := mx - mn
+		i := sort.SearchInts(arr, d)
+		arr = append(arr[:i], append([]int{d}, arr[i:]...)...)
+	}
+	return arr[0]
+}
+
+func runCase(exe string, n int) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := fmt.Sprint(simulate(n))
+	if got != exp {
+		return fmt.Errorf("n=%d expected %s got %s", n, exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(15) + 2
+		if err := runCase(exe, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1810 problems A–H
- verifiers generate 100 random tests and check candidate binaries
- verifiers for E–G build reference solutions
- simple simulator for problem H

## Testing
- `go run verifierA.go ./testA`
- `go run verifierH.go ./testH` *(fails as expected because 1810H.go is stub)*

------
https://chatgpt.com/codex/tasks/task_e_6887698dc918832484805ccae15495c8