### PR TITLE
Add basic verifiers for contest 1835 problems A–D

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1835/verifierA.go
+++ b/1000-1999/1800-1899/1830-1839/1835/verifierA.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func pow10(n int) int {
+	res := 1
+	for i := 0; i < n; i++ {
+		res *= 10
+	}
+	return res
+}
+
+func numDigits(x int) int {
+	if x == 0 {
+		return 1
+	}
+	d := 0
+	for x > 0 {
+		d++
+		x /= 10
+	}
+	return d
+}
+
+func kthEquality(A, B, C int, k int64) string {
+	aStart := pow10(A - 1)
+	aEnd := pow10(A) - 1
+	bStart := pow10(B - 1)
+	bEnd := pow10(B) - 1
+	cStart := pow10(C - 1)
+	cEnd := pow10(C) - 1
+	var list []string
+	for a := aStart; a <= aEnd; a++ {
+		for b := bStart; b <= bEnd; b++ {
+			c := a + b
+			if c >= cStart && c <= cEnd && numDigits(c) == C {
+				list = append(list, fmt.Sprintf("%d + %d = %d", a, b, c))
+			}
+		}
+	}
+	sort.Strings(list)
+	if int64(len(list)) < k {
+		return "-1"
+	}
+	return list[k-1]
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	A := rng.Intn(3) + 1
+	B := rng.Intn(3) + 1
+	C := rng.Intn(3) + 1
+	var eqs []string
+	aStart := pow10(A - 1)
+	aEnd := pow10(A) - 1
+	bStart := pow10(B - 1)
+	bEnd := pow10(B) - 1
+	cStart := pow10(C - 1)
+	cEnd := pow10(C) - 1
+	for a := aStart; a <= aEnd; a++ {
+		for b := bStart; b <= bEnd; b++ {
+			c := a + b
+			if c >= cStart && c <= cEnd && numDigits(c) == C {
+				eqs = append(eqs, fmt.Sprintf("%d + %d = %d", a, b, c))
+			}
+		}
+	}
+	var k int64
+	if len(eqs) == 0 {
+		k = rng.Int63n(3) + 1
+	} else {
+		k = rng.Int63n(int64(len(eqs))+3) + 1
+	}
+	input := fmt.Sprintf("1\n%d %d %d %d\n", A, B, C, k)
+	expected := kthEquality(A, B, C, k)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1835/verifierB.go
+++ b/1000-1999/1800-1899/1830-1839/1835/verifierB.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pair struct {
+	diff int64
+	idx  int
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func winCount(x int64, arr []int64, m int64, k int) int64 {
+	n := len(arr)
+	arr2 := append([]int64(nil), arr...)
+	arr2 = append(arr2, x)
+	count := int64(0)
+	for t := int64(0); t <= m; t++ {
+		diffs := make([]pair, n+1)
+		for i := 0; i < n+1; i++ {
+			diffs[i] = pair{diff: abs64(arr2[i] - t), idx: i}
+		}
+		sort.Slice(diffs, func(i, j int) bool {
+			if diffs[i].diff == diffs[j].diff {
+				return diffs[i].idx < diffs[j].idx
+			}
+			return diffs[i].diff < diffs[j].diff
+		})
+		winners := diffs
+		if len(winners) > k {
+			winners = winners[:k]
+		}
+		for _, p := range winners {
+			if p.idx == n { // Bytek index
+				count++
+				break
+			}
+		}
+	}
+	return count
+}
+
+func bruteB(n int, m int64, k int, arr []int64) (int64, int64) {
+	var bestX int64
+	bestVal := int64(-1)
+	for x := int64(0); x <= m; x++ {
+		val := winCount(x, arr, m, k)
+		if val > bestVal || (val == bestVal && x < bestX) {
+			bestVal = val
+			bestX = x
+		}
+	}
+	return bestVal, bestX
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	m := int64(rng.Intn(10) + 5)
+	k := rng.Intn(n) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(int(m + 1)))
+	}
+	val, x := bruteB(n, m, k, arr)
+	// build input
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected := fmt.Sprintf("%d %d", val, x)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1835/verifierC.go
+++ b/1000-1999/1800-1899/1830-1839/1835/verifierC.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func bruteC(k int, g []int) string {
+	n := 1 << (k + 1)
+	pref := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		pref[i] = pref[i-1] ^ g[i-1]
+	}
+	for l1 := 1; l1 <= n; l1++ {
+		for r1 := l1; r1 <= n; r1++ {
+			x1 := pref[r1] ^ pref[l1-1]
+			for l2 := 1; l2 <= n; l2++ {
+				for r2 := l2; r2 <= n; r2++ {
+					if r1 < l2 || r2 < l1 {
+						x2 := pref[r2] ^ pref[l2-1]
+						if x1 == x2 {
+							return fmt.Sprintf("%d %d %d %d", l1, r1, l2, r2)
+						}
+					}
+				}
+			}
+		}
+	}
+	return "-1"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	k := rng.Intn(3) // 0..2
+	n := 1 << (k + 1)
+	g := make([]int, n)
+	maxVal := 1 << (2 * k)
+	if maxVal == 0 {
+		maxVal = 1
+	}
+	for i := 0; i < n; i++ {
+		g[i] = rng.Intn(maxVal)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", g[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected := bruteC(k, g)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1830-1839/1835/verifierD.go
+++ b/1000-1999/1800-1899/1830-1839/1835/verifierD.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ from, to int }
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func bruteD(n int, edges []edge, k int) int64 {
+	adj := make([][]bool, n)
+	for i := range adj {
+		adj[i] = make([]bool, n)
+	}
+	for _, e := range edges {
+		adj[e.from][e.to] = true
+	}
+	dp := make([][][]bool, k+1)
+	for i := 0; i <= k; i++ {
+		dp[i] = make([][]bool, n)
+		for j := 0; j < n; j++ {
+			dp[i][j] = make([]bool, n)
+		}
+	}
+	for i := 0; i < n; i++ {
+		dp[0][i][i] = true
+	}
+	for step := 1; step <= k; step++ {
+		for i := 0; i < n; i++ {
+			for mid := 0; mid < n; mid++ {
+				if dp[step-1][i][mid] {
+					for j := 0; j < n; j++ {
+						if adj[mid][j] {
+							dp[step][i][j] = true
+						}
+					}
+				}
+			}
+		}
+	}
+	var ans int64
+	for i := 0; i < n; i++ {
+		if dp[k][i][i] {
+			ans++
+		}
+		for j := i + 1; j < n; j++ {
+			if dp[k][i][j] && dp[k][j][i] {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	maxEdges := n * (n - 1)
+	m := rng.Intn(maxEdges + 1)
+	k := rng.Intn(4) + 1
+	seen := make(map[[2]int]struct{})
+	var es []edge
+	for len(es) < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u == v {
+			continue
+		}
+		key := [2]int{u, v}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		es = append(es, edge{u, v})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for _, e := range es {
+		fmt.Fprintf(&sb, "%d %d\n", e.from+1, e.to+1)
+	}
+	input := sb.String()
+	val := bruteD(n, es, k)
+	expected := fmt.Sprintf("%d", val)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers `verifierA.go`–`verifierD.go` under contest 1835
- each verifier runs 100 randomly generated tests and checks a candidate binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`


------
https://chatgpt.com/codex/tasks/task_e_688770646a3883249362b7f4d1a192e8