### PR TITLE
Add Go verifiers for contest 1837

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1837/verifierA.go
+++ b/1000-1999/1800-1899/1830-1839/1837/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1837A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		x := rng.Intn(100) + 1
+		k := rng.Intn(99) + 2
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, k))
+	}
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1837/verifierB.go
+++ b/1000-1999/1800-1899/1830-1839/1837/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1837B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d ", n))
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('<')
+			} else {
+				sb.WriteByte('>')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1837/verifierC.go
+++ b/1000-1999/1800-1899/1830-1839/1837/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1837C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(20) + 1
+		for j := 0; j < n; j++ {
+			v := rng.Intn(3)
+			if v == 0 {
+				sb.WriteByte('0')
+			} else if v == 1 {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('?')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1837/verifierD.go
+++ b/1000-1999/1800-1899/1830-1839/1837/verifierD.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1837D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d ", n))
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('(')
+			} else {
+				sb.WriteByte(')')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1837/verifierE.go
+++ b/1000-1999/1800-1899/1830-1839/1837/verifierE.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1837E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	k := rng.Intn(9) // 0..8
+	n := 1 << k
+	usedTeams := make([]bool, n)
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = -1
+	}
+	fixed := rng.Intn(n + 1)
+	for i := 0; i < fixed; i++ {
+		pos := rng.Intn(n)
+		for arr[pos] != -1 {
+			pos = rng.Intn(n)
+		}
+		team := rng.Intn(n) + 1
+		for usedTeams[team-1] {
+			team = rng.Intn(n) + 1
+		}
+		arr[pos] = team
+		usedTeams[team-1] = true
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1837/verifierF.go
+++ b/1000-1999/1800-1899/1830-1839/1837/verifierF.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1837F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(100)+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–F of contest 1837
- each verifier builds the reference solution and runs 100 random tests against a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go run verifierA.go ./solA`

------
https://chatgpt.com/codex/tasks/task_e_688770f077d483249f73d5ad5f259cf4