### PR TITLE
Add verifiers for contest 1883

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1883/verifierA.go
+++ b/1000-1999/1800-1899/1880-1889/1883/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(pin string) string {
+	pos := 1
+	ans := 0
+	for _, ch := range pin {
+		d := int(ch - '0')
+		if d > pos {
+			ans += d - pos
+		} else {
+			ans += pos - d
+		}
+		ans++
+		pos = d
+	}
+	return fmt.Sprint(ans)
+}
+
+func runCase(bin, pin string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("1\n%s\n", pin))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCase(pin)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) string {
+	b := make([]byte, 4)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{"0000", "9999", "1234", "4321"}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for idx, pin := range cases {
+		if err := runCase(bin, pin); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %s\n", idx+1, err, pin)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1883/verifierB.go
+++ b/1000-1999/1800-1899/1880-1889/1883/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n int
+	k int
+	s string
+}
+
+func solveCaseB(tc testCaseB) string {
+	cnt := make([]int, 26)
+	for i := 0; i < tc.n; i++ {
+		cnt[tc.s[i]-'a']++
+	}
+	pairs := 0
+	for _, c := range cnt {
+		pairs += c / 2
+	}
+	remaining := tc.n - tc.k
+	if pairs >= remaining/2 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runCaseB(bin string, tc testCaseB) error {
+	input := fmt.Sprintf("1\n%d %d\n%s\n", tc.n, tc.k, tc.s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCaseB(tc)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCaseB(rng *rand.Rand) testCaseB {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return testCaseB{n: n, k: k, s: string(b)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseB{{n: 4, k: 1, s: "aaaa"}, {n: 3, k: 2, s: "abc"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCaseB(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCaseB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %v\n", idx+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1883/verifierC.go
+++ b/1000-1999/1800-1899/1880-1889/1883/verifierC.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	n int
+	k int
+	a []int
+}
+
+func solveCaseC(tc testCaseC) string {
+	ans := 0
+	switch tc.k {
+	case 2:
+		ans = 1
+		for _, v := range tc.a {
+			if v%2 == 0 {
+				ans = 0
+				break
+			}
+		}
+	case 3:
+		ans = 2
+		for _, v := range tc.a {
+			d := (3 - v%3) % 3
+			if d < ans {
+				ans = d
+				if ans == 0 {
+					break
+				}
+			}
+		}
+	case 4:
+		twos := 0
+		for _, v := range tc.a {
+			x := v
+			for x%2 == 0 {
+				twos++
+				x /= 2
+				if twos >= 2 {
+					break
+				}
+			}
+			if twos >= 2 {
+				break
+			}
+		}
+		if twos >= 2 {
+			ans = 0
+			break
+		}
+		best4 := int(1e9)
+		min1, min2 := int(1e9), int(1e9)
+		for _, v := range tc.a {
+			c4 := (4 - v%4) % 4
+			if c4 < best4 {
+				best4 = c4
+			}
+			ce := 0
+			if v%2 != 0 {
+				ce = 1
+			}
+			if ce < min1 {
+				min2 = min1
+				min1 = ce
+			} else if ce < min2 {
+				min2 = ce
+			}
+		}
+		if min2 == int(1e9) {
+			min2 = 0
+		}
+		if best4 < min1+min2 {
+			ans = best4
+		} else {
+			ans = min1 + min2
+		}
+	case 5:
+		ans = 4
+		for _, v := range tc.a {
+			d := (5 - v%5) % 5
+			if d < ans {
+				ans = d
+				if ans == 0 {
+					break
+				}
+			}
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func runCaseC(bin string, tc testCaseC) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCaseC(tc)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCaseC(rng *rand.Rand) testCaseC {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(4) + 2 // 2..5
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(10) + 1
+	}
+	return testCaseC{n: n, k: k, a: a}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseC{{n: 1, k: 2, a: []int{1}}, {n: 3, k: 4, a: []int{2, 3, 4}}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCaseC(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1883/verifierD.go
+++ b/1000-1999/1800-1899/1880-1889/1883/verifierD.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type opD struct {
+	add bool
+	l   int
+	r   int
+}
+
+type MaxHeap struct{ sort.IntSlice }
+
+func (h MaxHeap) Less(i, j int) bool  { return h.IntSlice[i] > h.IntSlice[j] }
+func (h *MaxHeap) Push(x interface{}) { h.IntSlice = append(h.IntSlice, x.(int)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := h.IntSlice
+	x := old[len(old)-1]
+	h.IntSlice = old[:len(old)-1]
+	return x
+}
+func (h *MaxHeap) Peek() int { return h.IntSlice[0] }
+
+type MinHeap struct{ sort.IntSlice }
+
+func (h *MinHeap) Push(x interface{}) { h.IntSlice = append(h.IntSlice, x.(int)) }
+func (h *MinHeap) Pop() interface{} {
+	old := h.IntSlice
+	x := old[len(old)-1]
+	h.IntSlice = old[:len(old)-1]
+	return x
+}
+func (h *MinHeap) Peek() int { return h.IntSlice[0] }
+
+func solveCaseD(ops []opD) []string {
+	lcnt := make(map[int]int)
+	rcnt := make(map[int]int)
+	var lMax MaxHeap
+	var rMin MinHeap
+	heap.Init(&lMax)
+	heap.Init(&rMin)
+	segments := 0
+	res := make([]string, len(ops))
+	for i, op := range ops {
+		if op.add {
+			heap.Push(&lMax, op.l)
+			heap.Push(&rMin, op.r)
+			lcnt[op.l]++
+			rcnt[op.r]++
+			segments++
+		} else {
+			lcnt[op.l]--
+			if lcnt[op.l] == 0 {
+				delete(lcnt, op.l)
+			}
+			rcnt[op.r]--
+			if rcnt[op.r] == 0 {
+				delete(rcnt, op.r)
+			}
+			segments--
+		}
+		for lMax.Len() > 0 {
+			top := lMax.Peek()
+			if lcnt[top] == 0 {
+				heap.Pop(&lMax)
+			} else {
+				break
+			}
+		}
+		for rMin.Len() > 0 {
+			top := rMin.Peek()
+			if rcnt[top] == 0 {
+				heap.Pop(&rMin)
+			} else {
+				break
+			}
+		}
+		if segments >= 2 && lMax.Peek() > rMin.Peek() {
+			res[i] = "YES"
+		} else {
+			res[i] = "NO"
+		}
+	}
+	return res
+}
+
+func runCaseD(bin string, ops []opD) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(ops)))
+	for _, op := range ops {
+		if op.add {
+			sb.WriteString(fmt.Sprintf("+ %d %d\n", op.l, op.r))
+		} else {
+			sb.WriteString(fmt.Sprintf("- %d %d\n", op.l, op.r))
+		}
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := strings.Fields(strings.TrimSpace(out.String()))
+	exp := solveCaseD(ops)
+	if len(gotLines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(gotLines))
+	}
+	for i := range exp {
+		if strings.ToUpper(gotLines[i]) != exp[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, exp[i], gotLines[i])
+		}
+	}
+	return nil
+}
+
+func randomCaseD(rng *rand.Rand) []opD {
+	q := rng.Intn(10) + 1
+	ops := make([]opD, 0, q)
+	active := make([]opD, 0)
+	for len(ops) < q {
+		if len(active) == 0 || rng.Intn(2) == 0 {
+			l := rng.Intn(20)
+			r := l + rng.Intn(20)
+			op := opD{add: true, l: l, r: r}
+			active = append(active, op)
+			ops = append(ops, op)
+		} else {
+			idx := rng.Intn(len(active))
+			op := active[idx]
+			active = append(active[:idx], active[idx+1:]...)
+			ops = append(ops, opD{add: false, l: op.l, r: op.r})
+		}
+	}
+	return ops
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := [][]opD{{{add: true, l: 1, r: 2}, {add: true, l: 3, r: 4}}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCaseD(rng))
+	}
+	for idx, ops := range cases {
+		if err := runCaseD(bin, ops); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1883/verifierE.go
+++ b/1000-1999/1800-1899/1880-1889/1883/verifierE.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseE struct {
+	n   int
+	arr []int64
+}
+
+func solveCaseE(tc testCaseE) string {
+	ops := 0
+	prev := tc.arr[0]
+	for i := 1; i < tc.n; i++ {
+		cur := tc.arr[i]
+		for cur < prev {
+			cur <<= 1
+			ops++
+		}
+		prev = cur
+	}
+	return fmt.Sprint(ops)
+}
+
+func runCaseE(bin string, tc testCaseE) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCaseE(tc)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCaseE(rng *rand.Rand) testCaseE {
+	n := rng.Intn(8) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rng.Intn(20) + 1)
+	}
+	return testCaseE{n: n, arr: arr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseE{{n: 1, arr: []int64{1}}, {n: 2, arr: []int64{5, 1}}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCaseE(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1883/verifierF.go
+++ b/1000-1999/1800-1899/1880-1889/1883/verifierF.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseF struct {
+	n int
+	a []int
+}
+
+func solveCaseF(tc testCaseF) string {
+	n := tc.n
+	a := tc.a
+	first := make([]bool, n)
+	seen := make(map[int]struct{})
+	for i, v := range a {
+		if _, ok := seen[v]; !ok {
+			first[i] = true
+			seen[v] = struct{}{}
+		}
+	}
+	last := make([]bool, n)
+	seen = make(map[int]struct{})
+	for i := n - 1; i >= 0; i-- {
+		v := a[i]
+		if _, ok := seen[v]; !ok {
+			last[i] = true
+			seen[v] = struct{}{}
+		}
+	}
+	suf := make([]int, n+1)
+	for i := n - 1; i >= 0; i-- {
+		if last[i] {
+			suf[i] = suf[i+1] + 1
+		} else {
+			suf[i] = suf[i+1]
+		}
+	}
+	var ans int64
+	for i := 0; i < n; i++ {
+		if first[i] {
+			ans += int64(suf[i])
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func runCaseF(bin string, tc testCaseF) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCaseF(tc)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCaseF(rng *rand.Rand) testCaseF {
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(10) + 1
+	}
+	return testCaseF{n: n, a: arr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseF{{n: 1, a: []int{1}}, {n: 3, a: []int{1, 2, 1}}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCaseF(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCaseF(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1883/verifierG1.go
+++ b/1000-1999/1800-1899/1880-1889/1883/verifierG1.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseG1 struct {
+	n int
+	m int
+	a []int
+	b []int
+}
+
+func solveCaseG1(tc testCaseG1) string {
+	n := tc.n
+	a := append([]int{1}, tc.a...)
+	b := append([]int(nil), tc.b...)
+	sort.Ints(a)
+	sort.Ints(b)
+	j := 0
+	match := 0
+	for _, x := range a {
+		for j < n && b[j] <= x {
+			j++
+		}
+		if j == n {
+			break
+		}
+		match++
+		j++
+	}
+	return fmt.Sprint(n - match)
+}
+
+func runCaseG1(bin string, tc testCaseG1) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCaseG1(tc)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCaseG1(rng *rand.Rand) testCaseG1 {
+	n := rng.Intn(6) + 2
+	m := 1
+	a := make([]int, n-1)
+	for i := range a {
+		a[i] = rng.Intn(10) + 1
+	}
+	b := make([]int, n)
+	for i := range b {
+		b[i] = rng.Intn(15) + 1
+	}
+	return testCaseG1{n: n, m: m, a: a, b: b}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseG1{{n: 2, m: 1, a: []int{2}, b: []int{3, 4}}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCaseG1(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCaseG1(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1883/verifierG2.go
+++ b/1000-1999/1800-1899/1880-1889/1883/verifierG2.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseG2 struct {
+	n int
+	m int
+	a []int
+	b []int
+}
+
+func solveCaseG2(tc testCaseG2) string {
+	n := tc.n
+	a := append([]int(nil), tc.a...)
+	b := append([]int(nil), tc.b...)
+	sort.Ints(a)
+	sort.Ints(b)
+	pre := make([]int, n)
+	for j := 0; j < n; j++ {
+		pre[j] = sort.SearchInts(a, b[j])
+	}
+	hist := make([]int, n+1)
+	used := 0
+	for j := 0; j < n; j++ {
+		if pre[j] > used {
+			used++
+		}
+		hist[j+1] = used
+	}
+	k0 := hist[n]
+	good := make([]int, n+1)
+	exist := false
+	for p := n; p >= 0; p-- {
+		if p < n && pre[p] == hist[p] {
+			exist = true
+		}
+		if exist {
+			good[p] = 1
+		}
+	}
+	counts := make([]int64, n+1)
+	prev := 1
+	for p := 0; p < n; p++ {
+		nxt := tc.m
+		if b[p]-1 < tc.m {
+			nxt = b[p] - 1
+		}
+		if nxt >= prev {
+			counts[p] = int64(nxt - prev + 1)
+		}
+		if b[p] > prev {
+			prev = b[p]
+		}
+	}
+	if prev <= tc.m {
+		counts[n] = int64(tc.m - prev + 1)
+	}
+	var ans int64
+	for p := 0; p <= n; p++ {
+		if counts[p] > 0 {
+			k := k0 + good[p]
+			ops := n - k
+			ans += counts[p] * int64(ops)
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func runCaseG2(bin string, tc testCaseG2) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCaseG2(tc)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCaseG2(rng *rand.Rand) testCaseG2 {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(10) + 1
+	a := make([]int, n-1)
+	for i := range a {
+		a[i] = rng.Intn(m) + 1
+	}
+	b := make([]int, n)
+	for i := range b {
+		b[i] = rng.Intn(m) + 1
+	}
+	return testCaseG2{n: n, m: m, a: a, b: b}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCaseG2{{n: 2, m: 1, a: []int{1}, b: []int{1, 1}}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCaseG2(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCaseG2(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G2 of contest 1883
- each verifier runs over 100 randomized test cases

## Testing
- `gofmt -w verifier*.go`
- `git commit`

------
https://chatgpt.com/codex/tasks/task_e_68877d86a3748324bad465c102878f10