### PR TITLE
Add Go verifiers for CF 1823

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1823/verifierA.go
+++ b/1000-1999/1800-1899/1820-1829/1823/verifierA.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n int
+	k int
+}
+
+func possible(n int, k int) bool {
+	for a := 0; a <= n; a++ {
+		b := n - a
+		cur := a*(a-1)/2 + b*(b-1)/2
+		if cur == k {
+			return true
+		}
+	}
+	return false
+}
+
+func checkArray(arr []int, k int) bool {
+	n := len(arr)
+	pairs := 0
+	for i := 0; i < n; i++ {
+		if arr[i] != 1 && arr[i] != -1 {
+			return false
+		}
+		for j := i + 1; j < n; j++ {
+			if arr[i]*arr[j] == 1 {
+				pairs++
+			}
+		}
+	}
+	return pairs == k
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	rand.Seed(1)
+	const cases = 100
+	tests := make([]Test, cases)
+	for i := range tests {
+		n := rand.Intn(10) + 2
+		maxK := n * (n - 1) / 2
+		k := rand.Intn(maxK + 1)
+		tests[i] = Test{n: n, k: k}
+	}
+
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		fmt.Print(out.String())
+		return
+	}
+
+	reader := bufio.NewReader(bytes.NewReader(out.Bytes()))
+	for idx, tc := range tests {
+		token, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("test %d: failed to read output\n", idx+1)
+			return
+		}
+		token = strings.TrimSpace(token)
+		if token != "YES" && token != "NO" {
+			fmt.Printf("test %d: expected YES/NO got %s\n", idx+1, token)
+			return
+		}
+		poss := possible(tc.n, tc.k)
+		if token == "NO" {
+			if poss {
+				fmt.Printf("test %d: expected YES but got NO\n", idx+1)
+				return
+			}
+			continue
+		}
+		// read n integers
+		arr := make([]int, tc.n)
+		for i := 0; i < tc.n; i++ {
+			if _, err := fmt.Fscan(reader, &arr[i]); err != nil {
+				fmt.Printf("test %d: failed to read array\n", idx+1)
+				return
+			}
+		}
+		// consume remainder of line
+		reader.ReadString('\n')
+		if !poss {
+			fmt.Printf("test %d: expected NO but got YES\n", idx+1)
+			return
+		}
+		if !checkArray(arr, tc.k) {
+			fmt.Printf("test %d: wrong array\n", idx+1)
+			return
+		}
+	}
+	fmt.Printf("verified %d test cases\n", len(tests))
+}

--- a/1000-1999/1800-1899/1820-1829/1823/verifierB.go
+++ b/1000-1999/1800-1899/1820-1829/1823/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n int
+	k int
+	p []int
+}
+
+func expected(tc Test) int {
+	mism := 0
+	for i := 0; i < tc.n; i++ {
+		if tc.p[i]%tc.k != (i+1)%tc.k {
+			mism++
+		}
+	}
+	if mism == 0 {
+		return 0
+	} else if mism == 2 {
+		return 1
+	}
+	return -1
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	rand.Seed(2)
+	const cases = 100
+	tests := make([]Test, cases)
+	for i := range tests {
+		n := rand.Intn(8) + 2
+		k := rand.Intn(n-1) + 1
+		p := rand.Perm(n)
+		for i2 := range p {
+			p[i2]++
+		}
+		tests[i] = Test{n: n, k: k, p: p}
+	}
+
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for i, v := range tc.p {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", v)
+		}
+		input.WriteByte('\n')
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		fmt.Print(out.String())
+		return
+	}
+
+	reader := bufio.NewReader(bytes.NewReader(out.Bytes()))
+	for idx, tc := range tests {
+		var ans int
+		if _, err := fmt.Fscan(reader, &ans); err != nil {
+			fmt.Printf("test %d: failed to read output\n", idx+1)
+			return
+		}
+		exp := expected(tc)
+		if ans != exp {
+			fmt.Printf("test %d: expected %d got %d\n", idx+1, exp, ans)
+			return
+		}
+	}
+	fmt.Printf("verified %d test cases\n", len(tests))
+}

