### PR TITLE
Add verifiers for Codeforces contest 1872

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1872/verifierA.go
+++ b/1000-1999/1800-1899/1870-1879/1872/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1872A.go")
+	out := filepath.Join(os.TempDir(), "refA.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if outb, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, outb)
+	}
+	return out, nil
+}
+
+func prepareBin(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		out := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", out, path)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s failed: %v\n%s", path, err, outb)
+		}
+		return out, nil
+	}
+	return path, nil
+}
+
+func runBin(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	t := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		a := rand.Intn(100) + 1
+		b := rand.Intn(100) + 1
+		c := rand.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, c))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand, err := prepareBin(os.Args[1], "candA")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := runBin(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1872/verifierB.go
+++ b/1000-1999/1800-1899/1870-1879/1872/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1872B.go")
+	out := filepath.Join(os.TempDir(), "refB.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if outb, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, outb)
+	}
+	return out, nil
+}
+
+func prepareBin(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		out := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", out, path)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s failed: %v\n%s", path, err, outb)
+		}
+		return out, nil
+	}
+	return path, nil
+}
+
+func runBin(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	t := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := rand.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			d := rand.Intn(200) + 1
+			s := rand.Intn(200) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", d, s))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	cand, err := prepareBin(os.Args[1], "candB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := runBin(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1872/verifierC.go
+++ b/1000-1999/1800-1899/1870-1879/1872/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1872C.go")
+	out := filepath.Join(os.TempDir(), "refC.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if outb, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, outb)
+	}
+	return out, nil
+}
+
+func prepareBin(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		out := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", out, path)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s failed: %v\n%s", path, err, outb)
+		}
+		return out, nil
+	}
+	return path, nil
+}
+
+func runBin(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	t := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		l := rand.Intn(100000-2) + 1
+		r := l + rand.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand, err := prepareBin(os.Args[1], "candC")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := runBin(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1872/verifierD.go
+++ b/1000-1999/1800-1899/1870-1879/1872/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1872D.go")
+	out := filepath.Join(os.TempDir(), "refD.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if outb, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, outb)
+	}
+	return out, nil
+}
+
+func prepareBin(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		out := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", out, path)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s failed: %v\n%s", path, err, outb)
+		}
+		return out, nil
+	}
+	return path, nil
+}
+
+func runBin(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	t := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Int63n(1e6) + 1
+		x := rand.Int63n(1e6) + 1
+		y := rand.Int63n(1e6) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x, y))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand, err := prepareBin(os.Args[1], "candD")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := runBin(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1872/verifierE.go
+++ b/1000-1999/1800-1899/1870-1879/1872/verifierE.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1872E.go")
+	out := filepath.Join(os.TempDir(), "refE.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if outb, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, outb)
+	}
+	return out, nil
+}
+
+func prepareBin(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		out := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", out, path)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s failed: %v\n%s", path, err, outb)
+		}
+		return out, nil
+	}
+	return path, nil
+}
+
+func runBin(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := rand.Intn(6) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(100)))
+		}
+		sb.WriteByte('\n')
+		var s strings.Builder
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				s.WriteByte('0')
+			} else {
+				s.WriteByte('1')
+			}
+		}
+		sb.WriteString(s.String())
+		sb.WriteByte('\n')
+		q := rand.Intn(6) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", q))
+		has := false
+		for i := 0; i < q; i++ {
+			tp := rand.Intn(2) + 1
+			if i == q-1 && !has {
+				tp = 2
+			}
+			if tp == 1 {
+				l := rand.Intn(n) + 1
+				r := rand.Intn(n-l+1) + l
+				sb.WriteString(fmt.Sprintf("1 %d %d\n", l, r))
+			} else {
+				g := rand.Intn(2)
+				sb.WriteString(fmt.Sprintf("2 %d\n", g))
+				has = true
+			}
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	cand, err := prepareBin(os.Args[1], "candE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := runBin(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1872/verifierF.go
+++ b/1000-1999/1800-1899/1870-1879/1872/verifierF.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1872F.go")
+	out := filepath.Join(os.TempDir(), "refF.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if outb, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, outb)
+	}
+	return out, nil
+}
+
+func prepareBin(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		out := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", out, path)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s failed: %v\n%s", path, err, outb)
+		}
+		return out, nil
+	}
+	return path, nil
+}
+
+func runBin(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := rand.Intn(6) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(n)+1))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(100)+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	cand, err := prepareBin(os.Args[1], "candF")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := runBin(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1872/verifierG.go
+++ b/1000-1999/1800-1899/1870-1879/1872/verifierG.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1872G.go")
+	out := filepath.Join(os.TempDir(), "refG.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if outb, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, outb)
+	}
+	return out, nil
+}
+
+func prepareBin(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		out := filepath.Join(os.TempDir(), tag+fmt.Sprint(time.Now().UnixNano()))
+		cmd := exec.Command("go", "build", "-o", out, path)
+		if outb, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s failed: %v\n%s", path, err, outb)
+		}
+		return out, nil
+	}
+	return path, nil
+}
+
+func runBin(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := rand.Intn(8) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(3)+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	cand, err := prepareBin(os.Args[1], "candG")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := runBin(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1872 problems A-G
- verifiers generate random test cases and compare candidate binaries to reference solutions

## Testing
- `go run 1000-1999/1800-1899/1870-1879/1872/verifierA.go /tmp/1872A_bin`
- `go run 1000-1999/1800-1899/1870-1879/1872/verifierB.go /tmp/1872B_bin`
- `go run 1000-1999/1800-1899/1870-1879/1872/verifierC.go /tmp/1872C_bin`

------
https://chatgpt.com/codex/tasks/task_e_68877a83d2208324be69f6b5265a095c