### PR TITLE
Add contest 1829 solution verifiers

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1829/verifierA.go
+++ b/1000-1999/1800-1899/1820-1829/1829/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const targetA = "codeforces"
+
+func solveA(s string) string {
+	diff := 0
+	for i := 0; i < len(targetA) && i < len(s); i++ {
+		if s[i] != targetA[i] {
+			diff++
+		}
+	}
+	return fmt.Sprint(diff)
+}
+
+func genTestsA() ([]string, string) {
+	const t = 100
+	rand.Seed(1)
+	var input strings.Builder
+	fmt.Fprintln(&input, t)
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		b := make([]byte, len(targetA))
+		for j := range b {
+			b[j] = byte('a' + rand.Intn(26))
+		}
+		s := string(b)
+		fmt.Fprintln(&input, s)
+		expected[i] = solveA(s)
+	}
+	return expected, input.String()
+}
+
+func runBinary(path, in string) ([]string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(&out)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, strings.TrimSpace(scanner.Text()))
+	}
+	return lines, scanner.Err()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	expected, input := genTestsA()
+	lines, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if len(lines) != len(expected) {
+		fmt.Fprintf(os.Stderr, "expected %d lines, got %d\n", len(expected), len(lines))
+		os.Exit(1)
+	}
+	rand.Seed(1) // regenerate inputs for error messages
+	for i, exp := range expected {
+		if lines[i] != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\n", i+1, exp, lines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+	_ = time.Now()
+}

