### PR TITLE
Add Go verifiers for contest 1834

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1834/verifierA.go
+++ b/1000-1999/1800-1899/1830-1839/1834/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseA struct {
+	arr []int
+}
+
+func expectedA(arr []int) string {
+	n := len(arr)
+	neg := 0
+	for _, x := range arr {
+		if x == -1 {
+			neg++
+		}
+	}
+	sum := n - 2*neg
+	ops := 0
+	if neg%2 == 1 {
+		ops++
+		neg--
+		sum += 2
+	}
+	if sum < 0 {
+		deficit := -sum
+		pairs := (deficit + 3) / 4
+		ops += pairs * 2
+	}
+	return fmt.Sprint(ops)
+}
+
+func genTestsA() []testCaseA {
+	rand.Seed(1)
+	tests := make([]testCaseA, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(10) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				arr[i] = -1
+			} else {
+				arr[i] = 1
+			}
+		}
+		tests = append(tests, testCaseA{arr: arr})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseA) error {
+	var input strings.Builder
+	input.WriteString("1\n")
+	input.WriteString(fmt.Sprintf("%d\n", len(tc.arr)))
+	for i, v := range tc.arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprint(v))
+	}
+	input.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedA(tc.arr)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s for %v", expect, got, tc.arr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1834/verifierB.go
+++ b/1000-1999/1800-1899/1830-1839/1834/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseB struct {
+	L string
+	R string
+}
+
+func expectedB(L, R string) string {
+	// pad with leading zeros
+	if len(L) < len(R) {
+		L = strings.Repeat("0", len(R)-len(L)) + L
+	} else if len(R) < len(L) {
+		R = strings.Repeat("0", len(L)-len(R)) + R
+	}
+	n := len(L)
+	ans := 0
+	for i := 0; i < n; i++ {
+		if L[i] != R[i] {
+			diff := int(L[i]) - int(R[i])
+			if diff < 0 {
+				diff = -diff
+			}
+			ans = diff + 9*(n-i-1)
+			break
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func genRandBig(maxDigits int) *big.Int {
+	digits := rand.Intn(maxDigits) + 1
+	var sb strings.Builder
+	sb.WriteByte(byte('1' + rand.Intn(9)))
+	for i := 1; i < digits; i++ {
+		sb.WriteByte(byte('0' + rand.Intn(10)))
+	}
+	n := new(big.Int)
+	n.SetString(sb.String(), 10)
+	return n
+}
+
+func genTestsB() []testCaseB {
+	rand.Seed(2)
+	tests := make([]testCaseB, 0, 100)
+	for len(tests) < 100 {
+		a := genRandBig(18)
+		b := new(big.Int).Add(a, big.NewInt(rand.Int63n(1000)))
+		if rand.Intn(2) == 0 {
+			a, b = b, a
+		}
+		if a.Cmp(b) > 0 {
+			a, b = b, a
+		}
+		tests = append(tests, testCaseB{L: a.String(), R: b.String()})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseB) error {
+	input := fmt.Sprintf("1\n%s %s\n", tc.L, tc.R)
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedB(tc.L, tc.R)
+	if got != expect {
+		return fmt.Errorf("L=%s R=%s expected %s got %s", tc.L, tc.R, expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1834/verifierC.go
+++ b/1000-1999/1800-1899/1830-1839/1834/verifierC.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseC struct {
+	s string
+	r string
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expectedC(s, r string) string {
+	n := len(s)
+	a := 0
+	b := 0
+	for i := 0; i < n; i++ {
+		if s[i] != r[i] {
+			a++
+		}
+		if s[i] != r[n-1-i] {
+			b++
+		}
+	}
+	ans1 := 2*a - a%2
+	ans2 := 2*b - (1 - b%2)
+	if ans2 < 0 {
+		ans2 = 1
+	}
+	return fmt.Sprint(min(ans1, ans2))
+}
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rand.Intn(3))
+	}
+	return string(b)
+}
+
+func genTestsC() []testCaseC {
+	rand.Seed(3)
+	tests := make([]testCaseC, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(10) + 1
+		s := randString(n)
+		r := randString(n)
+		tests = append(tests, testCaseC{s: s, r: r})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseC) error {
+	input := fmt.Sprintf("1\n%d\n%s\n%s\n", len(tc.s), tc.s, tc.r)
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedC(tc.s, tc.r)
+	if got != expect {
+		return fmt.Errorf("s=%s r=%s expected %s got %s", tc.s, tc.r, expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1834/verifierD.go
+++ b/1000-1999/1800-1899/1830-1839/1834/verifierD.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseD struct {
+	n int
+	m int
+	l []int
+	r []int
+}
+
+func expectedD(tc testCaseD) string {
+	n, m := tc.n, tc.m
+	best := 0
+	subsets := 1 << m
+	for mask := 0; mask < subsets; mask++ {
+		heights := make([]int, n)
+		for topic := 1; topic <= m; topic++ {
+			if mask&(1<<(topic-1)) == 0 {
+				continue
+			}
+			for i := 0; i < n; i++ {
+				if tc.l[i] <= topic && topic <= tc.r[i] {
+					heights[i]++
+				} else {
+					heights[i]--
+				}
+			}
+		}
+		hi := heights[0]
+		lo := heights[0]
+		for _, v := range heights {
+			if v > hi {
+				hi = v
+			}
+			if v < lo {
+				lo = v
+			}
+		}
+		diff := hi - lo
+		if diff > best {
+			best = diff
+		}
+	}
+	return fmt.Sprint(best)
+}
+
+func genTestsD() []testCaseD {
+	rand.Seed(4)
+	tests := make([]testCaseD, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(3) + 2 // 2..4
+		m := rand.Intn(5) + 1 // 1..5
+		l := make([]int, n)
+		r := make([]int, n)
+		for i := 0; i < n; i++ {
+			a := rand.Intn(m) + 1
+			b := rand.Intn(m) + 1
+			if a > b {
+				a, b = b, a
+			}
+			l[i] = a
+			r[i] = b
+		}
+		tests = append(tests, testCaseD{n: n, m: m, l: l, r: r})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseD) error {
+	var input strings.Builder
+	input.WriteString("1\n")
+	input.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for i := 0; i < tc.n; i++ {
+		input.WriteString(fmt.Sprintf("%d %d\n", tc.l[i], tc.r[i]))
+	}
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedD(tc)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1834/verifierE.go
+++ b/1000-1999/1800-1899/1830-1839/1834/verifierE.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const limitE = 300005
+
+type testCaseE struct {
+	arr []int64
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int64) int64 {
+	g := gcd(a, b)
+	res := a / g * b
+	if res > int64(limitE) {
+		return int64(limitE + 1)
+	}
+	return res
+}
+
+func expectedE(tc testCaseE) string {
+	seen := make([]bool, limitE+2)
+	prev := []int64{}
+	for _, val := range tc.arr {
+		curMap := make(map[int64]struct{})
+		if val <= limitE {
+			curMap[val] = struct{}{}
+		}
+		for _, v := range prev {
+			l := lcm(v, val)
+			if l <= limitE {
+				curMap[l] = struct{}{}
+			}
+		}
+		prev = prev[:0]
+		for k := range curMap {
+			prev = append(prev, k)
+			seen[int(k)] = true
+		}
+	}
+	ans := 1
+	for ans <= limitE && seen[ans] {
+		ans++
+	}
+	return fmt.Sprint(ans)
+}
+
+func genTestsE() []testCaseE {
+	rand.Seed(5)
+	tests := make([]testCaseE, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(5) + 1
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			arr[i] = int64(rand.Intn(20) + 1)
+		}
+		tests = append(tests, testCaseE{arr: arr})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseE) error {
+	var input strings.Builder
+	input.WriteString("1\n")
+	input.WriteString(fmt.Sprintf("%d\n", len(tc.arr)))
+	for i, v := range tc.arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprint(v))
+	}
+	input.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedE(tc)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1834/verifierF.go
+++ b/1000-1999/1800-1899/1830-1839/1834/verifierF.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func precomputeF(p []int) []int {
+	n := len(p)
+	diff := make([]int, n+1)
+	for j, v := range p {
+		if v == n {
+			continue
+		}
+		start := (j + 1) % n
+		end := (j - v + n) % n
+		if start <= end {
+			diff[start]++
+			diff[end+1]--
+		} else {
+			diff[start]++
+			diff[n]--
+			diff[0]++
+			diff[end+1]--
+		}
+	}
+	res := make([]int, n)
+	cur := 0
+	for i := 0; i < n; i++ {
+		cur += diff[i]
+		res[i] = cur
+	}
+	return res
+}
+
+type queryF struct {
+	t int
+	k int
+}
+
+type testCaseF struct {
+	p       []int
+	queries []queryF
+}
+
+func expectedF(tc testCaseF) []string {
+	n := len(tc.p)
+	counts := precomputeF(tc.p)
+	rev := make([]int, n)
+	for i, v := range tc.p {
+		rev[n-1-i] = v
+	}
+	countsRev := precomputeF(rev)
+
+	offset := 0
+	reversed := false
+	res := []string{}
+	if reversed {
+		res = append(res, fmt.Sprint(countsRev[offset]))
+	} else {
+		res = append(res, fmt.Sprint(counts[offset]))
+	}
+	for _, q := range tc.queries {
+		if q.t == 1 {
+			offset = (offset + q.k) % n
+		} else if q.t == 2 {
+			offset = (offset - q.k) % n
+			if offset < 0 {
+				offset += n
+			}
+		} else {
+			reversed = !reversed
+			offset = (n - offset) % n
+		}
+		if reversed {
+			res = append(res, fmt.Sprint(countsRev[offset]))
+		} else {
+			res = append(res, fmt.Sprint(counts[offset]))
+		}
+	}
+	return res
+}
+
+func genTestsF() []testCaseF {
+	rand.Seed(6)
+	tests := make([]testCaseF, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(6) + 1
+		p := rand.Perm(n)
+		for i := range p {
+			p[i]++
+		}
+		qnum := rand.Intn(5) + 1
+		queries := make([]queryF, qnum)
+		for j := 0; j < qnum; j++ {
+			t := rand.Intn(3) + 1
+			k := 0
+			if t == 1 || t == 2 {
+				k = rand.Intn(n) + 1
+			}
+			queries[j] = queryF{t: t, k: k}
+		}
+		tests = append(tests, testCaseF{p: p, queries: queries})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseF) error {
+	var input strings.Builder
+	n := len(tc.p)
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range tc.p {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprint(v))
+	}
+	input.WriteByte('\n')
+	input.WriteString(fmt.Sprintf("%d\n", len(tc.queries)))
+	for _, q := range tc.queries {
+		if q.t == 1 || q.t == 2 {
+			input.WriteString(fmt.Sprintf("%d %d\n", q.t, q.k))
+		} else {
+			input.WriteString(fmt.Sprintf("%d\n", q.t))
+		}
+	}
+
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	expect := expectedF(tc)
+	if len(gotLines) != len(expect) {
+		return fmt.Errorf("expected %d lines got %d", len(expect), len(gotLines))
+	}
+	for i := range expect {
+		if strings.TrimSpace(gotLines[i]) != expect[i] {
+			return fmt.Errorf("mismatch on line %d: expected %s got %s", i+1, expect[i], gotLines[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsF()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces Round 1834 problems A–F
- each verifier uses random deterministic test generation with at least 100 cases
- verifiers compute expected answers and run a provided binary or Go program

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6887701e5598832484498c6c5d061c5f