### PR TITLE
Add Go solution verifiers for contest 1859

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1859/verifierA.go
+++ b/1000-1999/1800-1899/1850-1859/1859/verifierA.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func generateTestCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	// deterministic cases
+	cases = append(cases, testCase{arr: []int{1, 1}})
+	cases = append(cases, testCase{arr: []int{1, 2}})
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 2 // 2..11
+		arr := make([]int, n)
+		if rng.Intn(3) == 0 {
+			v := rng.Intn(20) + 1
+			for i := range arr {
+				arr[i] = v
+			}
+		} else {
+			for i := range arr {
+				arr[i] = rng.Intn(20) + 1
+			}
+		}
+		cases = append(cases, testCase{arr: arr})
+	}
+	return cases
+}
+
+func validPartition(a, b, c []int) bool {
+	if len(b) == 0 || len(c) == 0 {
+		return false
+	}
+	if len(b)+len(c) != len(a) {
+		return false
+	}
+	cntInput := make(map[int]int)
+	for _, v := range a {
+		cntInput[v]++
+	}
+	for _, v := range b {
+		cntInput[v]--
+		if cntInput[v] < 0 {
+			return false
+		}
+	}
+	for _, v := range c {
+		cntInput[v]--
+		if cntInput[v] < 0 {
+			return false
+		}
+	}
+	for _, v := range cntInput {
+		if v != 0 {
+			return false
+		}
+	}
+	for _, bi := range b {
+		for _, cj := range c {
+			if bi%cj == 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func allEqual(a []int) bool {
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[0] {
+			return false
+		}
+	}
+	return true
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", len(tc.arr))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	output := strings.TrimSpace(out.String())
+	if output == "-1" {
+		if allEqual(tc.arr) {
+			return nil
+		}
+		return fmt.Errorf("expected valid partition, got -1")
+	}
+	nums := strings.Fields(output)
+	if len(nums) < 3 {
+		return fmt.Errorf("output too short: %q", output)
+	}
+	lb, err1 := strconv.Atoi(nums[0])
+	lc, err2 := strconv.Atoi(nums[1])
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("invalid sizes")
+	}
+	if lb <= 0 || lc <= 0 {
+		return fmt.Errorf("empty arrays")
+	}
+	if len(nums) != 2+lb+lc {
+		return fmt.Errorf("expected %d numbers got %d", 2+lb+lc, len(nums))
+	}
+	b := make([]int, lb)
+	c := make([]int, lc)
+	for i := 0; i < lb; i++ {
+		v, err := strconv.Atoi(nums[2+i])
+		if err != nil {
+			return fmt.Errorf("bad number %q", nums[2+i])
+		}
+		b[i] = v
+	}
+	for i := 0; i < lc; i++ {
+		v, err := strconv.Atoi(nums[2+lb+i])
+		if err != nil {
+			return fmt.Errorf("bad number %q", nums[2+lb+i])
+		}
+		c[i] = v
+	}
+	if !validPartition(tc.arr, b, c) {
+		return fmt.Errorf("invalid partition for input %v", tc.arr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTestCases()
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1859/verifierB.go
+++ b/1000-1999/1800-1899/1850-1859/1859/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	arrays [][]int64
+}
+
+func solveB(arrs [][]int64) int64 {
+	const INF int64 = 1 << 62
+	minFirst := INF
+	minSecond := INF
+	var sumSecond int64
+	for _, arr := range arrs {
+		first, second := INF, INF
+		for _, x := range arr {
+			if x < first {
+				second = first
+				first = x
+			} else if x < second {
+				second = x
+			}
+		}
+		if first < minFirst {
+			minFirst = first
+		}
+		if second < minSecond {
+			minSecond = second
+		}
+		sumSecond += second
+	}
+	return minFirst + sumSecond - minSecond
+}
+
+func generateCasesB() []testCaseB {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCaseB, 0, 100)
+	for len(cases) < 100 {
+		n := rng.Intn(4) + 1
+		arrs := make([][]int64, n)
+		for i := 0; i < n; i++ {
+			m := rng.Intn(4) + 2
+			a := make([]int64, m)
+			for j := 0; j < m; j++ {
+				a[j] = int64(rng.Intn(20) + 1)
+			}
+			arrs[i] = a
+		}
+		cases = append(cases, testCaseB{arrays: arrs})
+	}
+	return cases
+}
+
+func runCase(bin string, tc testCaseB) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.arrays)))
+	for _, arr := range tc.arrays {
+		sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(gotStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("non-integer output %q", gotStr)
+	}
+	exp := solveB(tc.arrays)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCasesB()
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1859/verifierC.go
+++ b/1000-1999/1800-1899/1850-1859/1859/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func maxCost(n int) int {
+	best := 0
+	for r := 0; r < n; r++ {
+		sum := 0
+		maxProd := 0
+		for i := 1; i <= r; i++ {
+			prod := i * i
+			sum += prod
+			if prod > maxProd {
+				maxProd = prod
+			}
+		}
+		for j := 1; j <= n-r; j++ {
+			val := n - j + 1
+			idx := r + j
+			prod := idx * val
+			sum += prod
+			if prod > maxProd {
+				maxProd = prod
+			}
+		}
+		cost := sum - maxProd
+		if cost > best {
+			best = cost
+		}
+	}
+	return best
+}
+
+func generateCasesC() []int {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]int, 0, 100)
+	cases = append(cases, 2)
+	for len(cases) < 100 {
+		n := rng.Intn(50) + 2
+		cases = append(cases, n)
+	}
+	return cases
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(gotStr)
+	if err != nil {
+		return fmt.Errorf("non-integer output %q", gotStr)
+	}
+	exp := maxCost(n)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCasesC()
+	for i, n := range cases {
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1859/verifierD.go
+++ b/1000-1999/1800-1899/1850-1859/1859/verifierD.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type portal struct {
+	l int
+	r int
+	a int
+	b int
+}
+
+func escape(x int, ps []portal) int {
+	l, r := x, x
+	changed := true
+	for changed {
+		changed = false
+		for _, p := range ps {
+			if p.r < l || p.l > r {
+				continue
+			}
+			if p.a < l {
+				l = p.a
+				changed = true
+			}
+			if p.b > r {
+				r = p.b
+				changed = true
+			}
+		}
+	}
+	return r
+}
+
+func solveD(ps []portal, xs []int) []int {
+	res := make([]int, len(xs))
+	for i, x := range xs {
+		res[i] = escape(x, ps)
+	}
+	return res
+}
+
+func generateCasesD() []struct {
+	ps []portal
+	xs []int
+} {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]struct {
+		ps []portal
+		xs []int
+	}, 0, 100)
+	for len(cases) < 100 {
+		n := rng.Intn(4) + 1
+		ps := make([]portal, n)
+		for i := 0; i < n; i++ {
+			a := rng.Intn(20) + 1
+			b := a + rng.Intn(5)
+			l := a - rng.Intn(5)
+			if l < 1 {
+				l = 1
+			}
+			r := b + rng.Intn(5)
+			ps[i] = portal{l: l, r: r, a: a, b: b}
+		}
+		q := rng.Intn(4) + 1
+		xs := make([]int, q)
+		for i := 0; i < q; i++ {
+			xs[i] = rng.Intn(25) + 1
+		}
+		cases = append(cases, struct {
+			ps []portal
+			xs []int
+		}{ps: ps, xs: xs})
+	}
+	return cases
+}
+
+func runCase(bin string, ps []portal, xs []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(ps)))
+	for _, p := range ps {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", p.l, p.r, p.a, p.b))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", len(xs)))
+	for i, x := range xs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(x))
+	}
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	exp := solveD(ps, xs)
+	if len(fields) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(fields))
+	}
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("bad int %q", f)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("expected %v got %v", exp, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCasesD()
+	for i, tc := range cases {
+		if err := runCase(bin, tc.ps, tc.xs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1859/verifierE.go
+++ b/1000-1999/1800-1899/1850-1859/1859/verifierE.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runReference(input string) (string, error) {
+	cmd := exec.Command("go", "run", "1859E.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateCase(rng *rand.Rand) (int, int, []int64, []int64) {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(n) + 1
+	a := make([]int64, n)
+	b := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(11) - 5)
+		b[i] = int64(rng.Intn(11) - 5)
+	}
+	return n, k, a, b
+}
+
+func buildInput(n, k int, a, b []int64) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, n, k int, a, b []int64) error {
+	input := buildInput(n, k, a, b)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expOut, err := runReference(input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\n%s", err, expOut)
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expOut), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, a, b := generateCase(rng)
+		if err := runCase(bin, n, k, a, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1850-1859/1859/verifierF.go
+++ b/1000-1999/1800-1899/1850-1859/1859/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runReference(input string) (string, error) {
+	cmd := exec.Command("go", "run", "1859F.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type edge struct{ u, v, w int }
+
+func generateCase(rng *rand.Rand) (int, int, []edge, string, [][2]int) {
+	n := rng.Intn(5) + 2
+	T := rng.Intn(5) + 1
+	edges := make([]edge, n-1)
+	for i := 2; i <= n; i++ {
+		u := rng.Intn(i-1) + 1
+		w := rng.Intn(10) + 1
+		edges[i-2] = edge{u, i, w}
+	}
+	sbytes := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sbytes[i] = '0'
+		} else {
+			sbytes[i] = '1'
+		}
+	}
+	s := string(sbytes)
+	q := rng.Intn(3) + 1
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		queries[i] = [2]int{a, b}
+	}
+	return n, T, edges, s, queries
+}
+func buildInput(n, T int, edges []edge, s string, qs [][2]int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, T))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u, e.v, e.w))
+	}
+	sb.WriteString(s + "\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(qs)))
+	for i, q := range qs {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(fmt.Sprintf("%d %d", q[0], q[1]))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func runCase(bin string, n, T int, edges []edge, s string, qs [][2]int) error {
+	input := buildInput(n, T, edges, s, qs)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	exp, err := runReference(input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\n%s", err, exp)
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(exp), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, T, edges, s, qs := generateCase(rng)
+		if err := runCase(bin, n, T, edges, s, qs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA-F.go to contest 1859 to test solutions
- verifiers generate 100 random test cases and check a binary's output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688776f5750c8324947fd613a1c992ec