### PR TITLE
Add contest 1825 Go verifiers

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1825/verifierA.go
+++ b/1000-1999/1800-1899/1820-1829/1825/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(s string) int {
+	allSame := true
+	for i := 1; i < len(s); i++ {
+		if s[i] != s[0] {
+			allSame = false
+			break
+		}
+	}
+	if allSame {
+		return -1
+	}
+	return len(s) - 1
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(42))
+	tests := []string{"a", "aa", "aba", "abba", "aaaa", "abcba"}
+	for len(tests) < 100 {
+		n := rng.Intn(50) + 1
+		b := make([]byte, n)
+		if rng.Intn(5) == 0 {
+			ch := byte('a' + rng.Intn(26))
+			for i := range b {
+				b[i] = ch
+			}
+		} else {
+			for i := 0; i < (n+1)/2; i++ {
+				ch := byte('a' + rng.Intn(26))
+				b[i] = ch
+				b[n-1-i] = ch
+			}
+		}
+		tests = append(tests, string(b))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, s := range tests {
+		input := fmt.Sprintf("1\n%s\n", s)
+		expected := fmt.Sprintf("%d", solve(s))
+		output, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if output != expected {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%s\nexpected: %s\n got: %s\n", i+1, s, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1800-1899/1820-1829/1825/verifierB.go
+++ b/1000-1999/1800-1899/1820-1829/1825/verifierB.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	n   int
+	m   int
+	arr []int
+}
+
+func solve(tc testCase) int64 {
+	vals := append([]int(nil), tc.arr...)
+	sort.Ints(vals)
+	n, m := tc.n, tc.m
+	k := n * m
+	mn := vals[0]
+	mn2 := vals[1]
+	mx := vals[k-1]
+	mx2 := vals[k-2]
+	s1 := int64(n-1)*int64(mx-mn2) + int64(n)*int64(m-1)*int64(mx-mn)
+	s2 := int64(m-1)*int64(mx-mn2) + int64(m)*int64(n-1)*int64(mx-mn)
+	s3 := int64(n-1)*int64(mx2-mn) + int64(n)*int64(m-1)*int64(mx-mn)
+	s4 := int64(m-1)*int64(mx2-mn) + int64(m)*int64(n-1)*int64(mx-mn)
+	ans := s1
+	if s2 > ans {
+		ans = s2
+	}
+	if s3 > ans {
+		ans = s3
+	}
+	if s4 > ans {
+		ans = s4
+	}
+	return ans
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(43))
+	tests := []testCase{
+		{2, 2, []int{4, 1, 1, 3}},
+		{2, 2, []int{0, 0, 0, 0}},
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(4) + 2
+		arr := make([]int, n*m)
+		for i := range arr {
+			arr[i] = rng.Intn(201) - 100
+		}
+		tests = append(tests, testCase{n, m, arr})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+		for j, v := range tc.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := fmt.Sprintf("%d", solve(tc))
+		output, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if output != expected {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for 1825A and 1825B
- include 100+ randomized tests for each problem

## Testing
- `go run verifierA.go /tmp/1825A_bin`
- `go run verifierB.go /tmp/1825B_bin`


------
https://chatgpt.com/codex/tasks/task_e_68876da7fa1c83249a5381ca5d27379c