--- a/1000-1999/1800-1899/1820-1829/1829/verifierB.go
+++ b/1000-1999/1800-1899/1820-1829/1829/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func solveB(arr []int) string {
+	maxZero := 0
+	curZero := 0
+	for _, v := range arr {
+		if v == 0 {
+			curZero++
+		} else {
+			if curZero > maxZero {
+				maxZero = curZero
+			}
+			curZero = 0
+		}
+	}
+	if curZero > maxZero {
+		maxZero = curZero
+	}
+	return strconv.Itoa(maxZero)
+}
+
+func genTestsB() ([]string, string) {
+	const t = 100
+	rand.Seed(1)
+	var input strings.Builder
+	fmt.Fprintln(&input, t)
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(100) + 1
+		fmt.Fprintln(&input, n)
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(2)
+		}
+		for j, v := range arr {
+			if j+1 == n {
+				fmt.Fprintln(&input, v)
+			} else {
+				fmt.Fprint(&input, v, " ")
+			}
+		}
+		expected[i] = solveB(arr)
+	}
+	return expected, input.String()
+}
+
+func runBinary(path, in string) ([]string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(&out)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, strings.TrimSpace(scanner.Text()))
+	}
+	return lines, scanner.Err()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	expected, input := genTestsB()
+	lines, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if len(lines) != len(expected) {
+		fmt.Fprintf(os.Stderr, "expected %d lines, got %d\n", len(expected), len(lines))
+		os.Exit(1)
+	}
+	for i, exp := range expected {
+		if lines[i] != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\n", i+1, exp, lines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1820-1829/1829/verifierC.go
+++ b/1000-1999/1800-1899/1820-1829/1829/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type book struct {
+	m int
+	s string
+}
+
+func solveC(books []book) string {
+	const inf = int(1e9)
+	bestBoth := inf
+	best1 := inf
+	best2 := inf
+	for _, b := range books {
+		switch b.s {
+		case "11":
+			if b.m < bestBoth {
+				bestBoth = b.m
+			}
+		case "10":
+			if b.m < best1 {
+				best1 = b.m
+			}
+		case "01":
+			if b.m < best2 {
+				best2 = b.m
+			}
+		}
+	}
+	ans := bestBoth
+	if best1+best2 < ans {
+		ans = best1 + best2
+	}
+	if ans >= inf {
+		return "-1"
+	}
+	return strconv.Itoa(ans)
+}
+
+func genTestsC() ([]string, string) {
+	const t = 100
+	rand.Seed(1)
+	var input strings.Builder
+	fmt.Fprintln(&input, t)
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(5) + 1
+		fmt.Fprintln(&input, n)
+		books := make([]book, n)
+		for j := 0; j < n; j++ {
+			m := rand.Intn(20) + 1
+			opt := rand.Intn(4)
+			var s string
+			switch opt {
+			case 0:
+				s = "00"
+			case 1:
+				s = "01"
+			case 2:
+				s = "10"
+			default:
+				s = "11"
+			}
+			books[j] = book{m: m, s: s}
+			fmt.Fprintf(&input, "%d %s\n", m, s)
+		}
+		expected[i] = solveC(books)
+	}
+	return expected, input.String()
+}
+
+func runBinary(path, in string) ([]string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(&out)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, strings.TrimSpace(scanner.Text()))
+	}
+	return lines, scanner.Err()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	expected, input := genTestsC()
+	lines, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if len(lines) != len(expected) {
+		fmt.Fprintf(os.Stderr, "expected %d lines, got %d\n", len(expected), len(lines))
+		os.Exit(1)
+	}
+	for i, exp := range expected {
+		if lines[i] != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\n", i+1, exp, lines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1820-1829/1829/verifierD.go
+++ b/1000-1999/1800-1899/1820-1829/1829/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func canCreate(n, m int) bool {
+	if n == m {
+		return true
+	}
+	if n < m || n%3 != 0 {
+		return false
+	}
+	a := n / 3
+	return canCreate(a, m) || canCreate(n-a, m)
+}
+
+func solveD(n, m int) string {
+	if canCreate(n, m) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genTestsD() ([]string, string) {
+	const t = 100
+	rand.Seed(1)
+	var input strings.Builder
+	fmt.Fprintln(&input, t)
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(1000000) + 1
+		m := rand.Intn(1000000) + 1
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		expected[i] = solveD(n, m)
+	}
+	return expected, input.String()
+}
+
+func runBinary(path, in string) ([]string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(&out)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, strings.TrimSpace(scanner.Text()))
+	}
+	return lines, scanner.Err()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	expected, input := genTestsD()
+	lines, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if len(lines) != len(expected) {
+		fmt.Fprintf(os.Stderr, "expected %d lines, got %d\n", len(expected), len(lines))
+		os.Exit(1)
+	}
+	for i, exp := range expected {
+		if !strings.EqualFold(lines[i], exp) {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\n", i+1, exp, lines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1820-1829/1829/verifierE.go
+++ b/1000-1999/1800-1899/1820-1829/1829/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type pair struct{ x, y int }
+
+func solveE(grid [][]int) string {
+	n := len(grid)
+	m := len(grid[0])
+	dx := []int{1, -1, 0, 0}
+	dy := []int{0, 0, 1, -1}
+	visited := make([][]bool, n)
+	for i := range visited {
+		visited[i] = make([]bool, m)
+	}
+	best := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 0 || visited[i][j] {
+				continue
+			}
+			sum := 0
+			q := []pair{{i, j}}
+			visited[i][j] = true
+			for head := 0; head < len(q); head++ {
+				p := q[head]
+				sum += grid[p.x][p.y]
+				for dir := 0; dir < 4; dir++ {
+					nx := p.x + dx[dir]
+					ny := p.y + dy[dir]
+					if nx >= 0 && nx < n && ny >= 0 && ny < m && !visited[nx][ny] && grid[nx][ny] > 0 {
+						visited[nx][ny] = true
+						q = append(q, pair{nx, ny})
+					}
+				}
+			}
+			if sum > best {
+				best = sum
+			}
+		}
+	}
+	return fmt.Sprint(best)
+}
+
+func genTestsE() ([]string, string) {
+	const t = 100
+	rand.Seed(1)
+	var input strings.Builder
+	fmt.Fprintln(&input, t)
+	expected := make([]string, t)
+	for tc := 0; tc < t; tc++ {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(10) + 1
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		grid := make([][]int, n)
+		for i := 0; i < n; i++ {
+			grid[i] = make([]int, m)
+			for j := 0; j < m; j++ {
+				grid[i][j] = rand.Intn(11)
+				if j+1 == m {
+					fmt.Fprintln(&input, grid[i][j])
+				} else {
+					fmt.Fprint(&input, grid[i][j], " ")
+				}
+			}
+		}
+		expected[tc] = solveE(grid)
+	}
+	return expected, input.String()
+}
+
+func runBinary(path, in string) ([]string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(&out)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, strings.TrimSpace(scanner.Text()))
+	}
+	return lines, scanner.Err()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	expected, input := genTestsE()
+	lines, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if len(lines) != len(expected) {
+		fmt.Fprintf(os.Stderr, "expected %d lines, got %d\n", len(expected), len(lines))
+		os.Exit(1)
+	}
+	for i, exp := range expected {
+		if lines[i] != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\n", i+1, exp, lines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1820-1829/1829/verifierF.go
+++ b/1000-1999/1800-1899/1820-1829/1829/verifierF.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveF(n int, edges [][2]int) string {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	deg := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		deg[i] = len(adj[i])
+	}
+	leafNeighbors := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		cnt := 0
+		for _, v := range adj[i] {
+			if deg[v] == 1 {
+				cnt++
+			}
+		}
+		leafNeighbors[i] = cnt
+	}
+	x := 0
+	y := 0
+	for i := 1; i <= n; i++ {
+		if leafNeighbors[i] > 0 {
+			x++
+			y = leafNeighbors[i]
+		}
+	}
+	return fmt.Sprintf("%d %d", x, y)
+}
+
+func genSnowflake() (int, [][2]int, int, int) {
+	x := rand.Intn(5) + 2
+	y := rand.Intn(5) + 2
+	n := 1 + x + x*y
+	edges := make([][2]int, 0, x+x*y)
+	center := 1
+	curr := 2
+	for i := 0; i < x; i++ {
+		v := curr
+		curr++
+		edges = append(edges, [2]int{center, v})
+		for j := 0; j < y; j++ {
+			w := curr
+			curr++
+			edges = append(edges, [2]int{v, w})
+		}
+	}
+	return n, edges, x, y
+}
+
+func genTestsF() ([]string, string) {
+	const t = 100
+	rand.Seed(1)
+	var input strings.Builder
+	fmt.Fprintln(&input, t)
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		n, edges, x, y := genSnowflake()
+		fmt.Fprintf(&input, "%d %d\n", n, len(edges))
+		for _, e := range edges {
+			fmt.Fprintf(&input, "%d %d\n", e[0], e[1])
+		}
+		expected[i] = fmt.Sprintf("%d %d", x, y)
+	}
+	return expected, input.String()
+}
+
+func runBinary(path, in string) ([]string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(&out)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, strings.TrimSpace(scanner.Text()))
+	}
+	return lines, scanner.Err()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	expected, input := genTestsF()
+	lines, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if len(lines) != len(expected) {
+		fmt.Fprintf(os.Stderr, "expected %d lines, got %d\n", len(expected), len(lines))
+		os.Exit(1)
+	}
+	for i, exp := range expected {
+		if lines[i] != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\n", i+1, exp, lines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1820-1829/1829/verifierG.go
+++ b/1000-1999/1800-1899/1820-1829/1829/verifierG.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const maxNG = 1000000
+
+var prefixG [maxNG + 1]int64
+var triG [2024]int
+
+func init() {
+	for i := 1; i <= maxNG; i++ {
+		prefixG[i] = prefixG[i-1] + int64(i*i)
+	}
+	for i := 1; i < len(triG); i++ {
+		triG[i] = triG[i-1] + i
+	}
+}
+
+func solveG(n int) string {
+	r := 1
+	for triG[r] < n {
+		r++
+	}
+	c := n - triG[r-1]
+	var ans int64
+	for i := 1; i <= r; i++ {
+		j1 := c - (r - i)
+		if j1 < 1 {
+			j1 = 1
+		}
+		if j1 > i {
+			continue
+		}
+		j2 := c
+		if j2 > i {
+			j2 = i
+		}
+		start := triG[i-1] + j1
+		end := triG[i-1] + j2
+		ans += prefixG[end] - prefixG[start-1]
+	}
+	return strconv.FormatInt(ans, 10)
+}
+
+func genTestsG() ([]string, string) {
+	const t = 100
+	rand.Seed(1)
+	var input strings.Builder
+	fmt.Fprintln(&input, t)
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(maxNG) + 1
+		fmt.Fprintln(&input, n)
+		expected[i] = solveG(n)
+	}
+	return expected, input.String()
+}
+
+func runBinary(path, in string) ([]string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(&out)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, strings.TrimSpace(scanner.Text()))
+	}
+	return lines, scanner.Err()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	expected, input := genTestsG()
+	lines, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if len(lines) != len(expected) {
+		fmt.Fprintf(os.Stderr, "expected %d lines, got %d\n", len(expected), len(lines))
+		os.Exit(1)
+	}
+	for i, exp := range expected {
+		if lines[i] != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\n", i+1, exp, lines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1820-1829/1829/verifierH.go
+++ b/1000-1999/1800-1899/1820-1829/1829/verifierH.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const MODH int64 = 1000000007
+
+func solveH(n, k int, arr []int) string {
+	freq := make([]int, 64)
+	for _, v := range arr {
+		freq[v]++
+	}
+	pow2 := make([]int64, n+1)
+	pow2[0] = 1
+	for i := 1; i <= n; i++ {
+		pow2[i] = pow2[i-1] * 2 % MODH
+	}
+	cntSuper := make([]int, 64)
+	for mask := 0; mask < 64; mask++ {
+		cnt := 0
+		for val := 0; val < 64; val++ {
+			if val&mask == mask {
+				cnt += freq[val]
+			}
+		}
+		cntSuper[mask] = cnt
+	}
+	dp := make([]int64, 64)
+	for mask := 63; mask >= 0; mask-- {
+		total := (pow2[cntSuper[mask]] - 1 + MODH) % MODH
+		for sup := mask + 1; sup < 64; sup++ {
+			if sup&mask == mask {
+				total -= dp[sup]
+				if total < 0 {
+					total += MODH
+				}
+			}
+		}
+		dp[mask] = total
+	}
+	var result int64
+	for mask := 0; mask < 64; mask++ {
+		if bits.OnesCount(uint(mask)) == k {
+			result += dp[mask]
+			if result >= MODH {
+				result -= MODH
+			}
+		}
+	}
+	return strconv.FormatInt(result, 10)
+}
+
+func genTestsH() ([]string, string) {
+	const t = 100
+	rand.Seed(1)
+	var input strings.Builder
+	fmt.Fprintln(&input, t)
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(7)
+		fmt.Fprintf(&input, "%d %d\n", n, k)
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rand.Intn(64)
+			if j+1 == n {
+				fmt.Fprintln(&input, arr[j])
+			} else {
+				fmt.Fprint(&input, arr[j], " ")
+			}
+		}
+		expected[i] = solveH(n, k, arr)
+	}
+	return expected, input.String()
+}
+
+func runBinary(path, in string) ([]string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(&out)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, strings.TrimSpace(scanner.Text()))
+	}
+	return lines, scanner.Err()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	expected, input := genTestsH()
+	lines, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error running binary:", err)
+		os.Exit(1)
+	}
+	if len(lines) != len(expected) {
+		fmt.Fprintf(os.Stderr, "expected %d lines, got %d\n", len(expected), len(lines))
+		os.Exit(1)
+	}
+	for i, exp := range expected {
+		if lines[i] != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\n", i+1, exp, lines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for each problem in contest 1829
- verifiers generate 100 random tests and check a given binary

## Testing
- `go build verifierA.go` (and other verifiers)
- `go run verifierA.go ./solA` (after building `1829A.go`)

------
https://chatgpt.com/codex/tasks/task_e_68876ec0227c83248a4472d9a1d941a3