### PR TITLE
Add Go verifiers for contest 1833

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1833/verifierA.go
+++ b/1000-1999/1800-1899/1830-1839/1833/verifierA.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(n int, s string) string {
+	mp := make(map[string]struct{})
+	for i := 0; i+1 < n; i++ {
+		mp[s[i:i+2]] = struct{}{}
+	}
+	return fmt.Sprintf("%d\n", len(mp))
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(49) + 2
+	var sb strings.Builder
+	letters := []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g'}
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	s := sb.String()
+	input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+	return input, expected(n, s)
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1833/verifierB.go
+++ b/1000-1999/1800-1899/1830-1839/1833/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type Test struct {
+	input    string
+	expected string
+}
+
+func solveCase(n, k int, a, b []int) string {
+	type pair struct{ val, idx int }
+	arr := make([]pair, n)
+	for i := 0; i < n; i++ {
+		arr[i] = pair{a[i], i}
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i].val < arr[j].val })
+	sort.Ints(b)
+	ans := make([]int, n)
+	for i := 0; i < n; i++ {
+		ans[arr[i].idx] = b[i]
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", ans[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) Test {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(100)
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(201) - 100
+		diff := rng.Intn(2*k+1) - k
+		b[i] = a[i] + diff
+	}
+	// shuffle b
+	rng.Shuffle(n, func(i, j int) { b[i], b[j] = b[j], b[i] })
+	input := fmt.Sprintf("1\n%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", a[i])
+	}
+	input += "\n"
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", b[i])
+	}
+	input += "\n"
+	return Test{input: input, expected: solveCase(n, k, a, append([]int(nil), b...))}
+}
+
+func runCase(bin string, t Test) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(t.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(t.expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		tcase := generateCase(rng)
+		if err := runCase(bin, tcase); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tcase.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1833/verifierC.go
+++ b/1000-1999/1800-1899/1830-1839/1833/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(nums []int) string {
+	even, odd := 0, 0
+	minVal := int(^uint(0) >> 1)
+	for _, x := range nums {
+		if x%2 == 0 {
+			even++
+		} else {
+			odd++
+		}
+		if x < minVal {
+			minVal = x
+		}
+	}
+	res := "NO"
+	if even == len(nums) || odd == len(nums) || minVal%2 == 1 {
+		res = "YES"
+	}
+	return res + "\n"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(1000)
+	}
+	input := fmt.Sprintf("1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", arr[i])
+	}
+	input += "\n"
+	return input, expected(arr)
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1833/verifierD.go
+++ b/1000-1999/1800-1899/1830-1839/1833/verifierD.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func lexGreater(a, b []int) bool {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i] != b[i] {
+			return a[i] > b[i]
+		}
+	}
+	return false
+}
+
+func solveCase(p []int) []int {
+	n := len(p)
+	if n == 1 {
+		return p
+	}
+	posMax := 1
+	for i := 1; i < n; i++ {
+		if p[i] > p[posMax] {
+			posMax = i
+		}
+	}
+	posPrevMax := 0
+	for i := 0; i < n-1; i++ {
+		if p[i] > p[posPrevMax] {
+			posPrevMax = i
+		}
+	}
+	rsetMap := map[int]bool{}
+	cand := []int{posMax - 1, posMax, posPrevMax - 1, posPrevMax, n - 1}
+	for _, r := range cand {
+		if r >= 0 && r < n {
+			rsetMap[r] = true
+		}
+	}
+	best := []int{}
+	for r := range rsetMap {
+		suffix := make([]int, n-r-1)
+		copy(suffix, p[r+1:])
+		for l := 0; l <= r; l++ {
+			candperm := append([]int{}, suffix...)
+			for i := r; i >= l; i-- {
+				candperm = append(candperm, p[i])
+			}
+			candperm = append(candperm, p[:l]...)
+			if len(best) == 0 || lexGreater(candperm, best) {
+				best = candperm
+			}
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	perm := rng.Perm(n)
+	for i := 0; i < n; i++ {
+		perm[i]++
+	}
+	input := fmt.Sprintf("1\n%d\n", n)
+	for i, v := range perm {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	ans := solveCase(perm)
+	var sb strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return input, sb.String()
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1833/verifierE.go
+++ b/1000-1999/1800-1899/1830-1839/1833/verifierE.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(a []int) (int, int) {
+	n := len(a) - 1
+	adj := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		j := a[i]
+		exists := false
+		for _, v := range adj[i] {
+			if v == j {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			adj[i] = append(adj[i], j)
+		}
+		exists = false
+		for _, v := range adj[j] {
+			if v == i {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			adj[j] = append(adj[j], i)
+		}
+	}
+	visited := make([]bool, n+1)
+	components, cycleComp := 0, 0
+	for i := 1; i <= n; i++ {
+		if visited[i] {
+			continue
+		}
+		components++
+		queue := []int{i}
+		visited[i] = true
+		isCycle := true
+		for len(queue) > 0 {
+			v := queue[0]
+			queue = queue[1:]
+			if len(adj[v]) != 2 {
+				isCycle = false
+			}
+			for _, to := range adj[v] {
+				if !visited[to] {
+					visited[to] = true
+					queue = append(queue, to)
+				}
+			}
+		}
+		if isCycle {
+			cycleComp++
+		}
+	}
+	pathComp := components - cycleComp
+	maxCycles := components
+	minCycles := cycleComp
+	if pathComp > 0 {
+		minCycles++
+	}
+	return minCycles, maxCycles
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 2
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		j := rng.Intn(n) + 1
+		if j == i {
+			j = (j % n) + 1
+		}
+		a[i] = j
+	}
+	input := fmt.Sprintf("1\n%d\n", n)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", a[i])
+	}
+	input += "\n"
+	minC, maxC := solveCase(a)
+	exp := fmt.Sprintf("%d %d\n", minC, maxC)
+	return input, exp
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1833/verifierF.go
+++ b/1000-1999/1800-1899/1830-1839/1833/verifierF.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const MOD int = 1000000007
+
+func modPow(a, e int) int {
+	res := 1
+	x := a % MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = int(int64(res) * int64(x) % int64(MOD))
+		}
+		x = int(int64(x) * int64(x) % int64(MOD))
+		e >>= 1
+	}
+	return res
+}
+
+func modInv(a int) int { return modPow(a, MOD-2) }
+
+func solveCase(arr []int, m int) string {
+	freq := make(map[int]int)
+	for _, v := range arr {
+		freq[v]++
+	}
+	unique := make([]int, 0, len(freq))
+	for v := range freq {
+		unique = append(unique, v)
+	}
+	sort.Ints(unique)
+	invCache := make(map[int]int)
+	getInv := func(x int) int {
+		if val, ok := invCache[x]; ok {
+			return val
+		}
+		val := modInv(x)
+		invCache[x] = val
+		return val
+	}
+	ans := 0
+	prod := 1
+	left := 0
+	for right := 0; right < len(unique); right++ {
+		cntR := freq[unique[right]]
+		prod = int(int64(prod) * int64(cntR) % int64(MOD))
+		for unique[right]-unique[left] >= m {
+			cntL := freq[unique[left]]
+			prod = int(int64(prod) * int64(getInv(cntL)) % int64(MOD))
+			left++
+		}
+		for right-left+1 > m {
+			cntL := freq[unique[left]]
+			prod = int(int64(prod) * int64(getInv(cntL)) % int64(MOD))
+			left++
+		}
+		if right-left+1 == m && unique[right]-unique[left] < m {
+			ans += prod
+			if ans >= MOD {
+				ans -= MOD
+			}
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(20)
+	}
+	input := fmt.Sprintf("1\n%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", arr[i])
+	}
+	input += "\n"
+	return input, solveCase(arr, m)
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1833/verifierG.go
+++ b/1000-1999/1800-1899/1830-1839/1833/verifierG.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type pair struct{ u, v int }
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveCase(n int, edges []pair) string {
+	adj := make([][]int, n+1)
+	deg := make([]int, n+1)
+	size := make([]int, n+1)
+	visited := make([]bool, n+1)
+	mp2 := make(map[pair]int)
+	for i := 1; i <= n; i++ {
+		size[i] = 1
+	}
+	for idx, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+		deg[e.u]++
+		deg[e.v]++
+		u, v := min(e.u, e.v), max(e.u, e.v)
+		mp2[pair{u, v}] = idx + 1
+	}
+	if n%3 != 0 {
+		return "-1\n"
+	}
+	queue := make([]int, 0, n)
+	head := 0
+	for i := 1; i <= n; i++ {
+		if deg[i] == 1 {
+			queue = append(queue, i)
+		}
+	}
+	st := make(map[pair]bool)
+	check := false
+	for head < len(queue) {
+		it := queue[head]
+		head++
+		if size[it] > 3 {
+			check = true
+			break
+		}
+		visited[it] = true
+		for _, child := range adj[it] {
+			if !visited[child] {
+				deg[child]--
+				if size[it] == 3 {
+					u, v := min(it, child), max(it, child)
+					st[pair{u, v}] = true
+				} else {
+					size[child] += size[it]
+				}
+				if deg[child] == 1 {
+					queue = append(queue, child)
+				}
+			}
+		}
+	}
+	if check {
+		return "-1\n"
+	}
+	keys := make([]pair, 0, len(st))
+	for k := range st {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].u != keys[j].u {
+			return keys[i].u < keys[j].u
+		}
+		return keys[i].v < keys[j].v
+	})
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(keys)))
+	for i, k := range keys {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", mp2[k]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateTree(rng *rand.Rand, n int) []pair {
+	edges := make([]pair, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, pair{p, i})
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 2
+	edges := generateTree(rng, n)
+	input := fmt.Sprintf("1\n%d\n", n)
+	for _, e := range edges {
+		input += fmt.Sprintf("%d %d\n", e.u, e.v)
+	}
+	return input, solveCase(n, edges)
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest **1833** (problems A-G)
- each verifier runs 100 randomized tests and checks output of a supplied binary

## Testing
- `go run 1000-1999/1800-1899/1830-1839/1833/verifierA.go /tmp/1833A_bin`
- `go run 1000-1999/1800-1899/1830-1839/1833/verifierB.go /tmp/1833B_bin`
- `go run 1000-1999/1800-1899/1830-1839/1833/verifierC.go /tmp/1833C_bin`


------
https://chatgpt.com/codex/tasks/task_e_68876fd8556c83249b35d5ff28f89776