### PR TITLE
Add verifiers for Codeforces contest 1858

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1858/verifierA.go
+++ b/1000-1999/1800-1899/1850-1859/1858/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1858A.go")
+	bin := filepath.Join(os.TempDir(), "oracle1858A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1 2 3\n",
+		"1\n2 1 4\n",
+		"1\n3 3 1\n",
+		"1\n3 3 2\n",
+		"2\n1 1 1\n2 2 2\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		a := rng.Intn(1000) + 1
+		b := rng.Intn(1000) + 1
+		c := rng.Intn(1000) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", a, b, c)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1850-1859/1858/verifierB.go
+++ b/1000-1999/1800-1899/1850-1859/1858/verifierB.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1858B.go")
+	bin := filepath.Join(os.TempDir(), "oracle1858B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n5 2 2\n2 4\n",
+		"1\n10 3 3\n1 5 10\n",
+		"1\n6 2 2\n3 6\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(50) + 2
+	m := rng.Intn(5) + 2
+	if m > n {
+		m = n
+	}
+	d := rng.Intn(n-1) + 2
+	pos := make([]int, m)
+	used := make(map[int]bool)
+	for i := 0; i < m; i++ {
+		for {
+			v := rng.Intn(n) + 1
+			if !used[v] {
+				used[v] = true
+				pos[i] = v
+				break
+			}
+		}
+	}
+	sort.Ints(pos)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d\n", n, m, d)
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", pos[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1850-1859/1858/verifierC.go
+++ b/1000-1999/1800-1899/1850-1859/1858/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1858C.go")
+	bin := filepath.Join(os.TempDir(), "oracle1858C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n2\n",
+		"1\n3\n",
+		"1\n5\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 2
+	return fmt.Sprintf("1\n%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1850-1859/1858/verifierD.go
+++ b/1000-1999/1800-1899/1850-1859/1858/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1858D.go")
+	bin := filepath.Join(os.TempDir(), "oracle1858D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n5 1\n01010\n",
+		"1\n4 2\n1111\n",
+		"1\n3 0\n001\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n + 1)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1850-1859/1858/verifierE1.go
+++ b/1000-1999/1800-1899/1850-1859/1858/verifierE1.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle(srcFile string, binName string) (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, srcFile)
+	bin := filepath.Join(os.TempDir(), binName)
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"5\n+ 1\n+ 2\n?\n- 1\n?\n",
+		"6\n+ 1\n+ 1\n+ 2\n?\n!\n?\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	q := rng.Intn(30) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", q)
+	arrLen := 0
+	history := 0
+	for i := 0; i < q; i++ {
+		opType := rng.Intn(4)
+		if opType == 0 || arrLen == 0 { // push
+			x := rng.Intn(1000000) + 1
+			fmt.Fprintf(&sb, "+ %d\n", x)
+			arrLen++
+			history++
+			continue
+		}
+		if opType == 1 && arrLen > 0 { // pop
+			k := rng.Intn(arrLen) + 1
+			fmt.Fprintf(&sb, "- %d\n", k)
+			arrLen -= k
+			history++
+			continue
+		}
+		if opType == 2 && history > 0 { // rollback
+			sb.WriteString("!\n")
+			history--
+			// arrLen cannot exceed q but we ignore exact arr state for generator
+			continue
+		}
+		sb.WriteString("?\n")
+	}
+	return sb.String()
+}
+
+func verify(oracle, userBin string, cases []string) {
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle("1858E1.go", "oracle1858E1.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	verify(oracle, userBin, cases)
+}

--- a/1000-1999/1800-1899/1850-1859/1858/verifierE2.go
+++ b/1000-1999/1800-1899/1850-1859/1858/verifierE2.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle(srcFile, binName string) (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, srcFile)
+	bin := filepath.Join(os.TempDir(), binName)
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"5\n+ 1\n+ 2\n?\n- 1\n?\n",
+		"6\n+ 3\n+ 4\n?\n!\n+ 5\n?\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	q := rng.Intn(30) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", q)
+	arrLen := 0
+	history := 0
+	for i := 0; i < q; i++ {
+		opType := rng.Intn(4)
+		if opType == 0 || arrLen == 0 { // push
+			x := rng.Intn(1000000) + 1
+			fmt.Fprintf(&sb, "+ %d\n", x)
+			arrLen++
+			history++
+			continue
+		}
+		if opType == 1 && arrLen > 0 { // pop
+			k := rng.Intn(arrLen) + 1
+			fmt.Fprintf(&sb, "- %d\n", k)
+			arrLen -= k
+			history++
+			continue
+		}
+		if opType == 2 && history > 0 { // rollback
+			sb.WriteString("!\n")
+			history--
+			continue
+		}
+		sb.WriteString("?\n")
+	}
+	return sb.String()
+}
+
+func verify(oracle, userBin string, cases []string) {
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle("1858E2.go", "oracle1858E2.bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	verify(oracle, userBin, cases)
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for problems A–E2 of contest 1858
- each verifier builds the provided reference solution and checks at least 100 generated test cases

## Testing
- `go build 1000-1999/1800-1899/1850-1859/1858/verifierA.go`
- `go build 1000-1999/1800-1899/1850-1859/1858/verifierB.go`
- `go build 1000-1999/1800-1899/1850-1859/1858/verifierC.go`
- `go build 1000-1999/1800-1899/1850-1859/1858/verifierD.go`
- `go build 1000-1999/1800-1899/1850-1859/1858/verifierE1.go`
- `go build 1000-1999/1800-1899/1850-1859/1858/verifierE2.go`

------
https://chatgpt.com/codex/tasks/task_e_688776aff4f48324b021b264c6bb2c91