### PR TITLE
Add Go verifiers for CF contest 1862

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1862/verifierA.go
+++ b/1000-1999/1800-1899/1860-1869/1862/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveA(n, m int, grid []string) string {
+	letters := "vika"
+	pos := 0
+	for col := 0; col < m && pos < 4; col++ {
+		for row := 0; row < n; row++ {
+			if grid[row][col] == letters[pos] {
+				pos++
+				break
+			}
+		}
+	}
+	if pos == 4 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genCases() []string {
+	rand.Seed(1)
+	cases := make([]string, 100)
+	for idx := 0; idx < 100; idx++ {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(8) + 4
+		grid := make([]string, n)
+		for i := 0; i < n; i++ {
+			row := make([]byte, m)
+			for j := 0; j < m; j++ {
+				row[j] = byte('a' + rand.Intn(26))
+			}
+			grid[i] = string(row)
+		}
+		sb := strings.Builder{}
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			sb.WriteString(grid[i])
+			sb.WriteByte('\n')
+		}
+		cases[idx] = sb.String()
+	}
+	return cases
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		lines := strings.Split(strings.TrimSpace(tc), "\n")
+		var n, m int
+		fmt.Sscan(lines[1], &n, &m)
+		grid := lines[2 : 2+n]
+		want := solveA(n, m, grid)
+		got, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(strings.ToUpper(got)) != want {
+			fmt.Fprintf(os.Stderr, "Wrong answer on case %d\nInput:\n%sExpected: %s Got: %s\n", i+1, tc, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1860-1869/1862/verifierB.go
+++ b/1000-1999/1800-1899/1860-1869/1862/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveB(n int, b []int) string {
+	res := make([]int, 0, 2*n)
+	res = append(res, b[0])
+	for i := 1; i < n; i++ {
+		if b[i] < b[i-1] {
+			res = append(res, b[i])
+		}
+		res = append(res, b[i])
+	}
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprint(len(res)))
+	sb.WriteByte('\n')
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func genCases() []string {
+	rand.Seed(2)
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 2
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rand.Intn(50) + 1
+		}
+		sb := strings.Builder{}
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprint(n))
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(arr[j]))
+		}
+		sb.WriteByte('\n')
+		cases[i] = sb.String()
+	}
+	return cases
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		lines := strings.Split(strings.TrimSpace(tc), "\n")
+		var n int
+		fmt.Sscan(lines[1], &n)
+		parts := strings.Fields(lines[2])
+		b := make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Sscan(parts[j], &b[j])
+		}
+		want := solveB(n, b)
+		got, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "Wrong answer on case %d\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, tc, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1860-1869/1862/verifierC.go
+++ b/1000-1999/1800-1899/1860-1869/1862/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func isSymmetric(a []int) bool {
+	n := len(a)
+	if a[0] != n {
+		return false
+	}
+	j := n - 1
+	for i := 1; i <= n; i++ {
+		for j >= 0 && a[j] < i {
+			j--
+		}
+		if j+1 != a[i-1] {
+			return false
+		}
+	}
+	return true
+}
+
+func genCases() []string {
+	rand.Seed(3)
+	cases := make([]string, 100)
+	for idx := 0; idx < 100; idx++ {
+		n := rand.Intn(7) + 1
+		a := make([]int, n)
+		a[0] = rand.Intn(10) + n
+		for i := 1; i < n; i++ {
+			dec := rand.Intn(3)
+			val := a[i-1] - dec
+			if val < 1 {
+				val = 1
+			}
+			a[i] = val
+		}
+		sb := strings.Builder{}
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprint(n))
+		sb.WriteByte('\n')
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		cases[idx] = sb.String()
+	}
+	return cases
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		lines := strings.Split(strings.TrimSpace(tc), "\n")
+		var n int
+		fmt.Sscan(lines[1], &n)
+		parts := strings.Fields(lines[2])
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Sscan(parts[j], &a[j])
+		}
+		want := "NO"
+		if isSymmetric(a) {
+			want = "YES"
+		}
+		got, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(strings.ToUpper(got)) != want {
+			fmt.Fprintf(os.Stderr, "Wrong answer on case %d\nInput:\n%sExpected: %s Got: %s\n", i+1, tc, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1860-1869/1862/verifierD.go
+++ b/1000-1999/1800-1899/1860-1869/1862/verifierD.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func isqrt(x int64) int64 {
+	r := int64(math.Sqrt(float64(x)))
+	for (r+1)*(r+1) <= x {
+		r++
+	}
+	for r*r > x {
+		r--
+	}
+	return r
+}
+
+func solveD(n int64) string {
+	x := (1 + isqrt(1+8*n)) / 2
+	for x*(x-1)/2 > n {
+		x--
+	}
+	tri := x * (x - 1) / 2
+	res := x + (n - tri)
+	return fmt.Sprint(res)
+}
+
+func genCases() []string {
+	rand.Seed(4)
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Int63n(1_000_000_000_000) + 1
+		sb := strings.Builder{}
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprint(n))
+		sb.WriteByte('\n')
+		cases[i] = sb.String()
+	}
+	return cases
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		var n int64
+		fmt.Sscan(strings.TrimSpace(tc), &n)
+		want := solveD(n)
+		got, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "Wrong answer on case %d\nInput:\n%sExpected: %s Got: %s\n", i+1, tc, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1860-1869/1862/verifierE.go
+++ b/1000-1999/1800-1899/1860-1869/1862/verifierE.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type minHeap []int
+
+func (h minHeap) Len() int            { return len(h) }
+func (h minHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h minHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *minHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *minHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func solveE(n, m, d int, a []int) string {
+	h := &minHeap{}
+	heap.Init(h)
+	sumPrev := 0
+	best := 0
+	for i := 0; i < n; i++ {
+		cand := a[i] + sumPrev - d*(i+1)
+		if cand > best {
+			best = cand
+		}
+		if a[i] > 0 {
+			heap.Push(h, a[i])
+			sumPrev += a[i]
+			if h.Len() > m-1 {
+				sumPrev -= heap.Pop(h).(int)
+			}
+		}
+	}
+	return fmt.Sprint(best)
+}
+
+func genCases() []string {
+	rand.Seed(5)
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(6) + 1
+		m := rand.Intn(n) + 1
+		d := rand.Intn(5) + 1
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rand.Intn(21) - 10
+		}
+		sb := strings.Builder{}
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, d))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(a[j]))
+		}
+		sb.WriteByte('\n')
+		cases[i] = sb.String()
+	}
+	return cases
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		lines := strings.Split(strings.TrimSpace(tc), "\n")
+		var n, m, d int
+		fmt.Sscan(lines[1], &n, &m, &d)
+		parts := strings.Fields(lines[2])
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Sscan(parts[j], &a[j])
+		}
+		want := solveE(n, m, d, a)
+		got, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "Wrong answer on case %d\nInput:\n%sExpected: %s Got: %s\n", i+1, tc, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1860-1869/1862/verifierF.go
+++ b/1000-1999/1800-1899/1860-1869/1862/verifierF.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func can(t int64, w, f int64, sum int, dp []bool) bool {
+	maxW := w * t
+	if maxW > int64(sum) {
+		maxW = int64(sum)
+	}
+	maxF := f * t
+	for i := int64(0); i <= maxW; i++ {
+		if dp[i] {
+			if int64(sum)-i <= maxF {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func solveF(w, f int64, s []int) string {
+	sum := 0
+	for _, v := range s {
+		sum += v
+	}
+	dp := make([]bool, sum+1)
+	dp[0] = true
+	for _, v := range s {
+		for j := sum; j >= v; j-- {
+			if dp[j-v] {
+				dp[j] = true
+			}
+		}
+	}
+	low := int64(0)
+	high := int64(sum)
+	if w < f {
+		if int64(sum)%w != 0 {
+			if int64(sum)/w+1 > high {
+				high = int64(sum)/w + 1
+			}
+		} else {
+			if int64(sum)/w > high {
+				high = int64(sum) / w
+			}
+		}
+	} else {
+		if int64(sum)%f != 0 {
+			if int64(sum)/f+1 > high {
+				high = int64(sum)/f + 1
+			}
+		} else {
+			if int64(sum)/f > high {
+				high = int64(sum) / f
+			}
+		}
+	}
+	for low < high {
+		mid := (low + high) / 2
+		if can(mid, w, f, sum, dp) {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	return fmt.Sprint(low)
+}
+
+func genCases() []string {
+	rand.Seed(6)
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		w := int64(rand.Intn(5) + 1)
+		f := int64(rand.Intn(5) + 1)
+		n := rand.Intn(6) + 1
+		s := make([]int, n)
+		for j := 0; j < n; j++ {
+			s[j] = rand.Intn(10) + 1
+		}
+		sb := strings.Builder{}
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", w, f))
+		sb.WriteString(fmt.Sprint(n))
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(s[j]))
+		}
+		sb.WriteByte('\n')
+		cases[i] = sb.String()
+	}
+	return cases
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		lines := strings.Split(strings.TrimSpace(tc), "\n")
+		var w, f int64
+		fmt.Sscan(lines[1], &w, &f)
+		var n int
+		fmt.Sscan(lines[2], &n)
+		parts := strings.Fields(lines[3])
+		s := make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Sscan(parts[j], &s[j])
+		}
+		want := solveF(w, f, s)
+		got, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "Wrong answer on case %d\nInput:\n%sExpected: %s Got: %s\n", i+1, tc, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1800-1899/1860-1869/1862/verifierG.go
+++ b/1000-1999/1800-1899/1860-1869/1862/verifierG.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func processArray(arr []int) int {
+	sort.Ints(arr)
+	arr = unique(arr)
+	for len(arr) > 1 {
+		n := len(arr)
+		for i := 0; i < n; i++ {
+			arr[i] += n - i
+		}
+		sort.Ints(arr)
+		arr = unique(arr)
+	}
+	return arr[0]
+}
+
+func unique(a []int) []int {
+	if len(a) == 0 {
+		return a
+	}
+	j := 0
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[j] {
+			j++
+			a[j] = a[i]
+		}
+	}
+	return a[:j+1]
+}
+
+func solveG(n int, a []int, ops [][2]int) string {
+	res := make([]string, len(ops))
+	for i, op := range ops {
+		a[op[0]] = op[1]
+		arrCopy := make([]int, len(a))
+		copy(arrCopy, a)
+		val := processArray(arrCopy)
+		res[i] = fmt.Sprint(val)
+	}
+	return strings.Join(res, "\n")
+}
+
+func genCases() []string {
+	rand.Seed(7)
+	cases := make([]string, 100)
+	for idx := 0; idx < 100; idx++ {
+		n := rand.Intn(4) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(10) + 1
+		}
+		q := rand.Intn(4) + 1
+		ops := make([][2]int, q)
+		for i := 0; i < q; i++ {
+			ops[i][0] = rand.Intn(n)
+			ops[i][1] = rand.Intn(10) + 1
+		}
+		sb := strings.Builder{}
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprint(n))
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(a[i]))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprint(q))
+		sb.WriteByte('\n')
+		for i := 0; i < q; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", ops[i][0]+1, ops[i][1]))
+		}
+		cases[idx] = sb.String()
+	}
+	return cases
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		lines := strings.Split(strings.TrimSpace(tc), "\n")
+		idx := 0
+		var n int
+		fmt.Sscan(lines[1], &n)
+		idx = 2
+		parts := strings.Fields(lines[idx])
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Sscan(parts[j], &a[j])
+		}
+		idx++
+		var q int
+		fmt.Sscan(lines[idx], &q)
+		idx++
+		ops := make([][2]int, q)
+		for j := 0; j < q; j++ {
+			fmt.Sscan(lines[idx+j], &ops[j][0], &ops[j][1])
+			ops[j][0]--
+		}
+		want := solveG(n, append([]int(nil), a...), ops)
+		got, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "Wrong answer on case %d\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, tc, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for problems A–G of contest 1862
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go run verifierA.go ./solA`


------
https://chatgpt.com/codex/tasks/task_e_688777c76fe08324b720cec231b43aaa