### PR TITLE
Add verifiers for Codeforces 1851

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1851/verifierA.go
+++ b/1000-1999/1800-1899/1850-1859/1851/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleA1851.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1851A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(1))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(50) + 1
+		m := rng.Intn(50) + 1
+		k := rng.Intn(50) + 1
+		H := rng.Intn(1000) + 1
+		fmt.Fprintf(&sb, "%d %d %d %d\n", n, m, k, H)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(1000)+1)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1851/verifierB.go
+++ b/1000-1999/1800-1899/1850-1859/1851/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleB1851.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1851B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(2))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(50) + 1
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(1000)+1)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1851/verifierC.go
+++ b/1000-1999/1800-1899/1850-1859/1851/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleC1851.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1851C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(3))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(50) + 1
+		k := rng.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(n)+1)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1851/verifierD.go
+++ b/1000-1999/1800-1899/1850-1859/1851/verifierD.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleD1851.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1851D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(4))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(10) + 2
+		fmt.Fprintf(&sb, "%d\n", n)
+		cur := 0
+		for j := 0; j < n-1; j++ {
+			cur += rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "%d ", cur)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1851/verifierE.go
+++ b/1000-1999/1800-1899/1850-1859/1851/verifierE.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleE1851.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1851E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(5))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(5) + 1
+		k := rng.Intn(n-1) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(100)+1)
+		}
+		sb.WriteByte('\n')
+		perm := rng.Perm(n)
+		for j := 0; j < k; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", perm[j]+1)
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			m := rng.Intn(n)
+			fmt.Fprintf(&sb, "%d", m)
+			for x := 0; x < m; x++ {
+				fmt.Fprintf(&sb, " %d", rng.Intn(n)+1)
+			}
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1851/verifierF.go
+++ b/1000-1999/1800-1899/1850-1859/1851/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleF1851.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1851F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(6))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(5) + 2
+		k := rng.Intn(4) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(1<<k))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1851/verifierG.go
+++ b/1000-1999/1800-1899/1850-1859/1851/verifierG.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	oracle := filepath.Join(os.TempDir(), "oracleG1851.bin")
+	cmd := exec.Command("go", "build", "-o", oracle, "1851G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("oracle build failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() string {
+	const T = 100
+	rng := rand.New(rand.NewSource(7))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(n*(n-1)/2) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(20)+1)
+		}
+		sb.WriteByte('\n')
+		edges := make([][2]int, 0, m)
+		used := make(map[[2]int]bool)
+		for len(edges) < m {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			a, b := u, v
+			if a > b {
+				a, b = b, a
+			}
+			key := [2]int{a, b}
+			if used[key] {
+				continue
+			}
+			used[key] = true
+			edges = append(edges, key)
+		}
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+		}
+		q := rng.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d\n", q)
+		for j := 0; j < q; j++ {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			e := rng.Intn(20)
+			fmt.Fprintf(&sb, "%d %d %d\n", a, b, e)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	input := generate()
+	exp, err := run(oracle, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+		os.Exit(1)
+	}
+	got, err := run(cand, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		fmt.Println("wrong answer")
+		fmt.Println("input:\n" + input)
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems in contest 1851
- each verifier builds the official solution, generates 100 random test cases and checks an arbitrary binary

## Testing
- `go build 1000-1999/1800-1899/1850-1859/1851/verifierA.go`

------
https://chatgpt.com/codex/tasks/task_e_688774c5062483249cecd463aa92d459