### PR TITLE
Add verifiers for Codeforces Round 1841

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1841/verifierA.go
+++ b/1000-1999/1800-1899/1840-1849/1841/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(nums []int) string {
+	var sb strings.Builder
+	for _, n := range nums {
+		if n <= 4 {
+			sb.WriteString("Bob\n")
+		} else {
+			sb.WriteString("Alice\n")
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(5) + 1
+	var input strings.Builder
+	var expected strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", t))
+	nums := make([]int, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(99) + 2
+		nums[i] = n
+		input.WriteString(fmt.Sprintf("%d\n", n))
+	}
+	expected.WriteString(solveA(nums))
+	return testCase{input: input.String(), expected: expected.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	got, err := runCandidate(bin, tc.input)
+	if err != nil {
+		return err
+	}
+	got = strings.TrimSpace(got)
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{input: "1\n5\n", expected: "Alice\n"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1840-1849/1841/verifierB.go
+++ b/1000-1999/1800-1899/1840-1849/1841/verifierB.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	input    string
+	expected string
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(arr []int) string {
+	res := make([]byte, len(arr))
+	var first, last int
+	have := false
+	flag := false
+	for i, x := range arr {
+		if !have {
+			first, last = x, x
+			have = true
+			res[i] = '1'
+			continue
+		}
+		if !flag {
+			if x >= last {
+				last = x
+				res[i] = '1'
+			} else if x <= first {
+				last = x
+				flag = true
+				res[i] = '1'
+			} else {
+				res[i] = '0'
+			}
+		} else {
+			if x >= last && x <= first {
+				last = x
+				res[i] = '1'
+			} else {
+				res[i] = '0'
+			}
+		}
+	}
+	return string(res)
+}
+
+func generateCaseB(rng *rand.Rand) testCaseB {
+	t := rng.Intn(3) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for j := 0; j < t; j++ {
+		q := rng.Intn(20) + 1
+		arr := make([]int, q)
+		in.WriteString(fmt.Sprintf("%d\n", q))
+		for i := 0; i < q; i++ {
+			if i > 0 {
+				in.WriteByte(' ')
+			}
+			arr[i] = rng.Intn(50)
+			in.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		in.WriteByte('\n')
+		out.WriteString(solveB(arr))
+		out.WriteByte('\n')
+	}
+	return testCaseB{input: in.String(), expected: out.String()}
+}
+
+func runCaseB(bin string, tc testCaseB) error {
+	got, err := runCandidate(bin, tc.input)
+	if err != nil {
+		return err
+	}
+	got = strings.TrimSpace(got)
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseB{generateCaseB(rng)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseB(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1840-1849/1841/verifierC.go
+++ b/1000-1999/1800-1899/1840-1849/1841/verifierC.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var val = []int64{1, 10, 100, 1000, 10000}
+
+const negInf int64 = -1 << 60
+
+type testCaseC struct {
+	input    string
+	expected string
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveC(s string) int64 {
+	n := len(s)
+	dp0 := make([]int64, 5)
+	dp1 := make([]int64, 5)
+	for i := 0; i < 5; i++ {
+		dp0[i] = 0
+		dp1[i] = negInf
+	}
+	for idx := n - 1; idx >= 0; idx-- {
+		orig := int(s[idx] - 'A')
+		newdp0 := [5]int64{negInf, negInf, negInf, negInf, negInf}
+		newdp1 := [5]int64{negInf, negInf, negInf, negInf, negInf}
+		for pm := 0; pm < 5; pm++ {
+			if dp0[pm] != negInf {
+				sign := val[orig]
+				if orig < pm {
+					sign = -sign
+				}
+				nm := pm
+				if orig > nm {
+					nm = orig
+				}
+				newdp0[nm] = max64(newdp0[nm], sign+dp0[pm])
+				for ni := 0; ni < 5; ni++ {
+					sign2 := val[ni]
+					if ni < pm {
+						sign2 = -sign2
+					}
+					nm2 := pm
+					if ni > nm2 {
+						nm2 = ni
+					}
+					newdp1[nm2] = max64(newdp1[nm2], sign2+dp0[pm])
+				}
+			}
+			if dp1[pm] != negInf {
+				sign := val[orig]
+				if orig < pm {
+					sign = -sign
+				}
+				nm := pm
+				if orig > nm {
+					nm = orig
+				}
+				newdp1[nm] = max64(newdp1[nm], sign+dp1[pm])
+			}
+		}
+		for j := 0; j < 5; j++ {
+			dp0[j] = newdp0[j]
+			dp1[j] = newdp1[j]
+		}
+	}
+	ans := negInf
+	for i := 0; i < 5; i++ {
+		ans = max64(ans, dp0[i])
+		ans = max64(ans, dp1[i])
+	}
+	return ans
+}
+
+func generateCaseC(rng *rand.Rand) testCaseC {
+	t := rng.Intn(3) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for j := 0; j < t; j++ {
+		n := rng.Intn(15) + 1
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b[i] = byte('A' + rng.Intn(5))
+		}
+		s := string(b)
+		in.WriteString(fmt.Sprintf("%s\n", s))
+		out.WriteString(fmt.Sprintf("%d\n", solveC(s)))
+	}
+	return testCaseC{input: in.String(), expected: out.String()}
+}
+
+func runCaseC(bin string, tc testCaseC) error {
+	got, err := runCandidate(bin, tc.input)
+	if err != nil {
+		return err
+	}
+	got = strings.TrimSpace(got)
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseC{generateCaseC(rng)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseC(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1840-1849/1841/verifierD.go
+++ b/1000-1999/1800-1899/1840-1849/1841/verifierD.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Segment struct {
+	l int
+	r int
+}
+
+type testCaseD struct {
+	input    string
+	expected string
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func minRemovals(segs []Segment) int {
+	sort.Slice(segs, func(i, j int) bool {
+		if segs[i].r == segs[j].r {
+			return segs[i].l < segs[j].l
+		}
+		return segs[i].r < segs[j].r
+	})
+	n := len(segs)
+	rvals := make([]int, n)
+	for i := 0; i < n; i++ {
+		rvals[i] = segs[i].r
+	}
+	dp := make([]int, n+1)
+	prefix := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		dp[i] = prefix[i-1]
+		li, ri := segs[i-1].l, segs[i-1].r
+		for j := i - 1; j > 0; j-- {
+			lj, rj := segs[j-1].l, segs[j-1].r
+			if rj < li {
+				break
+			}
+			if ri < lj {
+				continue
+			}
+			start := li
+			if lj < start {
+				start = lj
+			}
+			p := sort.SearchInts(rvals, start) - 1
+			cand := 2
+			if p >= 0 {
+				cand = prefix[p+1] + 2
+			}
+			if cand > dp[i] {
+				dp[i] = cand
+			}
+		}
+		if dp[i] > prefix[i-1] {
+			prefix[i] = dp[i]
+		} else {
+			prefix[i] = prefix[i-1]
+		}
+	}
+	return n - prefix[n]
+}
+
+func generateCaseD(rng *rand.Rand) testCaseD {
+	t := rng.Intn(3) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for j := 0; j < t; j++ {
+		n := rng.Intn(6) + 2
+		segs := make([]Segment, n)
+		in.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			l := rng.Intn(20)
+			r := l + rng.Intn(20)
+			segs[i] = Segment{l, r}
+			in.WriteString(fmt.Sprintf("%d %d\n", l, r))
+		}
+		out.WriteString(fmt.Sprintf("%d\n", minRemovals(segs)))
+	}
+	return testCaseD{input: in.String(), expected: out.String()}
+}
+
+func runCaseD(bin string, tc testCaseD) error {
+	got, err := runCandidate(bin, tc.input)
+	if err != nil {
+		return err
+	}
+	got = strings.TrimSpace(got)
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseD{generateCaseD(rng)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseD(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseD(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1840-1849/1841/verifierE.go
+++ b/1000-1999/1800-1899/1840-1849/1841/verifierE.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent []int
+	size   []int
+}
+
+func NewDSU(n int) *DSU {
+	d := &DSU{make([]int, n), make([]int, n)}
+	for i := range d.parent {
+		d.parent[i] = i
+	}
+	return d
+}
+
+func (d *DSU) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) union(x, y int, cur *int64) {
+	rx := d.find(x)
+	ry := d.find(y)
+	if rx == ry {
+		return
+	}
+	if d.size[rx] < d.size[ry] {
+		rx, ry = ry, rx
+	}
+	*cur -= int64(d.size[rx]/2 + d.size[ry]/2)
+	d.size[rx] += d.size[ry]
+	d.parent[ry] = rx
+	*cur += int64(d.size[rx] / 2)
+}
+
+type testCaseE struct {
+	input    string
+	expected string
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(n int, a []int, m int64) int64 {
+	events := make([][]int, n+2)
+	for i, v := range a {
+		if v < n {
+			events[v+1] = append(events[v+1], i)
+		}
+	}
+
+	d := NewDSU(n)
+	active := make([]bool, n)
+	var curPairs int64
+	var totalPairs int64
+
+	for r := 1; r <= n; r++ {
+		for _, c := range events[r] {
+			active[c] = true
+			d.parent[c] = c
+			d.size[c] = 1
+			if c > 0 && active[c-1] {
+				d.union(c, c-1, &curPairs)
+			}
+			if c+1 < n && active[c+1] {
+				d.union(c, c+1, &curPairs)
+			}
+		}
+		totalPairs += curPairs
+	}
+
+	if totalPairs > m/2 {
+		totalPairs = m / 2
+	}
+	return totalPairs
+}
+
+func generateCaseE(rng *rand.Rand) testCaseE {
+	t := rng.Intn(3) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for j := 0; j < t; j++ {
+		n := rng.Intn(5) + 1
+		a := make([]int, n)
+		in.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				in.WriteByte(' ')
+			}
+			a[i] = rng.Intn(n + 1)
+			in.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		in.WriteByte('\n')
+		white := 0
+		for _, v := range a {
+			white += n - v
+		}
+		var mVal int64
+		if white == 0 {
+			mVal = 0
+		} else {
+			mVal = int64(rng.Intn(white + 1))
+		}
+		in.WriteString(fmt.Sprintf("%d\n", mVal))
+		out.WriteString(fmt.Sprintf("%d\n", solveE(n, a, mVal)))
+	}
+	return testCaseE{input: in.String(), expected: out.String()}
+}
+
+func runCaseE(bin string, tc testCaseE) error {
+	got, err := runCandidate(bin, tc.input)
+	if err != nil {
+		return err
+	}
+	got = strings.TrimSpace(got)
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseE{generateCaseE(rng)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseE(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1840-1849/1841/verifierF.go
+++ b/1000-1999/1800-1899/1840-1849/1841/verifierF.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type point struct {
+	x, y int64
+}
+
+func quadrant(p point) int {
+	if p.x > 0 && p.y >= 0 {
+		return 1
+	} else if p.x <= 0 && p.y > 0 {
+		return 2
+	} else if p.x < 0 && p.y <= 0 {
+		return 3
+	}
+	return 4
+}
+
+type testCaseF struct {
+	input    string
+	expected string
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveF(groups [][4]int64) float64 {
+	var v []point
+	var sx, sy int64
+	for _, g := range groups {
+		a, b, c, d := g[0], g[1], g[2], g[3]
+		dx := a - b
+		dy := c - d
+		if dx == 0 && dy == 0 {
+			continue
+		}
+		v = append(v, point{dx, dy})
+		v = append(v, point{-dx, -dy})
+		if c < d || (c == d && a < b) {
+			sx += dx
+			sy += dy
+		}
+	}
+	sort.Slice(v, func(i, j int) bool {
+		pi, pj := v[i], v[j]
+		qi, qj := quadrant(pi), quadrant(pj)
+		if qi != qj {
+			return qi < qj
+		}
+		return pi.x*pj.y > pi.y*pj.x
+	})
+	ans := float64(sx*sx + sy*sy)
+	for _, p := range v {
+		sx += p.x
+		sy += p.y
+		val := float64(sx*sx + sy*sy)
+		if val > ans {
+			ans = val
+		}
+	}
+	return ans
+}
+
+func generateCaseF(rng *rand.Rand) testCaseF {
+	n := rng.Intn(6) + 1
+	var in strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", n))
+	groups := make([][4]int64, n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < 4; j++ {
+			groups[i][j] = int64(rng.Intn(5))
+		}
+		in.WriteString(fmt.Sprintf("%d %d %d %d\n", groups[i][0], groups[i][1], groups[i][2], groups[i][3]))
+	}
+	exp := fmt.Sprintf("%.10f\n", solveF(groups))
+	return testCaseF{input: in.String(), expected: exp}
+}
+
+func runCaseF(bin string, tc testCaseF) error {
+	got, err := runCandidate(bin, tc.input)
+	if err != nil {
+		return err
+	}
+	got = strings.TrimSpace(got)
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseF{generateCaseF(rng)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseF(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseF(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for contest 1841 problems A–F
- each verifier generates 100+ random tests and checks output of any binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68877208963c832494fe7e36cfd6e304