### PR TITLE
Add verifiers for contest 1870

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1870/verifierA.go
+++ b/1000-1999/1800-1899/1870-1879/1870/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseA struct {
+	n int64
+	k int64
+	x int64
+}
+
+func genTestsA() []testCaseA {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]testCaseA, 100)
+	for i := range tests {
+		tests[i] = testCaseA{
+			n: int64(rng.Intn(200) + 1),
+			k: int64(rng.Intn(200) + 1),
+			x: int64(rng.Intn(200) + 1),
+		}
+	}
+	return tests
+}
+
+func solveA(tc testCaseA) int64 {
+	if tc.n < tc.k || tc.x < tc.k-1 {
+		return -1
+	}
+	base := tc.k * (tc.k - 1) / 2
+	val := tc.x
+	if val == tc.k {
+		val--
+	}
+	return base + (tc.n-tc.k)*val
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d %d\n", tc.n, tc.k, tc.x)
+	}
+	expected := make([]int64, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveA(tc)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		valStr := scanner.Text()
+		val, err := strconv.ParseInt(valStr, 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d: %s\n", i+1, valStr)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", i+1, exp, val)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1870-1879/1870/verifierB.go
+++ b/1000-1999/1800-1899/1870-1879/1870/verifierB.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseB struct {
+	n int
+	m int
+	a []int
+	b []int
+}
+
+func genTestsB() []testCaseB {
+	rng := rand.New(rand.NewSource(43))
+	tests := make([]testCaseB, 100)
+	for i := range tests {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rng.Intn(50)
+		}
+		b := make([]int, m)
+		for j := range b {
+			b[j] = rng.Intn(50)
+		}
+		tests[i] = testCaseB{n, m, a, b}
+	}
+	return tests
+}
+
+func solveB(tc testCaseB) (int, int) {
+	orB := 0
+	for _, v := range tc.b {
+		orB |= v
+	}
+	xorA := 0
+	for _, v := range tc.a {
+		xorA ^= v
+	}
+	xorOR := 0
+	for _, v := range tc.a {
+		xorOR ^= (v | orB)
+	}
+	if tc.n%2 == 1 {
+		return xorA, xorOR
+	}
+	return xorOR, xorA
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.m)
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		for i, v := range tc.b {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+	expected := make([][2]int, len(tests))
+	for i, tc := range tests {
+		x, y := solveB(tc)
+		expected[i] = [2]int{x, y}
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		vals := make([]int, 2)
+		for j := 0; j < 2; j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			v, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			vals[j] = v
+		}
+		if vals[0] != exp[0] || vals[1] != exp[1] {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d %d got %d %d\n", i+1, exp[0], exp[1], vals[0], vals[1])
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1870-1879/1870/verifierC.go
+++ b/1000-1999/1800-1899/1870-1879/1870/verifierC.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseC struct {
+	n int
+	k int
+	a []int
+}
+
+func genTestsC() []testCaseC {
+	rng := rand.New(rand.NewSource(44))
+	tests := make([]testCaseC, 100)
+	for i := range tests {
+		n := rng.Intn(8) + 2
+		k := rng.Intn(6) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rng.Intn(10)
+		}
+		tests[i] = testCaseC{n, k, a}
+	}
+	return tests
+}
+
+func solveC(tc testCaseC) []int {
+	exists := make([]bool, tc.k+1)
+	pmax := make([]int, tc.n)
+	cur := 0
+	for i := 0; i < tc.n; i++ {
+		v := tc.a[i]
+		if v <= tc.k {
+			exists[v] = true
+		}
+		if v > cur {
+			cur = v
+		}
+		pmax[i] = cur
+	}
+	smax := make([]int, tc.n)
+	cur = 0
+	for i := tc.n - 1; i >= 0; i-- {
+		if tc.a[i] > cur {
+			cur = tc.a[i]
+		}
+		smax[i] = cur
+	}
+	L := make([]int, tc.k+1)
+	idx := 0
+	for c := 1; c <= tc.k; c++ {
+		for idx < tc.n && pmax[idx] < c {
+			idx++
+		}
+		if idx < tc.n {
+			L[c] = idx
+		} else {
+			L[c] = tc.n
+		}
+	}
+	R := make([]int, tc.k+1)
+	idx = tc.n - 1
+	for c := 1; c <= tc.k; c++ {
+		for idx >= 0 && smax[idx] < c {
+			idx--
+		}
+		if idx >= 0 {
+			R[c] = idx
+		} else {
+			R[c] = -1
+		}
+	}
+	res := make([]int, tc.k)
+	for c := 1; c <= tc.k; c++ {
+		if !exists[c] {
+			res[c-1] = 0
+			continue
+		}
+		res[c-1] = 2 * (R[c] - L[c] + 1)
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+	expected := make([][]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveC(tc)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for idx, exp := range expected {
+		for j := 0; j < len(exp); j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			if val != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d element %d: expected %d got %d\n", idx+1, j+1, exp[j], val)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1870-1879/1870/verifierD.go
+++ b/1000-1999/1800-1899/1870-1879/1870/verifierD.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseD struct {
+	n int
+	c []int64
+	k int64
+}
+
+func genTestsD() []testCaseD {
+	rng := rand.New(rand.NewSource(45))
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rng.Intn(8) + 1
+		c := make([]int64, n)
+		for j := range c {
+			c[j] = int64(rng.Intn(20) + 1)
+		}
+		k := int64(rng.Intn(20) + 1)
+		tests[i] = testCaseD{n, c, k}
+	}
+	return tests
+}
+
+func solveD(tc testCaseD) []int64 {
+	n := tc.n
+	a := make([]int64, n)
+	const INF int64 = 1 << 60
+	mn := INF
+	prefix := int64(0)
+	k := tc.k
+	for i := n - 1; i >= 0; i-- {
+		if tc.c[i] < mn {
+			mn = tc.c[i]
+		}
+		times := k / mn
+		prefix += times
+		k -= times * mn
+		a[i] = prefix
+	}
+	return a
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for i, v := range tc.c {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		fmt.Fprintln(&input, tc.k)
+	}
+	expected := make([][]int64, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveD(tc)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for idx, exp := range expected {
+		for j := 0; j < len(exp); j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			if val != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d element %d: expected %d got %d\n", idx+1, j+1, exp[j], val)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1870-1879/1870/verifierE.go
+++ b/1000-1999/1800-1899/1870-1879/1870/verifierE.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+const (
+	MaxXor = 1 << 13
+	Words  = MaxXor / 64
+	Limit  = 130
+)
+
+type Bitset [Words]uint64
+
+type testCaseE struct {
+	n int
+	a []int
+}
+
+func applyXor(dst *Bitset, src *Bitset, val int) {
+	for i := 0; i < Words; i++ {
+		w := src[i]
+		for w != 0 {
+			b := bits.TrailingZeros64(w)
+			idx := i*64 + b
+			nidx := idx ^ val
+			dst[nidx>>6] |= 1 << (uint(nidx) & 63)
+			w &= w - 1
+		}
+	}
+}
+
+func genTestsE() []testCaseE {
+	rng := rand.New(rand.NewSource(46))
+	tests := make([]testCaseE, 100)
+	for i := range tests {
+		n := rng.Intn(6) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rng.Intn(10)
+		}
+		tests[i] = testCaseE{n, a}
+	}
+	return tests
+}
+
+func solveE(tc testCaseE) int {
+	n := tc.n
+	a := tc.a
+	dp := make([]Bitset, n+1)
+	dp[0][0] = 1
+	freq := make([]int, Limit+2)
+	for r := 1; r <= n; r++ {
+		for i := 0; i < Words; i++ {
+			dp[r][i] = dp[r-1][i]
+		}
+		for i := range freq {
+			freq[i] = 0
+		}
+		mex := 0
+		for l := r; l >= 1 && r-l+1 <= Limit; l-- {
+			v := a[l-1]
+			if v <= Limit {
+				freq[v]++
+			}
+			for mex <= Limit && freq[mex] > 0 {
+				mex++
+			}
+			if mex > Limit {
+				break
+			}
+			applyXor(&dp[r], &dp[l-1], mex)
+		}
+	}
+	ans := 0
+	for x := MaxXor - 1; x >= 0; x-- {
+		if (dp[n][x>>6]>>(uint(x)&63))&1 != 0 {
+			ans = x
+			break
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveE(tc)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", i+1, exp, val)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1870-1879/1870/verifierF.go
+++ b/1000-1999/1800-1899/1870-1879/1870/verifierF.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+)
+
+type testCaseF struct {
+	n int
+	k int
+}
+
+func genTestsF() []testCaseF {
+	rng := rand.New(rand.NewSource(47))
+	tests := make([]testCaseF, 100)
+	for i := range tests {
+		n := rng.Intn(7) + 1
+		k := rng.Intn(5) + 2
+		tests[i] = testCaseF{n, k}
+	}
+	return tests
+}
+
+func baseK(x int, k int) string {
+	if x == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for x > 0 {
+		digits = append(digits, byte('0'+x%k))
+		x /= k
+	}
+	for i, j := 0, len(digits)-1; i < j; i, j = i+1, j-1 {
+		digits[i], digits[j] = digits[j], digits[i]
+	}
+	return string(digits)
+}
+
+func solveF(tc testCaseF) int {
+	repr := make([]struct {
+		str string
+		idx int
+	}, tc.n)
+	for i := 1; i <= tc.n; i++ {
+		repr[i-1] = struct {
+			str string
+			idx int
+		}{baseK(i, tc.k), i}
+	}
+	sort.Slice(repr, func(i, j int) bool { return repr[i].str < repr[j].str })
+	cnt := 0
+	for pos, v := range repr {
+		if v.idx == pos+1 {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsF()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+	}
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveF(tc)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", i+1, exp, val)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1870-1879/1870/verifierG.go
+++ b/1000-1999/1800-1899/1870-1879/1870/verifierG.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+)
+
+type testCaseG struct {
+	n int
+	a []int
+}
+
+func genTestsG() []testCaseG {
+	rng := rand.New(rand.NewSource(48))
+	tests := make([]testCaseG, 100)
+	for i := range tests {
+		n := rng.Intn(4) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rng.Intn(6)
+		}
+		tests[i] = testCaseG{n, a}
+	}
+	return tests
+}
+
+func mex(arr []int) int {
+	exists := make(map[int]bool)
+	for _, v := range arr {
+		exists[v] = true
+	}
+	m := 0
+	for exists[m] {
+		m++
+	}
+	return m
+}
+
+func encode(arr []int) string {
+	b := make([]byte, 0, len(arr)*4)
+	for i, v := range arr {
+		if i > 0 {
+			b = append(b, ',')
+		}
+		b = append(b, []byte(fmt.Sprintf("%d", v))...)
+	}
+	return string(b)
+}
+
+func f(arr []int) int {
+	sort.Ints(arr)
+	best := -1
+	type node []int
+	q := []node{append([]int{}, arr...)}
+	seen := map[string]bool{}
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		if len(cur) == 1 {
+			if cur[0] > best {
+				best = cur[0]
+			}
+			continue
+		}
+		key := encode(cur)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		n := len(cur)
+		// enumerate subsets by mask
+		for mask := 1; mask < (1 << n); mask++ {
+			subset := []int{}
+			rest := []int{}
+			for i := 0; i < n; i++ {
+				if mask&(1<<i) != 0 {
+					subset = append(subset, cur[i])
+				} else {
+					rest = append(rest, cur[i])
+				}
+			}
+			m := mex(subset)
+			next := append(rest, m)
+			sort.Ints(next)
+			q = append(q, next)
+		}
+	}
+	return best
+}
+
+func solveG(tc testCaseG) []int {
+	res := make([]int, tc.n)
+	for i := 1; i <= tc.n; i++ {
+		res[i-1] = f(tc.a[:i])
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsG()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+	expected := make([][]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveG(tc)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for idx, exp := range expected {
+		for j := 0; j < len(exp); j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			if val != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d element %d: expected %d got %d\n", idx+1, j+1, exp[j], val)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1800-1899/1870-1879/1870/verifierH.go
+++ b/1000-1999/1800-1899/1870-1879/1870/verifierH.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type Edge struct {
+	to int
+	w  int
+}
+
+type Item struct {
+	node int
+	dist int64
+}
+
+type PriorityQueue []Item
+
+func (pq PriorityQueue) Len() int            { return len(pq) }
+func (pq PriorityQueue) Less(i, j int) bool  { return pq[i].dist < pq[j].dist }
+func (pq PriorityQueue) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PriorityQueue) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[:n-1]
+	return item
+}
+
+const INF int64 = 1 << 60
+
+func dijkstra(n int, revAdj [][]Edge, highlighted []bool) []int64 {
+	dist := make([]int64, n)
+	for i := range dist {
+		dist[i] = INF
+	}
+	pq := &PriorityQueue{}
+	heap.Init(pq)
+	for i, hl := range highlighted {
+		if hl {
+			dist[i] = 0
+			heap.Push(pq, Item{i, 0})
+		}
+	}
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(Item)
+		if it.dist != dist[it.node] {
+			continue
+		}
+		u := it.node
+		for _, e := range revAdj[u] {
+			v := e.to
+			nd := it.dist + int64(e.w)
+			if nd < dist[v] {
+				dist[v] = nd
+				heap.Push(pq, Item{v, nd})
+			}
+		}
+	}
+	return dist
+}
+
+func computeCost(n int, adj, revAdj [][]Edge, highlighted []bool) int64 {
+	any := false
+	for _, hl := range highlighted {
+		if hl {
+			any = true
+			break
+		}
+	}
+	if !any {
+		return -1
+	}
+	dist := dijkstra(n, revAdj, highlighted)
+	cost := int64(0)
+	for i := 0; i < n; i++ {
+		if highlighted[i] {
+			continue
+		}
+		if dist[i] == INF {
+			return -1
+		}
+		best := int64(INF)
+		for _, e := range adj[i] {
+			if dist[e.to]+int64(e.w) == dist[i] {
+				if int64(e.w) < best {
+					best = int64(e.w)
+				}
+			}
+		}
+		if best == INF {
+			return -1
+		}
+		cost += best
+	}
+	return cost
+}
+
+type testCaseH struct {
+	n     int
+	m     int
+	q     int
+	edges [][3]int
+	ops   []struct {
+		add bool
+		v   int
+	}
+}
+
+func genTestsH() []testCaseH {
+	rng := rand.New(rand.NewSource(49))
+	tests := make([]testCaseH, 100)
+	for i := range tests {
+		n := rng.Intn(4) + 3
+		m := rng.Intn(5) + 1
+		q := rng.Intn(4) + 1
+		edges := make([][3]int, m)
+		for j := 0; j < m; j++ {
+			u := rng.Intn(n)
+			v := rng.Intn(n)
+			for v == u {
+				v = rng.Intn(n)
+			}
+			w := rng.Intn(10) + 1
+			edges[j] = [3]int{u, v, w}
+		}
+		ops := make([]struct {
+			add bool
+			v   int
+		}, q)
+		highlighted := make([]bool, n)
+		for j := 0; j < q; j++ {
+			if rng.Intn(2) == 0 {
+				// add
+				v := rng.Intn(n)
+				for highlighted[v] {
+					v = rng.Intn(n)
+				}
+				highlighted[v] = true
+				ops[j] = struct {
+					add bool
+					v   int
+				}{true, v}
+			} else {
+				// remove; ensure at least one highlighted
+				v := rng.Intn(n)
+				if !highlighted[v] {
+					highlighted[v] = true
+					ops[j] = struct {
+						add bool
+						v   int
+					}{true, v}
+				} else {
+					ops[j] = struct {
+						add bool
+						v   int
+					}{false, v}
+					highlighted[v] = false
+				}
+			}
+		}
+		tests[i] = testCaseH{n, m, q, edges, ops}
+	}
+	return tests
+}
+
+func solveH(tc testCaseH) []int64 {
+	adj := make([][]Edge, tc.n)
+	rev := make([][]Edge, tc.n)
+	for _, e := range tc.edges {
+		u, v, w := e[0], e[1], e[2]
+		adj[u] = append(adj[u], Edge{v, w})
+		rev[v] = append(rev[v], Edge{u, w})
+	}
+	highlighted := make([]bool, tc.n)
+	res := make([]int64, tc.q)
+	for i, op := range tc.ops {
+		if op.add {
+			highlighted[op.v] = true
+		} else {
+			highlighted[op.v] = false
+		}
+		res[i] = computeCost(tc.n, adj, rev, highlighted)
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsH()
+	for idx, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d %d\n", tc.n, tc.m, tc.q)
+		for _, e := range tc.edges {
+			fmt.Fprintf(&input, "%d %d %d\n", e[0]+1, e[1]+1, e[2])
+		}
+		for _, op := range tc.ops {
+			if op.add {
+				fmt.Fprintf(&input, "+ %d\n", op.v+1)
+			} else {
+				fmt.Fprintf(&input, "- %d\n", op.v+1)
+			}
+		}
+		expected := solveH(tc)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\noutput:\n%s\n", idx+1, err, out.String())
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+		scanner.Split(bufio.ScanWords)
+		for j, exp := range expected {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "case %d wrong output format\n", idx+1)
+				os.Exit(1)
+			}
+			val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d non-integer output\n", idx+1)
+				os.Exit(1)
+			}
+			if val != exp {
+				fmt.Fprintf(os.Stderr, "case %d query %d: expected %d got %d\n", idx+1, j+1, exp, val)
+				os.Exit(1)
+			}
+		}
+		if scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "case %d extra output\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest 1870
- each verifier generates 100 random tests and checks a provided binary
- verifiers implement reference solutions or brute force for expected results

## Testing
- `go build verifierA.go` (and similarly for B–H)
- `go run verifierA.go ./a.out` with binary from 1870A.go

------
https://chatgpt.com/codex/tasks/task_e_688779f7c14c8324a6acaf5640257153