### PR TITLE
Add verifiers for contest 1832

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1832/verifierA.go
+++ b/1000-1999/1800-1899/1830-1839/1832/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(s string) string {
+	freq := make(map[rune]int)
+	for _, c := range s {
+		freq[c]++
+	}
+	if len(freq) == 1 {
+		return "NO"
+	}
+	if len(freq) == 2 {
+		ones := 0
+		for _, c := range freq {
+			if c == 1 {
+				ones++
+			}
+		}
+		if ones == 1 {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(49) + 2
+	b := make([]byte, n)
+	for i := 0; i < (n+1)/2; i++ {
+		c := byte('a' + rng.Intn(26))
+		b[i] = c
+		b[n-1-i] = c
+	}
+	s := string(b)
+	input := fmt.Sprintf("1\n%s\n", s)
+	return input, solve(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1832/verifierB.go
+++ b/1000-1999/1800-1899/1830-1839/1832/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n, k int, arr []int) int64 {
+	sort.Ints(arr)
+	prefix := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] + int64(arr[i])
+	}
+	var best int64
+	for i := 0; i <= k; i++ {
+		left := 2 * i
+		if left > n {
+			break
+		}
+		right := n - (k - i)
+		if right < left {
+			continue
+		}
+		sum := prefix[right] - prefix[left]
+		if sum > best {
+			best = sum
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	k := rng.Intn(n/2 + 1)
+	arr := make([]int, n)
+	used := map[int]bool{}
+	for i := 0; i < n; i++ {
+		v := rng.Intn(100)
+		for used[v] {
+			v = rng.Intn(100)
+		}
+		used[v] = true
+		arr[i] = v
+	}
+	input := fmt.Sprintf("1\n%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", arr[i])
+	}
+	input += "\n"
+	return input, fmt.Sprintf("%d", solve(n, k, arr))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1832/verifierC.go
+++ b/1000-1999/1800-1899/1830-1839/1832/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(arr []int) int {
+	n := len(arr)
+	if n == 1 {
+		return 1
+	}
+	b := make([]int, 0, n)
+	b = append(b, arr[0])
+	for i := 1; i < n-1; i++ {
+		prev := b[len(b)-1]
+		curr := arr[i]
+		next := arr[i+1]
+		if (prev <= curr && curr <= next) || (prev >= curr && curr >= next) {
+			continue
+		}
+		b = append(b, curr)
+	}
+	b = append(b, arr[n-1])
+	ans := len(b)
+	if ans == 2 && b[0] == b[1] {
+		ans = 1
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(21) - 10
+	}
+	input := fmt.Sprintf("1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", arr[i])
+	}
+	input += "\n"
+	return input, fmt.Sprintf("%d", solve(arr))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1832/verifierD1.go
+++ b/1000-1999/1800-1899/1830-1839/1832/verifierD1.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(arr []int, k int) int {
+	n := len(arr)
+	a := append([]int(nil), arr...)
+	colors := make([]bool, n)
+	maxOps := k
+	if maxOps > 2000 {
+		maxOps = 2000
+	}
+	for i := 1; i <= maxOps; i++ {
+		idx := 0
+		for j := 1; j < n; j++ {
+			if a[j] < a[idx] {
+				idx = j
+			}
+		}
+		if !colors[idx] {
+			a[idx] += i
+			colors[idx] = true
+		} else {
+			a[idx] -= i
+			colors[idx] = false
+		}
+	}
+	mn := a[0]
+	for _, v := range a {
+		if v < mn {
+			mn = v
+		}
+	}
+	return mn
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(50)
+	}
+	input := fmt.Sprintf("%d 1\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", arr[i])
+	}
+	input += "\n"
+	input += fmt.Sprintf("%d\n", k)
+	return input, fmt.Sprintf("%d", solve(arr, k))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1832/verifierD2.go
+++ b/1000-1999/1800-1899/1830-1839/1832/verifierD2.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(arr []int, k int) int {
+	n := len(arr)
+	a := append([]int(nil), arr...)
+	colors := make([]bool, n)
+	maxOps := k
+	if maxOps > 2000 {
+		maxOps = 2000
+	}
+	for i := 1; i <= maxOps; i++ {
+		idx := 0
+		for j := 1; j < n; j++ {
+			if a[j] < a[idx] {
+				idx = j
+			}
+		}
+		if !colors[idx] {
+			a[idx] += i
+			colors[idx] = true
+		} else {
+			a[idx] -= i
+			colors[idx] = false
+		}
+	}
+	mn := a[0]
+	for _, v := range a {
+		if v < mn {
+			mn = v
+		}
+	}
+	return mn
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(50)
+	}
+	input := fmt.Sprintf("%d 1\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", arr[i])
+	}
+	input += "\n"
+	input += fmt.Sprintf("%d\n", k)
+	return input, fmt.Sprintf("%d", solve(arr, k))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1832/verifierE.go
+++ b/1000-1999/1800-1899/1830-1839/1832/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n, a1, x, y, m, k int) uint64 {
+	a := int64(a1)
+	xm := int64(x)
+	ym := int64(y)
+	mm := int64(m)
+	b := make([]int64, k+1)
+	var ans uint64
+	for i := 1; i <= n; i++ {
+		ai := a
+		for t := k; t >= 1; t-- {
+			val := (b[t] + b[t-1]) % mod
+			if t == 1 {
+				val = (val + ai) % mod
+			}
+			b[t] = val
+		}
+		b[0] = (b[0] + ai) % mod
+		ans ^= uint64(b[k]) * uint64(i)
+		a = (a*xm + ym) % mm
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(50) + 2
+	a1 := rng.Intn(m)
+	x := rng.Intn(m)
+	y := rng.Intn(m)
+	k := rng.Intn(5) + 1
+	input := fmt.Sprintf("%d %d %d %d %d %d\n", n, a1, x, y, m, k)
+	exp := solve(n, a1, x, y, m, k)
+	return input, fmt.Sprintf("%d", exp)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1832/verifierF.go
+++ b/1000-1999/1800-1899/1830-1839/1832/verifierF.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func zombies(n, k int, x, m int64, l, r []int64) int64 {
+	maxStart := int(x - m)
+	starts := make([]int, k)
+	assign := make([]int, n)
+	best := int64(-1)
+
+	var calc func() // compute zombies for current starts and assignment
+	calc = func() {
+		var total int64
+		for i := 0; i < n; i++ {
+			s := int64(starts[assign[i]])
+			for t := int64(0); t < x; t++ {
+				defended := false
+				if t >= l[i] && t < r[i] {
+					defended = true
+				}
+				if !defended && t >= s && t < s+m {
+					defended = true
+				}
+				if !defended {
+					total++
+				}
+			}
+		}
+		if total > best {
+			best = total
+		}
+	}
+
+	var assignDFS func(int)
+	assignDFS = func(i int) {
+		if i == n {
+			calc()
+			return
+		}
+		for g := 0; g < k; g++ {
+			assign[i] = g
+			assignDFS(i + 1)
+		}
+	}
+
+	var startDFS func(int)
+	startDFS = func(pos int) {
+		if pos == k {
+			assignDFS(0)
+			return
+		}
+		for t := 0; t <= maxStart; t++ {
+			starts[pos] = t
+			startDFS(pos + 1)
+		}
+	}
+
+	startDFS(0)
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	k := rng.Intn(n) + 1
+	x := int64(rng.Intn(5) + 1)
+	m := int64(rng.Intn(int(x)) + 1)
+	l := make([]int64, n)
+	r := make([]int64, n)
+	for i := 0; i < n; i++ {
+		L := int64(rng.Intn(int(x)))
+		R := int64(rng.Intn(int(x-L))) + L + 1
+		l[i] = L
+		r[i] = R
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, k, x, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", l[i], r[i]))
+	}
+	exp := zombies(n, k, x, m, l, r)
+	return sb.String(), fmt.Sprintf("%d", exp)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA–F.go for contest 1832
- each verifier runs 100 randomized tests and checks output

## Testing
- `go run verifierA.go ./1832A.go`


------
https://chatgpt.com/codex/tasks/task_e_68876f92421c8324845af6e286c7aa19