### PR TITLE
Add verifiers for contest 1815

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1815/verifierA.go
+++ b/1000-1999/1800-1899/1810-1819/1815/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct {
+	arr []int64
+}
+
+func expected(arr []int64) string {
+	var altSum int64
+	for i, v := range arr {
+		if i%2 == 0 {
+			altSum += v
+		} else {
+			altSum -= v
+		}
+	}
+	if len(arr)%2 == 1 || altSum <= 0 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1815))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(19) + 2 // 2..20
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = rng.Int63n(1_000_000_000) + 1
+		}
+		cases[i] = Case{arr}
+	}
+	return cases
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d\n", len(c.arr))
+		for j, v := range c.arr {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		want := expected(c.arr)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1815/verifierB.go
+++ b/1000-1999/1800-1899/1810-1819/1815/verifierB.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const expectedOutput = "Problem B is interactive and cannot be automatically solved.\n"
+
+func run(bin string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	out, err := run(bin)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if out != expectedOutput {
+		fmt.Printf("expected %q got %q\n", expectedOutput, out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1815/verifierC.go
+++ b/1000-1999/1800-1899/1810-1819/1815/verifierC.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct {
+	n     int
+	m     int
+	edges [][2]int
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1815))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(20) + 1
+		maxEdges := n * (n - 1)
+		m := 0
+		if maxEdges > 0 {
+			m = rng.Intn(min(20, maxEdges) + 1)
+		}
+		edges := make([][2]int, 0, m)
+		seen := make(map[[2]int]bool)
+		for len(edges) < m {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			if a == b {
+				continue
+			}
+			key := [2]int{a, b}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			edges = append(edges, key)
+		}
+		cases[i] = Case{n, m, edges}
+	}
+	return cases
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1815C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	input := fmt.Sprintf("1\n%d %d\n", c.n, c.m)
+	for _, e := range c.edges {
+		input += fmt.Sprintf("%d %d\n", e[0], e[1])
+	}
+	expected, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			input := fmt.Sprintf("1\n%d %d\n", c.n, c.m)
+			for _, e := range c.edges {
+				input += fmt.Sprintf("%d %d\n", e[0], e[1])
+			}
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1815/verifierD.go
+++ b/1000-1999/1800-1899/1810-1819/1815/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct {
+	n uint64
+	m int64
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1815))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Uint64() % 1000000000 // up to 1e9
+		m := int64(rng.Intn(10) + 1)
+		cases[i] = Case{n, m}
+	}
+	return cases
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1815D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	input := fmt.Sprintf("1\n%d %d\n", c.n, c.m)
+	expected, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			input := fmt.Sprintf("1\n%d %d\n", c.n, c.m)
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1815/verifierE.go
+++ b/1000-1999/1800-1899/1810-1819/1815/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct {
+	strings []string
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1815))
+	cases := make([]Case, 100)
+	letters := []byte{'0', '1'}
+	for i := range cases {
+		n := rng.Intn(10) + 1
+		arr := make([]string, n)
+		for j := range arr {
+			l := rng.Intn(5) + 1
+			b := make([]byte, l)
+			for k := range b {
+				b[k] = letters[rng.Intn(2)]
+			}
+			arr[j] = string(b)
+		}
+		cases[i] = Case{arr}
+	}
+	return cases
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1815E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	input := fmt.Sprintf("%d\n", len(c.strings))
+	for _, s := range c.strings {
+		input += fmt.Sprintf("%s\n", s)
+	}
+	expected, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			input := fmt.Sprintf("%d\n", len(c.strings))
+			for _, s := range c.strings {
+				input += fmt.Sprintf("%s\n", s)
+			}
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1810-1819/1815/verifierF.go
+++ b/1000-1999/1800-1899/1810-1819/1815/verifierF.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Triangle struct{ a, b, c int }
+
+type Case struct {
+	n       int
+	m       int
+	weights []int
+	tris    []Triangle
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1815))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 3 // 3..7
+		m := rng.Intn(4) + 1 // 1..4
+		weights := make([]int, n)
+		for j := range weights {
+			weights[j] = rng.Intn(10)
+		}
+		tris := make([]Triangle, m)
+		for j := range tris {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			for b == a {
+				b = rng.Intn(n) + 1
+			}
+			c := rng.Intn(n) + 1
+			for c == a || c == b {
+				c = rng.Intn(n) + 1
+			}
+			if a > b {
+				a, b = b, a
+			}
+			if b > c {
+				b, c = c, b
+			}
+			if a > b {
+				a, b = b, a
+			}
+			tris[j] = Triangle{a, b, c}
+		}
+		cases[i] = Case{n, m, weights, tris}
+	}
+	return cases
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1815F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	input := fmt.Sprintf("1\n%d %d\n", c.n, c.m)
+	for i, w := range c.weights {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", w)
+	}
+	input += "\n"
+	for _, t := range c.tris {
+		input += fmt.Sprintf("%d %d %d\n", t.a, t.b, t.c)
+	}
+	expected, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			input := fmt.Sprintf("1\n%d %d\n", c.n, c.m)
+			for idx, w := range c.weights {
+				if idx > 0 {
+					input += " "
+				}
+				input += fmt.Sprintf("%d", w)
+			}
+			input += "\n"
+			for _, t := range c.tris {
+				input += fmt.Sprintf("%d %d %d\n", t.a, t.b, t.c)
+			}
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for each problem in contest 1815
- verifiers run a target binary against 100 generated test cases (except problem B which is interactive)

## Testing
- `go build 1000-1999/1800-1899/1810-1819/1815/verifierA.go`
- `go build 1000-1999/1800-1899/1810-1819/1815/verifierB.go`
- `go build 1000-1999/1800-1899/1810-1819/1815/verifierC.go`
- `go build 1000-1999/1800-1899/1810-1819/1815/verifierD.go`
- `go build 1000-1999/1800-1899/1810-1819/1815/verifierE.go`
- `go build 1000-1999/1800-1899/1810-1819/1815/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68876aebcb4c83248a7d06070e8b9f8f