### PR TITLE
Add Go verifiers for Codeforces round 1849

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1849/verifierA.go
+++ b/1000-1999/1800-1899/1840-1849/1849/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1849A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return out.String(), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		b := rng.Intn(99) + 2
+		c := rng.Intn(100) + 1
+		h := rng.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", b, c, h))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "test %d failed:\nexpected: %s\ngot: %s\ninput:\n%s", i+1, strings.TrimSpace(expect), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1840-1849/1849/verifierB.go
+++ b/1000-1999/1800-1899/1840-1849/1849/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1849B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return out.String(), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(6) + 1
+		k := rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(20)+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "test %d failed:\nexpected: %s\ngot: %s\ninput:\n%s", i+1, strings.TrimSpace(expect), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1840-1849/1849/verifierC.go
+++ b/1000-1999/1800-1899/1840-1849/1849/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1849C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return out.String(), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 1 {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('0')
+			}
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < m; j++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "test %d failed:\nexpected: %s\ngot: %s\ninput:\n%s", i+1, strings.TrimSpace(expect), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1840-1849/1849/verifierD.go
+++ b/1000-1999/1800-1899/1840-1849/1849/verifierD.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1849D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return out.String(), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(3)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "test %d failed:\nexpected: %s\ngot: %s\ninput:\n%s", i+1, strings.TrimSpace(expect), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1840-1849/1849/verifierE.go
+++ b/1000-1999/1800-1899/1840-1849/1849/verifierE.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1849E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return out.String(), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	perm := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", perm[i]+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "test %d failed:\nexpected: %s\ngot: %s\ninput:\n%s", i+1, strings.TrimSpace(expect), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1840-1849/1849/verifierF.go
+++ b/1000-1999/1800-1899/1840-1849/1849/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1849F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return out.String(), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	vals := make([]int, n)
+	used := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		v := rng.Intn(1024)
+		for used[v] {
+			v = rng.Intn(1024)
+		}
+		used[v] = true
+		vals[i] = v
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", vals[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expect, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "test %d failed:\nexpected: %s\ngot: %s\ninput:\n%s", i+1, strings.TrimSpace(expect), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–F of contest 1849
- each verifier builds the reference solution and runs 100 random test cases

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68877438ef948324ae2c69070e90e2ef