### PR TITLE
Add verification scripts for contest 1844

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1844/verifierA.go
+++ b/1000-1999/1800-1899/1840-1849/1844/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1844A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := range tests {
+		a := rand.Intn(99) + 1
+		b := rand.Intn(100-a) + a + 1
+		tests[i] = fmt.Sprintf("1\n%d %d\n", a, b)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1840-1849/1844/verifierB.go
+++ b/1000-1999/1800-1899/1840-1849/1844/verifierB.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1844B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(2)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(200) + 1
+		tests[i] = fmt.Sprintf("1\n%d\n", n)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1840-1849/1844/verifierC.go
+++ b/1000-1999/1800-1899/1840-1849/1844/verifierC.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1844C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(3)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(201)-100))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1840-1849/1844/verifierD.go
+++ b/1000-1999/1800-1899/1840-1849/1844/verifierD.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1844D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(4)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(100) + 1
+		tests[i] = fmt.Sprintf("1\n%d\n", n)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1840-1849/1844/verifierE.go
+++ b/1000-1999/1800-1899/1840-1849/1844/verifierE.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1844E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(5)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(4) + 2
+		k := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for j := 0; j < k; j++ {
+			x1 := rand.Intn(n-1) + 1
+			y1 := rand.Intn(m) + 1
+			if rand.Intn(2) == 0 {
+				if y1 == m {
+					y1--
+				}
+				fmt.Fprintf(&sb, "%d %d %d %d\n", x1, y1, x1+1, y1+1)
+			} else {
+				if y1 == 1 {
+					y1++
+				}
+				fmt.Fprintf(&sb, "%d %d %d %d\n", x1, y1, x1+1, y1-1)
+			}
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1840-1849/1844/verifierF1.go
+++ b/1000-1999/1800-1899/1840-1849/1844/verifierF1.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF1.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1844F1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(6)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 1
+		c := rand.Intn(201) - 100
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, c))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(200)+1))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF1.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1840-1849/1844/verifierF2.go
+++ b/1000-1999/1800-1899/1840-1849/1844/verifierF2.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF2.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1844F2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(7)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		c := rand.Intn(201) - 100
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, c))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(200)+1))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF2.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1840-1849/1844/verifierG.go
+++ b/1000-1999/1800-1899/1840-1849/1844/verifierG.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1844G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(8)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(9) + 2
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 2; j <= n; j++ {
+			p := rand.Intn(j-1) + 1
+			fmt.Fprintf(&sb, "%d %d\n", p, j)
+		}
+		for j := 0; j < n-1; j++ {
+			d := rand.Intn(100) + 1
+			fmt.Fprintf(&sb, "%d", d)
+			if j+1 < n-1 {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1800-1899/1840-1849/1844/verifierH.go
+++ b/1000-1999/1800-1899/1840-1849/1844/verifierH.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refH.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1844H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(9)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := (rand.Intn(5) + 1) * 3
+		xs := rand.Perm(n)
+		ys := rand.Perm(n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d %d\n", xs[j]+1, ys[j]+1)
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–H of contest 1844
- each verifier builds the reference solution, generates 100 tests and checks a candidate binary

## Testing
- `go build 1000-1999/1800-1899/1840-1849/1844/verifierA.go`
- `go build 1000-1999/1800-1899/1840-1849/1844/verifierB.go`
- `go build 1000-1999/1800-1899/1840-1849/1844/verifierC.go`
- `go build 1000-1999/1800-1899/1840-1849/1844/verifierD.go`
- `go build 1000-1999/1800-1899/1840-1849/1844/verifierE.go`
- `go build 1000-1999/1800-1899/1840-1849/1844/verifierF1.go`
- `go build 1000-1999/1800-1899/1840-1849/1844/verifierF2.go`
- `go build 1000-1999/1800-1899/1840-1849/1844/verifierG.go`
- `go build 1000-1999/1800-1899/1840-1849/1844/verifierH.go`

------
https://chatgpt.com/codex/tasks/task_e_688772dab1dc8324ba507901040d27e4