--- a/1000-1999/1800-1899/1820-1829/1823/verifierC.go
+++ b/1000-1999/1800-1899/1820-1829/1823/verifierC.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n   int
+	arr []int
+}
+
+func sieve(n int) []int {
+	isPrime := make([]bool, n+1)
+	for i := 2; i <= n; i++ {
+		isPrime[i] = true
+	}
+	for i := 2; i*i <= n; i++ {
+		if isPrime[i] {
+			for j := i * i; j <= n; j += i {
+				isPrime[j] = false
+			}
+		}
+	}
+	primes := []int{}
+	for i := 2; i <= n; i++ {
+		if isPrime[i] {
+			primes = append(primes, i)
+		}
+	}
+	return primes
+}
+
+func factorize(x int, primes []int, counts map[int]int) {
+	for _, p := range primes {
+		if p*p > x {
+			break
+		}
+		for x%p == 0 {
+			counts[p]++
+			x /= p
+		}
+	}
+	if x > 1 {
+		counts[x]++
+	}
+}
+
+func expected(tc Test, primes []int) int {
+	counts := make(map[int]int)
+	for _, v := range tc.arr {
+		factorize(v, primes, counts)
+	}
+	pairs := 0
+	leftover := 0
+	for _, c := range counts {
+		pairs += c / 2
+		leftover += c % 2
+	}
+	return pairs + leftover/3
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	rand.Seed(3)
+	const cases = 100
+	tests := make([]Test, cases)
+	for i := range tests {
+		n := rand.Intn(4) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(50) + 2
+		}
+		tests[i] = Test{n: n, arr: arr}
+	}
+
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d\n", tc.n)
+		for j, v := range tc.arr {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", v)
+		}
+		input.WriteByte('\n')
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		fmt.Print(out.String())
+		return
+	}
+
+	primes := sieve(100)
+	reader := bufio.NewReader(bytes.NewReader(out.Bytes()))
+	for idx, tc := range tests {
+		var ans int
+		if _, err := fmt.Fscan(reader, &ans); err != nil {
+			fmt.Printf("test %d: failed to read output\n", idx+1)
+			return
+		}
+		exp := expected(tc, primes)
+		if ans != exp {
+			fmt.Printf("test %d: expected %d got %d\n", idx+1, exp, ans)
+			return
+		}
+	}
+	fmt.Printf("verified %d test cases\n", len(tests))
+}

--- a/1000-1999/1800-1899/1820-1829/1823/verifierD.go
+++ b/1000-1999/1800-1899/1820-1829/1823/verifierD.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n   int
+	k   int
+	pos []int
+	cnt []int
+}
+
+func possible(n int, k int, pos []int, cnt []int) bool {
+	lp, lc := 0, 0
+	for i := 0; i < k; i++ {
+		if pos[i]-lp < cnt[i]-lc {
+			return false
+		}
+		if pos[i] <= 3 {
+			if cnt[i] != pos[i] {
+				return false
+			}
+		} else {
+			if cnt[i] < 3 {
+				return false
+			}
+		}
+		lp = pos[i]
+		lc = cnt[i]
+	}
+	return true
+}
+
+func isPal(s string) bool {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		if s[i] != s[j] {
+			return false
+		}
+	}
+	return true
+}
+
+func pCount(s string, m int) int {
+	seen := map[string]struct{}{}
+	for i := 0; i < m; i++ {
+		for j := i + 1; j <= m; j++ {
+			sub := s[i:j]
+			if isPal(sub) {
+				seen[sub] = struct{}{}
+			}
+		}
+	}
+	return len(seen)
+}
+
+func checkString(s string, n int, pos []int, cnt []int) bool {
+	if len(s) != n {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < 'a' || s[i] > 'z' {
+			return false
+		}
+	}
+	for i := range pos {
+		if pCount(s, pos[i]) != cnt[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	rand.Seed(4)
+	const cases = 100
+	tests := make([]Test, cases)
+	for i := range tests {
+		n := rand.Intn(7) + 3
+		k := rand.Intn(3) + 1
+		pos := make([]int, k)
+		cnt := make([]int, k)
+		lastP, lastC := 0, 0
+		for j := 0; j < k; j++ {
+			lastP += rand.Intn(n/k+1) + 1
+			if lastP > n {
+				lastP = n
+			}
+			pos[j] = lastP
+			lastC += rand.Intn(3)
+			cnt[j] = lastC
+		}
+		tests[i] = Test{n: n, k: k, pos: pos, cnt: cnt}
+	}
+
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for i, v := range tc.pos {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", v)
+		}
+		input.WriteByte('\n')
+		for i, v := range tc.cnt {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", v)
+		}
+		input.WriteByte('\n')
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		fmt.Print(out.String())
+		return
+	}
+
+	reader := bufio.NewReader(bytes.NewReader(out.Bytes()))
+	for idx, tc := range tests {
+		token, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("test %d: failed to read output\n", idx+1)
+			return
+		}
+		token = strings.TrimSpace(token)
+		poss := possible(tc.n, tc.k, tc.pos, tc.cnt)
+		if token == "NO" {
+			if poss {
+				fmt.Printf("test %d: expected YES but got NO\n", idx+1)
+				return
+			}
+			continue
+		}
+		if token != "YES" {
+			fmt.Printf("test %d: expected YES/NO got %s\n", idx+1, token)
+			return
+		}
+		sline, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("test %d: failed to read string\n", idx+1)
+			return
+		}
+		s := strings.TrimSpace(sline)
+		if !poss {
+			fmt.Printf("test %d: expected NO but got YES\n", idx+1)
+			return
+		}
+		if !checkString(s, tc.n, tc.pos, tc.cnt) {
+			fmt.Printf("test %d: invalid string\n", idx+1)
+			return
+		}
+	}
+	fmt.Printf("verified %d test cases\n", len(tests))
+}

