### PR TITLE
Update verifier timeouts to 30s

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -247,7 +247,7 @@ func runVerifier(verifierFile, tempBinAbs string) bool {
 		return false
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Use a separate process group so we can kill all children on timeout
@@ -281,7 +281,7 @@ func runVerifier(verifierFile, tempBinAbs string) bool {
 		pgid, _ := syscall.Getpgid(cmd.Process.Pid)
 		syscall.Kill(-pgid, syscall.SIGKILL)
 		<-done
-		fmt.Println("Verification timed out after 10 seconds")
+		fmt.Println("Verification timed out after 30 seconds")
 		fmt.Printf("Verifier stdout: %s\n", out.String())
 		fmt.Printf("Verifier stderr: %s\n", stderr.String())
 		return false

--- a/webserver.go
+++ b/webserver.go
@@ -323,7 +323,7 @@ func submitSolution(w http.ResponseWriter, r *http.Request, c *contestInfo, lett
 	} else {
 		verifier := findVerifier(c.Path, letter)
 		if verifier != "" {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			cmd := exec.CommandContext(ctx, "go", "run", filepath.Base(verifier), exe)
 			cmd.Dir = c.Path
@@ -349,7 +349,7 @@ func submitSolution(w http.ResponseWriter, r *http.Request, c *contestInfo, lett
 
 			output.Write(res)
 			if ctx.Err() == context.DeadlineExceeded {
-				output.WriteString("\nVerifier timed out after 10 seconds")
+				output.WriteString("\nVerifier timed out after 30 seconds")
 			} else if err != nil {
 				if ee, ok := err.(*exec.ExitError); ok {
 					output.WriteString(fmt.Sprintf("\nVerifier exited with status %d", ee.ExitCode()))


### PR DESCRIPTION
## Summary
- extend verifier timeout from 10s to 30s in `webserver.go` and `eval.go`

## Testing
- `go build webserver.go`
- `go build eval.go`


------
https://chatgpt.com/codex/tasks/task_e_68876e8f6a0c8324a1caa940105e0a23