### PR TITLE
Add Go verifiers for contest 1861

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1861/verifierA.go
+++ b/1000-1999/1800-1899/1860-1869/1861/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct{ input, expected string }
+
+var primes = []struct{ a, b, val int }{
+	{1, 3, 13}, {1, 7, 17}, {1, 9, 19}, {2, 3, 23}, {2, 9, 29}, {3, 1, 31}, {3, 7, 37},
+	{4, 1, 41}, {4, 3, 43}, {4, 7, 47}, {5, 3, 53}, {5, 9, 59}, {6, 1, 61}, {6, 7, 67},
+	{7, 1, 71}, {7, 3, 73}, {8, 3, 83}, {8, 9, 89}, {9, 7, 97},
+}
+
+func solveCase(s string) string {
+	var pos [10]int
+	for i, ch := range s {
+		pos[ch-'0'] = i
+	}
+	for _, p := range primes {
+		if pos[p.a] < pos[p.b] {
+			return fmt.Sprintf("%d", p.val)
+		}
+	}
+	return "-1"
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(42))
+	digits := []byte{'1', '2', '3', '4', '5', '6', '7', '8', '9'}
+	var tests []test
+	for len(tests) < 100 {
+		rng.Shuffle(len(digits), func(i, j int) { digits[i], digits[j] = digits[j], digits[i] })
+		s := string(digits)
+		input := fmt.Sprintf("1\n%s\n", s)
+		tests = append(tests, test{input, solveCase(s)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1800-1899/1860-1869/1861/verifierB.go
+++ b/1000-1999/1800-1899/1860-1869/1861/verifierB.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct{ input, expected string }
+
+func reachableBoundaries(s string) []int {
+	n := len(s)
+	leftOne := make([]int, n)
+	last := 0
+	for i := 0; i < n; i++ {
+		if s[i] == '1' {
+			last = i + 1
+		}
+		leftOne[i] = last
+	}
+	const inf = int(1e9)
+	minLeft := make([]int, n+1)
+	for i := range minLeft {
+		minLeft[i] = inf
+	}
+	for i := n - 1; i >= 0; i-- {
+		minLeft[i] = minLeft[i+1]
+		if s[i] == '0' {
+			if leftOne[i] < minLeft[i] {
+				minLeft[i] = leftOne[i]
+			}
+		}
+	}
+	res := make([]int, 0)
+	for j := 0; j < n-1; j++ {
+		if s[j] == '0' && minLeft[j+1] > j+1 {
+			res = append(res, j+1)
+		}
+	}
+	return res
+}
+
+func canEqual(a, b string) bool {
+	ba := reachableBoundaries(a)
+	bb := reachableBoundaries(b)
+	i, j := 0, 0
+	for i < len(ba) && j < len(bb) {
+		if ba[i] == bb[j] {
+			return true
+		}
+		if ba[i] < bb[j] {
+			i++
+		} else {
+			j++
+		}
+	}
+	return false
+}
+
+func solveCase(a, b string) string {
+	if canEqual(a, b) {
+		return "YES"
+	} else {
+		return "NO"
+	}
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(43))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(9) + 2 // length 2..10
+		a := make([]byte, n)
+		b := make([]byte, n)
+		a[0] = '0'
+		b[0] = '0'
+		a[n-1] = '1'
+		b[n-1] = '1'
+		for i := 1; i < n-1; i++ {
+			a[i] = byte('0' + rng.Intn(2))
+			b[i] = byte('0' + rng.Intn(2))
+		}
+		sa := string(a)
+		sb := string(b)
+		input := fmt.Sprintf("1\n%s\n%s\n", sa, sb)
+		tests = append(tests, test{input, solveCase(sa, sb)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1800-1899/1860-1869/1861/verifierC.go
+++ b/1000-1999/1800-1899/1860-1869/1861/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct{ input, expected string }
+
+func solveCase(s string) string {
+	size := 0
+	need := -1
+	added := 0
+	valid := true
+	for i := 0; i < len(s) && valid; i++ {
+		switch s[i] {
+		case '+':
+			size++
+			added++
+		case '-':
+			size--
+			if added > 0 {
+				added--
+			}
+			if need != -1 && size < need {
+				need = -1
+			}
+		case '1':
+			if need != -1 {
+				valid = false
+				break
+			}
+			added = 0
+		case '0':
+			if size < 2 || added == 0 {
+				valid = false
+				break
+			}
+			need = size
+		}
+	}
+	if valid {
+		return "YES"
+	} else {
+		return "NO"
+	}
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(44))
+	var tests []test
+	ops := []byte{"+-01"}
+	for len(tests) < 100 {
+		n := rng.Intn(15) + 1
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteByte(ops[rng.Intn(4)])
+		}
+		s := sb.String()
+		input := fmt.Sprintf("1\n%s\n", s)
+		tests = append(tests, test{input, solveCase(s)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1800-1899/1860-1869/1861/verifierD.go
+++ b/1000-1999/1800-1899/1860-1869/1861/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct{ input, expected string }
+
+func lisLength(arr []int) int {
+	dp := make([]int, 0)
+	for _, v := range arr {
+		l, r := 0, len(dp)
+		for l < r {
+			m := (l + r) / 2
+			if dp[m] < v {
+				l = m + 1
+			} else {
+				r = m
+			}
+		}
+		if l == len(dp) {
+			dp = append(dp, v)
+		} else {
+			dp[l] = v
+		}
+	}
+	return len(dp)
+}
+
+func solveCase(arr []int) string {
+	l := lisLength(arr)
+	return fmt.Sprintf("%d", len(arr)-l)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(45))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rng.Intn(20)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, test{sb.String(), solveCase(arr)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1800-1899/1860-1869/1861/verifierE.go
+++ b/1000-1999/1800-1899/1860-1869/1861/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct{ input, expected string }
+
+const mod int64 = 998244353
+
+func solveCase(n, k int) string {
+	dp := make([]int64, k)
+	sum := make([]int64, k)
+	dp[0] = 1
+	prefixDp := make([]int64, k+1)
+	prefixSum := make([]int64, k+1)
+	nextDp := make([]int64, k)
+	nextSum := make([]int64, k)
+	for step := 0; step < n; step++ {
+		prefixDp[k] = 0
+		prefixSum[k] = 0
+		for i := k - 1; i >= 0; i-- {
+			prefixDp[i] = prefixDp[i+1] + dp[i]
+			if prefixDp[i] >= mod {
+				prefixDp[i] %= mod
+			}
+			prefixSum[i] = prefixSum[i+1] + sum[i]
+			if prefixSum[i] >= mod {
+				prefixSum[i] %= mod
+			}
+		}
+		for i := 0; i < k; i++ {
+			nextDp[i] = 0
+			nextSum[i] = 0
+		}
+		for r := 1; r < k; r++ {
+			nextDp[r] = prefixDp[r]
+			nextSum[r] = prefixSum[r]
+		}
+		for m := 0; m < k; m++ {
+			if dp[m] == 0 && sum[m] == 0 {
+				continue
+			}
+			newChoices := int64(k - m)
+			if m+1 == k {
+				nextDp[0] = (nextDp[0] + dp[m]*newChoices) % mod
+				inc := (sum[m] + dp[m]) % mod
+				nextSum[0] = (nextSum[0] + inc*newChoices) % mod
+			} else {
+				nextDp[m+1] = (nextDp[m+1] + dp[m]*newChoices) % mod
+				nextSum[m+1] = (nextSum[m+1] + sum[m]*newChoices) % mod
+			}
+		}
+		dp, nextDp = nextDp, dp
+		sum, nextSum = nextSum, sum
+	}
+	var ans int64
+	for i := 0; i < k; i++ {
+		ans = (ans + sum[i]) % mod
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(46))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		k := rng.Intn(5) + 1
+		input := fmt.Sprintf("%d %d\n", n, k)
+		tests = append(tests, test{input, solveCase(n, k)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1800-1899/1860-1869/1861/verifierF.go
+++ b/1000-1999/1800-1899/1860-1869/1861/verifierF.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct{ input, expected string }
+
+func solveCase(n int, a [][4]int64, b [4]int64) string {
+	var sumA int64
+	suitSums := make([]int64, 4)
+	for i := 0; i < n; i++ {
+		for j := 0; j < 4; j++ {
+			sumA += a[i][j]
+			suitSums[j] += a[i][j]
+		}
+	}
+	var sumB int64
+	for j := 0; j < 4; j++ {
+		sumB += b[j]
+		suitSums[j] += b[j]
+	}
+	total := sumA + sumB
+	T := total / int64(n)
+
+	maxSuit := make([]int64, n)
+	for i := 0; i < n; i++ {
+		mx := a[i][0]
+		for j := 1; j < 4; j++ {
+			if a[i][j] > mx {
+				mx = a[i][j]
+			}
+		}
+		maxSuit[i] = mx
+	}
+	prefix := make([]int64, n)
+	if n > 0 {
+		prefix[0] = maxSuit[0]
+		for i := 1; i < n; i++ {
+			if maxSuit[i] > prefix[i-1] {
+				prefix[i] = maxSuit[i]
+			} else {
+				prefix[i] = prefix[i-1]
+			}
+		}
+	}
+	suffix := make([]int64, n)
+	if n > 0 {
+		suffix[n-1] = maxSuit[n-1]
+		for i := n - 2; i >= 0; i-- {
+			if maxSuit[i] > suffix[i+1] {
+				suffix[i] = maxSuit[i]
+			} else {
+				suffix[i] = suffix[i+1]
+			}
+		}
+	}
+	results := make([]int64, n)
+	for i := 0; i < n; i++ {
+		baseOthers := int64(0)
+		if i > 0 {
+			baseOthers = prefix[i-1]
+		}
+		if i+1 < n && suffix[i+1] > baseOthers {
+			baseOthers = suffix[i+1]
+		}
+		d := T
+		for j := 0; j < 4; j++ {
+			d -= a[i][j]
+		}
+		Sother := make([]int64, 4)
+		for j := 0; j < 4; j++ {
+			Sother[j] = suitSums[j] - a[i][j]
+		}
+		bestDiff := int64(0)
+		for j0 := 0; j0 < 4; j0++ {
+			Btemp := make([]int64, 4)
+			copy(Btemp, b[:])
+			Stemp := make([]int64, 4)
+			copy(Stemp, Sother)
+			x := make([]int64, 4)
+			take := Btemp[j0]
+			if take > d {
+				take = d
+			}
+			x[j0] = take
+			Btemp[j0] -= take
+			Stemp[j0] -= take
+			remaining := d - take
+			for remaining > 0 {
+				best := -1
+				for s := 0; s < 4; s++ {
+					if Btemp[s] > 0 {
+						if best == -1 || Stemp[s] > Stemp[best] {
+							best = s
+						}
+					}
+				}
+				if best == -1 {
+					break
+				}
+				give := Btemp[best]
+				if give > remaining {
+					give = remaining
+				}
+				x[best] += give
+				Btemp[best] -= give
+				Stemp[best] -= give
+				remaining -= give
+			}
+			curMax := a[i][0] + x[0]
+			for s := 1; s < 4; s++ {
+				if a[i][s]+x[s] > curMax {
+					curMax = a[i][s] + x[s]
+				}
+			}
+			y := baseOthers
+			for s := 0; s < 4; s++ {
+				val := (Stemp[s] + int64(n-1) - 1) / int64(n-1)
+				if val > y {
+					y = val
+				}
+			}
+			diff := curMax - y
+			if diff > bestDiff {
+				bestDiff = diff
+			}
+		}
+		if bestDiff < 0 {
+			bestDiff = 0
+		}
+		results[i] = bestDiff
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", results[i]))
+	}
+	return sb.String()
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(47))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		a := make([][4]int64, n)
+		var sumA int64
+		for i := 0; i < n; i++ {
+			for j := 0; j < 4; j++ {
+				val := int64(rng.Intn(5))
+				a[i][j] = val
+				sumA += val
+			}
+		}
+		T := int64(rng.Intn(5) + 1)
+		if T*int64(n) < sumA {
+			T = (sumA + int64(n) - 1) / int64(n)
+		}
+		sumB := T*int64(n) - sumA
+		b := [4]int64{}
+		for j := 0; j < 4; j++ {
+			if j == 3 {
+				b[j] = sumB
+			} else {
+				val := int64(rng.Intn(int(sumB + 1)))
+				b[j] = val
+				sumB -= val
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			for j := 0; j < 4; j++ {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", a[i][j]))
+			}
+			sb.WriteByte('\n')
+		}
+		for j := 0; j < 4; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", b[j]))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, test{sb.String(), solveCase(n, a, b)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–F of contest 1861
- each verifier generates 100 random tests and checks the given binary

## Testing
- `go build verifierA.go && ./verifierA 1861A.go`

------
https://chatgpt.com/codex/tasks/task_e_6887778163e08324881a4e81f853a825