--- a/1000-1999/1800-1899/1820-1829/1823/verifierE.go
+++ b/1000-1999/1800-1899/1820-1829/1823/verifierE.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n     int
+	l     int
+	r     int
+	edges [][2]int
+}
+
+func mex(set map[int]bool) int {
+	for i := 0; ; i++ {
+		if !set[i] {
+			return i
+		}
+	}
+}
+
+func expected(tc Test) string {
+	n := tc.n
+	l, r := tc.l, tc.r
+	adj := make([][]int, n)
+	for _, e := range tc.edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	visited := make([]bool, n)
+	cycles := []int{}
+	for i := 0; i < n; i++ {
+		if visited[i] {
+			continue
+		}
+		cur := i
+		prev := -1
+		length := 0
+		for {
+			visited[cur] = true
+			length++
+			next := adj[cur][0]
+			if next == prev {
+				if len(adj[cur]) > 1 {
+					next = adj[cur][1]
+				}
+			}
+			prev, cur = cur, next
+			if cur == i {
+				break
+			}
+		}
+		cycles = append(cycles, length)
+	}
+	maxLen := 0
+	for _, v := range cycles {
+		if v > maxLen {
+			maxLen = v
+		}
+	}
+	if maxLen < l {
+		return "Bob"
+	}
+	grundy := make([]int, maxLen+1)
+	for length := 1; length <= maxLen; length++ {
+		reachable := make(map[int]bool)
+		for k := l; k <= r && k <= length; k++ {
+			for start := 0; start <= length-k; start++ {
+				left := start
+				right := length - k - start
+				val := grundy[left] ^ grundy[right]
+				reachable[val] = true
+			}
+		}
+		grundy[length] = mex(reachable)
+	}
+	total := 0
+	for _, c := range cycles {
+		reachable := make(map[int]bool)
+		if c >= l && c <= r {
+			reachable[0] = true
+		}
+		for k := l; k <= r && k < c; k++ {
+			reachable[grundy[c-k]] = true
+		}
+		g := mex(reachable)
+		total ^= g
+	}
+	if total != 0 {
+		return "Alice"
+	}
+	return "Bob"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	rand.Seed(5)
+	const cases = 100
+	tests := make([]Test, cases)
+	for i := range tests {
+		cycles := rand.Intn(3) + 1
+		total := 0
+		lengths := make([]int, cycles)
+		for j := 0; j < cycles; j++ {
+			lengths[j] = rand.Intn(4) + 1
+			total += lengths[j]
+		}
+		l := rand.Intn(3) + 1
+		r := l + rand.Intn(3)
+		edges := make([][2]int, 0, total)
+		idx := 0
+		for _, lenC := range lengths {
+			for j := 0; j < lenC; j++ {
+				u := idx + j
+				v := idx + (j+1)%lenC
+				edges = append(edges, [2]int{u, v})
+			}
+			idx += lenC
+		}
+		tests[i] = Test{n: total, l: l, r: r, edges: edges}
+	}
+
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d %d\n", tc.n, tc.l, tc.r)
+		for _, e := range tc.edges {
+			fmt.Fprintf(&input, "%d %d\n", e[0]+1, e[1]+1)
+		}
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		fmt.Print(out.String())
+		return
+	}
+
+	reader := bufio.NewReader(bytes.NewReader(out.Bytes()))
+	for idx, tc := range tests {
+		var ans string
+		if _, err := fmt.Fscan(reader, &ans); err != nil {
+			fmt.Printf("test %d: failed to read output\n", idx+1)
+			return
+		}
+		exp := expected(tc)
+		if ans != exp {
+			fmt.Printf("test %d: expected %s got %s\n", idx+1, exp, ans)
+			return
+		}
+	}
+	fmt.Printf("verified %d test cases\n", len(tests))
+}

