### PR TITLE
Add Go verifiers for CF contest 1821

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1821/verifierA.go
+++ b/1000-1999/1800-1899/1820-1829/1821/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedA(s string) int {
+	if s[0] == '0' {
+		return 0
+	}
+	ans := 1
+	if s[0] == '?' {
+		ans *= 9
+	}
+	for i := 1; i < len(s); i++ {
+		if s[i] == '?' {
+			ans *= 10
+		}
+	}
+	return ans
+}
+
+func genCaseA(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	chars := "0123456789?"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = chars[rng.Intn(len(chars))]
+	}
+	return string(b)
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := genCaseA(rng)
+		input := fmt.Sprintf("1\n%s\n", s)
+		expect := fmt.Sprintf("%d", expectedA(s))
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, s)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s\n", i+1, expect, out, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1820-1829/1821/verifierB.go
+++ b/1000-1999/1800-1899/1820-1829/1821/verifierB.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveB(a, b []int) (int, int) {
+	n := len(a)
+	l := 0
+	for l < n && a[l] == b[l] {
+		l++
+	}
+	if l == n {
+		return 1, n
+	}
+	r := n - 1
+	for r >= 0 && a[r] == b[r] {
+		r--
+	}
+	for l > 0 && a[l-1] <= b[l] {
+		l--
+	}
+	for r < n-1 && a[r+1] >= b[r] {
+		r++
+	}
+	return l + 1, r + 1
+}
+
+func genCaseB(rng *rand.Rand) (int, []int, []int) {
+	n := rng.Intn(10) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(n) + 1
+	}
+	l := rng.Intn(n)
+	r := l + rng.Intn(n-l)
+	b := append([]int(nil), a...)
+	sort.Ints(b[l : r+1])
+	if equalInts(a, b) {
+		if r < n-1 {
+			r++
+		} else if l > 0 {
+			l--
+		}
+		b = append([]int(nil), a...)
+		sort.Ints(b[l : r+1])
+	}
+	return n, a, b
+}
+
+func equalInts(x, y []int) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	for i := range x {
+		if x[i] != y[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, a, b := genCaseB(rng)
+		input := fmt.Sprintf("1\n%d\n", n)
+		for j, v := range a {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+		for j, v := range b {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+		l, r := solveB(a, b)
+		expect := fmt.Sprintf("%d %d", l, r)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1820-1829/1821/verifierC.go
+++ b/1000-1999/1800-1899/1820-1829/1821/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(s string) int {
+	n := len(s)
+	best := int(^uint(0) >> 1)
+	for ch := byte('a'); ch <= 'z'; ch++ {
+		prev := -1
+		maxSeg := 0
+		for i := 0; i < n; i++ {
+			if s[i] == ch {
+				seg := i - prev - 1
+				if seg > maxSeg {
+					maxSeg = seg
+				}
+				prev = i
+			}
+		}
+		seg := n - prev - 1
+		if seg > maxSeg {
+			maxSeg = seg
+		}
+		ops := 0
+		for v := maxSeg; v > 0; v >>= 1 {
+			ops++
+		}
+		if ops < best {
+			best = ops
+		}
+	}
+	return best
+}
+
+func genCaseC(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := genCaseC(rng)
+		input := fmt.Sprintf("1\n%s\n", s)
+		expect := fmt.Sprintf("%d", solveC(s))
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1820-1829/1821/verifierD.go
+++ b/1000-1999/1800-1899/1820-1829/1821/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(l, r []int64, k int64) int64 {
+	var pref int64
+	for i := 0; i < len(l); i++ {
+		seg := r[i] - l[i] + 1
+		if pref+seg >= k {
+			q := l[i] + (k - pref) - 1
+			return q + 2
+		}
+		pref += seg
+	}
+	return -1
+}
+
+func genCaseD(rng *rand.Rand) (int, []int64, []int64, int64) {
+	n := rng.Intn(5) + 1
+	l := make([]int64, n)
+	r := make([]int64, n)
+	cur := int64(rng.Intn(5) + 1)
+	for i := 0; i < n; i++ {
+		lenSeg := int64(rng.Intn(5) + 1)
+		l[i] = cur
+		r[i] = cur + lenSeg - 1
+		cur = r[i] + int64(rng.Intn(3)+2)
+	}
+	total := int64(0)
+	for i := 0; i < n; i++ {
+		total += r[i] - l[i] + 1
+	}
+	k := int64(rng.Intn(int(total)+5) + 1)
+	return n, l, r, k
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, larr, rarr, k := genCaseD(rng)
+		input := fmt.Sprintf("1\n%d %d\n", n, k)
+		for j, v := range larr {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+		for j, v := range rarr {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+		expect := fmt.Sprintf("%d", solveD(larr, rarr, k))
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1820-1829/1821/verifierE.go
+++ b/1000-1999/1800-1899/1820-1829/1821/verifierE.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isRegular(s string) bool {
+	bal := 0
+	for _, ch := range s {
+		if ch == '(' {
+			bal++
+		} else {
+			bal--
+		}
+		if bal < 0 {
+			return false
+		}
+	}
+	return bal == 0
+}
+
+func minCostSeq(s string, memo map[string]int) int {
+	if s == "" {
+		return 0
+	}
+	if v, ok := memo[s]; ok {
+		return v
+	}
+	n := len(s)
+	best := math.MaxInt32
+	for i := 0; i < n-1; i++ {
+		if s[i] == '(' && s[i+1] == ')' {
+			t := s[:i] + s[i+2:]
+			c := n - (i + 1) + minCostSeq(t, memo)
+			if c < best {
+				best = c
+			}
+		}
+	}
+	memo[s] = best
+	return best
+}
+
+func reachable(s string, k int) map[string]struct{} {
+	type state struct {
+		str   string
+		moves int
+	}
+	q := []state{{s, 0}}
+	vis := map[string]int{s: 0}
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		if cur.moves == k {
+			continue
+		}
+		n := len(cur.str)
+		for i := 0; i < n; i++ {
+			for j := 0; j <= n; j++ {
+				if j == i || j == i+1 {
+					continue
+				}
+				t := cur.str[:i] + cur.str[i+1:]
+				jj := j
+				if j > i {
+					jj = j - 1
+				}
+				t = t[:jj] + string(cur.str[i]) + t[jj:]
+				if v, ok := vis[t]; !ok || v > cur.moves+1 {
+					vis[t] = cur.moves + 1
+					q = append(q, state{t, cur.moves + 1})
+				}
+			}
+		}
+	}
+	res := make(map[string]struct{})
+	for str := range vis {
+		if isRegular(str) {
+			res[str] = struct{}{}
+		}
+	}
+	return res
+}
+
+func solveE(k int, s string) int {
+	best := math.MaxInt32
+	for str := range reachable(s, k) {
+		c := minCostSeq(str, map[string]int{})
+		if c < best {
+			best = c
+		}
+	}
+	return best
+}
+
+func genRegular(rng *rand.Rand, n int) string {
+	open := n / 2
+	close := open
+	bal := 0
+	var sb strings.Builder
+	for open+close > 0 {
+		if open > 0 && (bal == 0 || rng.Intn(open+close) < open) {
+			sb.WriteByte('(')
+			open--
+			bal++
+		} else {
+			sb.WriteByte(')')
+			close--
+			bal--
+		}
+	}
+	return sb.String()
+}
+
+func genCaseE(rng *rand.Rand) (int, string) {
+	n := rng.Intn(3)*2 + 2
+	s := genRegular(rng, n)
+	k := rng.Intn(3)
+	return k, s
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		k, s := genCaseE(rng)
+		input := fmt.Sprintf("1\n%d\n%s\n", k, s)
+		expect := fmt.Sprintf("%d", solveE(k, s))
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1820-1829/1821/verifierF.go
+++ b/1000-1999/1800-1899/1820-1829/1821/verifierF.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func countUnfortunate(n, m, k int) int {
+	positions := make([]int, n)
+	for i := 0; i < n; i++ {
+		positions[i] = i + 1
+	}
+	var result int
+	var rec func(int, int, []int)
+	rec = func(start, need int, cur []int) {
+		if len(cur) == need {
+			result = (result + countOrientations(cur, k, n)) % mod
+			return
+		}
+		for i := start; i < n; i++ {
+			cur = append(cur, positions[i])
+			rec(i+1, need, cur)
+			cur = cur[:len(cur)-1]
+		}
+	}
+	rec(0, m, []int{})
+	return result
+}
+
+func countOrientations(pos []int, k, n int) int {
+	m := len(pos)
+	total := 0
+	maskMax := 1 << m
+	for mask := 0; mask < maskMax; mask++ {
+		intervals := make([][2]int, m)
+		ok := true
+		for i, p := range pos {
+			if (mask>>i)&1 == 0 { // left
+				l := p - k
+				r := p
+				if l < 1 || r > n {
+					ok = false
+					break
+				}
+				intervals[i] = [2]int{l, r}
+			} else { // right
+				l := p
+				r := p + k
+				if l < 1 || r > n {
+					ok = false
+					break
+				}
+				intervals[i] = [2]int{l, r}
+			}
+		}
+		if !ok {
+			continue
+		}
+		sort.Slice(intervals, func(i, j int) bool { return intervals[i][0] < intervals[j][0] })
+		for i := 1; i < m; i++ {
+			if intervals[i][0] <= intervals[i-1][1] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			total++
+		}
+	}
+	return total
+}
+
+func genCaseF(rng *rand.Rand) (int, int, int) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(n) + 1
+	k := rng.Intn(n) + 1
+	return n, m, k
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, k := genCaseF(rng)
+		input := fmt.Sprintf("%d %d %d\n", n, m, k)
+		expect := fmt.Sprintf("%d", countUnfortunate(n, m, k))
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA-F.go for contest 1821
- generate 100 random tests per problem
- verifiers support binaries or `.go` files

## Testing
- `go build 1000-1999/1800-1899/1820-1829/1821/verifierA.go`
- `go build 1000-1999/1800-1899/1820-1829/1821/verifierB.go`
- `go build 1000-1999/1800-1899/1820-1829/1821/verifierC.go`
- `go build 1000-1999/1800-1899/1820-1829/1821/verifierD.go`
- `go build 1000-1999/1800-1899/1820-1829/1821/verifierE.go`
- `go build 1000-1999/1800-1899/1820-1829/1821/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68876c9006cc8324a1cb7d15c824d22d