### PR TITLE
Add Go verifiers for CF contest 1881

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1881/verifierA.go
+++ b/1000-1999/1800-1899/1880-1889/1881/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1881A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randString(n int) string {
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func genTests() []Test {
+	rand.Seed(1)
+	tests := make([]Test, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(5) + 1
+		for n*m > 25 {
+			n = rand.Intn(5) + 1
+			m = rand.Intn(5) + 1
+		}
+		x := randString(n)
+		s := randString(m)
+		input := fmt.Sprintf("1\n%d %d\n%s\n%s\n", n, m, x, s)
+		tests = append(tests, Test{input})
+	}
+	tests = append(tests, Test{"1\n1 1\na\na\n"})
+	tests = append(tests, Test{"1\n1 2\na\nab\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1881/verifierB.go
+++ b/1000-1999/1800-1899/1880-1889/1881/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1881B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(2)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		a := rand.Intn(1000) + 1
+		b := rand.Intn(1000) + 1
+		c := rand.Intn(1000) + 1
+		input := fmt.Sprintf("1\n%d %d %d\n", a, b, c)
+		tests = append(tests, Test{input})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1881/verifierC.go
+++ b/1000-1999/1800-1899/1880-1889/1881/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1881C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randString(n int) string {
+	letters := []byte("abcde")
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func genTests() []Test {
+	rand.Seed(3)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			sb.WriteString(randString(n))
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1881/verifierD.go
+++ b/1000-1999/1800-1899/1880-1889/1881/verifierD.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1881D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(4)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rand.Intn(100) + 1
+			sb.WriteString(fmt.Sprint(val))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1881/verifierE.go
+++ b/1000-1999/1800-1899/1880-1889/1881/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1881E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(5)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rand.Intn(n) + 1
+			sb.WriteString(fmt.Sprint(val))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1881/verifierF.go
+++ b/1000-1999/1800-1899/1880-1889/1881/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1881F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTree(n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	perm := rand.Perm(n)
+	for i := 1; i < n; i++ {
+		u := perm[i]
+		v := perm[rand.Intn(i)]
+		edges = append(edges, [2]int{u + 1, v + 1})
+	}
+	return edges
+}
+
+func genTests() []Test {
+	rand.Seed(6)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 2
+		k := rand.Intn(n) + 1
+		marks := rand.Perm(n)[:k]
+		edges := genTree(n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for j, m := range marks {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(m + 1))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1881/verifierG.go
+++ b/1000-1999/1800-1899/1880-1889/1881/verifierG.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1881G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randString(n int) string {
+	letters := []byte("abc")
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func genTests() []Test {
+	rand.Seed(7)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(6) + 1
+		m := rand.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		sb.WriteString(randString(n) + "\n")
+		for j := 0; j < m; j++ {
+			if rand.Intn(2) == 0 {
+				l := rand.Intn(n) + 1
+				r := rand.Intn(n-l+1) + l
+				x := rand.Intn(26)
+				sb.WriteString(fmt.Sprintf("1 %d %d %d\n", l, r, x))
+			} else {
+				l := rand.Intn(n) + 1
+				r := rand.Intn(n-l+1) + l
+				sb.WriteString(fmt.Sprintf("2 %d %d\n", l, r))
+			}
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G of contest 1881
- verifiers compile a reference solution and run >100 randomized tests

## Testing
- `go run verifierA.go ./candidateA.bin`
- `go run verifierB.go ./candidateB.bin`
- `go run verifierC.go ./candidateC.bin`
- `go run verifierD.go ./candidateD.bin`
- `go run verifierE.go ./candidateE.bin`
- `go run verifierF.go ./candidateF.bin`
- `go run verifierG.go ./candidateG.bin`


------
https://chatgpt.com/codex/tasks/task_e_68877cfc975083248efd746a59808d73