--- a/1000-1999/1800-1899/1820-1829/1823/verifierF.go
+++ b/1000-1999/1800-1899/1820-1829/1823/verifierF.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD int64 = 998244353
+
+type Test struct {
+	n     int
+	s     int
+	t     int
+	edges [][2]int
+}
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		b >>= 1
+	}
+	return res
+}
+
+func solve(tc Test) []int64 {
+	n, s, t := tc.n, tc.s, tc.t
+	g := make([][]int, n+1)
+	for _, e := range tc.edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	deg := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		deg[i] = len(g[i])
+	}
+	invDeg := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		if deg[i] > 0 {
+			invDeg[i] = modPow(int64(deg[i]), MOD-2)
+		}
+	}
+	parent := make([]int, n+1)
+	for i := range parent {
+		parent[i] = -2
+	}
+	order := make([]int, 0, n)
+	stack := []int{t}
+	parent[t] = -1
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, v)
+		for _, to := range g[v] {
+			if to == parent[v] {
+				continue
+			}
+			parent[to] = v
+			stack = append(stack, to)
+		}
+	}
+	A := make([]int64, n+1)
+	B := make([]int64, n+1)
+	for i := len(order) - 1; i >= 0; i-- {
+		v := order[i]
+		var sumA, sumB int64
+		for _, to := range g[v] {
+			if to == parent[v] {
+				continue
+			}
+			sumA = (sumA + A[to]*invDeg[to]) % MOD
+			sumB = (sumB + B[to]*invDeg[to]) % MOD
+		}
+		denom := (1 + MOD - sumA) % MOD
+		invDen := modPow(denom, MOD-2)
+		termParent := int64(0)
+		if parent[v] != -1 && parent[v] != t {
+			termParent = invDeg[parent[v]]
+		}
+		A[v] = termParent * invDen % MOD
+		delta := int64(0)
+		if v == s {
+			delta = 1
+		}
+		B[v] = (delta + sumB) % MOD
+		B[v] = B[v] * invDen % MOD
+	}
+	ans := make([]int64, n+1)
+	queue := []int{t}
+	ans[t] = B[t]
+	for len(queue) > 0 {
+		v := queue[0]
+		queue = queue[1:]
+		for _, to := range g[v] {
+			if to == parent[v] {
+				continue
+			}
+			ans[to] = (A[to]*ans[v] + B[to]) % MOD
+			queue = append(queue, to)
+		}
+	}
+	res := make([]int64, n)
+	for i := 1; i <= n; i++ {
+		res[i-1] = ans[i] % MOD
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	rand.Seed(7)
+	const cases = 100
+	tests := make([]Test, cases)
+	for i := range tests {
+		n := rand.Intn(6) + 2
+		s := rand.Intn(n) + 1
+		t := rand.Intn(n) + 1
+		for t == s {
+			t = rand.Intn(n) + 1
+		}
+		edges := make([][2]int, n-1)
+		for j := 1; j < n; j++ {
+			u := rand.Intn(j) + 1
+			v := j + 1
+			edges[j-1] = [2]int{u, v}
+		}
+		tests[i] = Test{n: n, s: s, t: t, edges: edges}
+	}
+
+	for idx, tc := range tests {
+		var input strings.Builder
+		fmt.Fprintf(&input, "%d %d %d\n", tc.n, tc.s, tc.t)
+		for _, e := range tc.edges {
+			fmt.Fprintf(&input, "%d %d\n", e[0], e[1])
+		}
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(input.String())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		if err != nil {
+			fmt.Printf("error running binary on test %d: %v\n", idx+1, err)
+			fmt.Print(out.String())
+			return
+		}
+		reader := bufio.NewReader(bytes.NewReader(out.Bytes()))
+		exp := solve(tc)
+		for i := 0; i < tc.n; i++ {
+			var val int64
+			if _, err := fmt.Fscan(reader, &val); err != nil {
+				fmt.Printf("test %d: failed to read output\n", idx+1)
+				return
+			}
+			if val%MOD != exp[i] {
+				fmt.Printf("test %d: expected %d got %d at vertex %d\n", idx+1, exp[i], val%MOD, i+1)
+				return
+			}
+		}
+	}
+	fmt.Printf("verified %d test cases\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1823
- each verifier runs 100 random tests against a provided binary
- verifiers check correctness of output according to the problem

## Testing
- `go run verifierA.go ./solutionA`
- `go run verifierB.go ./solutionB`
- `go run verifierC.go ./solutionC`

------
https://chatgpt.com/codex/tasks/task_e_68876d1c24f88324918a6868f80d0b05