### PR TITLE
Add Go verifiers for Codeforces contest 1882

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1882/verifierA.go
+++ b/1000-1999/1800-1899/1880-1889/1882/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(a []int) string {
+	cur := 1
+	for _, x := range a {
+		if cur == x {
+			cur++
+		}
+		cur++
+	}
+	return fmt.Sprintf("%d", cur-1)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(1_000_000_000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(a)
+}
+
+func fixedCases() [][2]string {
+	return [][2]string{
+		{"1\n1\n1\n", "2"},
+		{"1\n1\n2\n", "1"},
+		{"1\n5\n1 2 3 4 5\n", "6"},
+		{"1\n3\n1 2 4\n", "5"},
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for idx, tc := range fixedCases() {
+		out, err := runCandidate(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if out != tc[1] {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1882/verifierB.go
+++ b/1000-1999/1800-1899/1880-1889/1882/verifierB.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(sets []uint64) string {
+	var all uint64
+	for _, m := range sets {
+		all |= m
+	}
+	ans := 0
+	for e := 0; e < 50; e++ {
+		if all&(1<<uint(e)) == 0 {
+			continue
+		}
+		var u uint64
+		for _, m := range sets {
+			if m&(1<<uint(e)) == 0 {
+				u |= m
+			}
+		}
+		cnt := bits.OnesCount64(u)
+		if cnt > ans {
+			ans = cnt
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	sets := make([]uint64, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		k := rng.Intn(6) + 1
+		var mask uint64
+		elems := make([]int, 0, k)
+		for len(elems) < k {
+			x := rng.Intn(50) + 1
+			dup := false
+			for _, v := range elems {
+				if v == x {
+					dup = true
+					break
+				}
+			}
+			if dup {
+				continue
+			}
+			elems = append(elems, x)
+			mask |= 1 << uint(x-1)
+		}
+		sets[i] = mask
+		sb.WriteString(fmt.Sprintf("%d", k))
+		for _, v := range elems {
+			sb.WriteString(fmt.Sprintf(" %d", v))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), solveCase(sets)
+}
+
+func fixedCases() [][2]string {
+	return [][2]string{
+		{"1\n1\n1 1\n", "0"},
+		{"1\n2\n1 1\n1 2\n", "1"},
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for idx, tc := range fixedCases() {
+		out, err := runCandidate(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if out != tc[1] {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1882/verifierC.go
+++ b/1000-1999/1800-1899/1880-1889/1882/verifierC.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type MinHeap []int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MinHeap) Pop() interface{} {
+	old := *h
+	x := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return x
+}
+
+func solveCase(arr []int) string {
+	h := &MinHeap{}
+	heap.Init(h)
+	posOdd := 0
+	var score int64
+	for i, v := range arr {
+		if i%2 == 0 { // odd index (1-based)
+			if v >= 0 {
+				score += int64(v)
+				posOdd++
+			} else {
+				heap.Push(h, -v)
+			}
+		} else {
+			if v > 0 {
+				if posOdd > 0 {
+					score += int64(v)
+					posOdd--
+				} else if h.Len() > 0 && v > (*h)[0] {
+					score += int64(v - (*h)[0])
+					heap.Pop(h)
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d", score)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(21) - 10
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveCase(arr)
+}
+
+func fixedCases() [][2]string {
+	return [][2]string{
+		{"1\n1\n5\n", "5"},
+		{"1\n3\n1 -2 3\n", "4"},
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for idx, tc := range fixedCases() {
+		out, err := runCandidate(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if out != tc[1] {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1882/verifierD.go
+++ b/1000-1999/1800-1899/1880-1889/1882/verifierD.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, a []int, edges [][2]int) string {
+	g := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	parent := make([]int, n+1)
+	size := make([]int, n+1)
+	order := make([]int, 0, n)
+	stack := []int{1}
+	parent[1] = 0
+	for len(stack) > 0 {
+		u := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, u)
+		for _, v := range g[u] {
+			if v != parent[u] {
+				parent[v] = u
+				stack = append(stack, v)
+			}
+		}
+	}
+	base := int64(0)
+	for i := len(order) - 1; i >= 0; i-- {
+		u := order[i]
+		size[u] = 1
+		for _, v := range g[u] {
+			if v != parent[u] {
+				size[u] += size[v]
+				base += int64(size[v]) * int64(a[u]^a[v])
+			}
+		}
+	}
+	cost := make([]int64, n+1)
+	cost[1] = base
+	queue := []int{1}
+	for len(queue) > 0 {
+		u := queue[0]
+		queue = queue[1:]
+		for _, v := range g[u] {
+			if v == parent[u] {
+				continue
+			}
+			w := a[u] ^ a[v]
+			cost[v] = cost[u] + int64(n-2*size[v])*int64(w)
+			queue = append(queue, v)
+		}
+	}
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", cost[i]))
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = rng.Intn(32)
+	}
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String(), solveCase(n, a, edges)
+}
+
+func fixedCases() [][2]string {
+	// small tree example
+	return [][2]string{
+		{"1\n1\n5\n", "0"},
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for idx, tc := range fixedCases() {
+		out, err := runCandidate(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if out != tc[1] {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1882/verifierE1.go
+++ b/1000-1999/1800-1899/1880-1889/1882/verifierE1.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func readInt(reader *bufio.Reader) (int, error) {
+	x := 0
+	sign := 1
+	b, err := reader.ReadByte()
+	for err == nil && (b == ' ' || b == '\n' || b == '\r' || b == '\t') {
+		b, err = reader.ReadByte()
+	}
+	if err != nil {
+		return 0, err
+	}
+	if b == '-' {
+		sign = -1
+		b, err = reader.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+	}
+	for b >= '0' && b <= '9' {
+		x = x*10 + int(b-'0')
+		b, err = reader.ReadByte()
+		if err != nil {
+			break
+		}
+	}
+	return x * sign, nil
+}
+
+func solvePerm(n int, a []int) []int {
+	var ops []int
+	for i := 1; i <= n; i++ {
+		for j := i; j <= n; j++ {
+			if a[j] == i {
+				if j != i {
+					ops = append(ops, i, j-i, n-j+1)
+				}
+				a[i], a[j] = a[j], a[i]
+				break
+			}
+		}
+	}
+	return ops
+}
+
+func expectedOutput(n, m int, a, b []int) string {
+	opa := solvePerm(n, append([]int(nil), a...))
+	opb := solvePerm(m, append([]int(nil), b...))
+	la, lb := len(opa), len(opb)
+	if (la+lb)%2 == 1 {
+		if n%2 == 1 {
+			for i := 0; i < n; i++ {
+				opa = append(opa, n)
+			}
+		} else if m%2 == 1 {
+			for i := 0; i < m; i++ {
+				opb = append(opb, m)
+			}
+		} else {
+			return "-1"
+		}
+		la, lb = len(opa), len(opb)
+	}
+	for la < lb {
+		opa = append(opa, 1, n)
+		la += 2
+	}
+	for lb < la {
+		opb = append(opb, 1, m)
+		lb += 2
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", la))
+	for i := 0; i < la; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", opa[i], opb[i]))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	p := rng.Perm(n)
+	q := rng.Perm(m)
+	a := make([]int, n+1)
+	b := make([]int, m+1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range p {
+		a[i+1] = v + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	for i, v := range q {
+		b[i+1] = v + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	expect := expectedOutput(n, m, a, b)
+	input := sb.String()
+	input = fmt.Sprintf("%s", input)
+	return input, expect
+}
+
+func fixedCases() [][2]string {
+	return [][2]string{
+		{"1 1\n1\n1\n", "0"},
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for idx, tc := range fixedCases() {
+		out, err := runCandidate(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1882/verifierE2.go
+++ b/1000-1999/1800-1899/1880-1889/1882/verifierE2.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func calc(n int, a []int, w int) int {
+	p := make([]int, n+1)
+	vis := make([]bool, n+1)
+	for i := 0; i <= n; i++ {
+		p[i] = (a[i] + w) % (n + 1)
+	}
+	ans := n
+	work(p, vis, 0, true)
+	for i := 1; i <= n; i++ {
+		if p[i] == i {
+			ans--
+		} else if !vis[i] {
+			work(p, vis, i, false)
+			ans++
+		}
+	}
+	return ans
+}
+
+func work(p []int, vis []bool, x int, reset bool) {
+	if reset {
+		for i := range vis {
+			vis[i] = false
+		}
+	}
+	vis[x] = true
+	for y := p[x]; y != x; y = p[y] {
+		vis[y] = true
+	}
+}
+
+func dfs(p []int, v *[]int, x, y int) {
+	if x == y {
+		return
+	}
+	dfs(p, v, p[x], y)
+	*v = append(*v, x-p[x])
+}
+
+func solvePerm(n int, a []int, w int) []int {
+	p := make([]int, n+1)
+	vis := make([]bool, n+1)
+	v := make([]int, 0)
+	for i := 0; i <= n; i++ {
+		p[i] = (a[i] + w) % (n + 1)
+	}
+	cur := 0
+	work(p, vis, 0, true)
+	for i := 1; i <= n; i++ {
+		if p[i] != i && !vis[i] {
+			v = append(v, i-cur)
+			p[cur], p[i] = p[i], p[cur]
+			cur = i
+			work(p, vis, cur, true)
+		}
+	}
+	dfs(p, &v, p[cur], cur)
+	return v
+}
+
+func F(n, x int) int {
+	if x > 0 {
+		return x
+	}
+	return n + 1 + x
+}
+
+func expectedOutput(n, m int, a, b []int) string {
+	f1 := make([]int, n+1)
+	f2 := make([]int, m+1)
+	for i := 0; i <= n; i++ {
+		f1[i] = calc(n, a, i)
+	}
+	for j := 0; j <= m; j++ {
+		f2[j] = calc(m, b, j)
+	}
+	ans := 1<<31 - 1
+	bi, bj := -1, -1
+	for i := 0; i <= n; i++ {
+		for j := 0; j <= m; j++ {
+			if (f1[i]^f2[j])%2 == 0 {
+				mx := f1[i]
+				if f2[j] > mx {
+					mx = f2[j]
+				}
+				if mx < ans {
+					ans = mx
+					bi, bj = i, j
+				}
+			}
+		}
+	}
+	if bi < 0 {
+		return "-1"
+	}
+	v1 := solvePerm(n, append([]int(nil), a...), bi)
+	v2 := solvePerm(m, append([]int(nil), b...), bj)
+	for len(v1) < len(v2) {
+		v1 = append(v1, 1, n)
+	}
+	for len(v2) < len(v1) {
+		v2 = append(v2, 1, m)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(v1)))
+	for k := range v1 {
+		sb.WriteString(fmt.Sprintf("%d %d\n", F(n, v1[k]), F(m, v2[k])))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	p := rng.Perm(n)
+	q := rng.Perm(m)
+	a := make([]int, n+1)
+	b := make([]int, m+1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range p {
+		a[i+1] = v + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	for i, v := range q {
+		b[i+1] = v + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	expect := expectedOutput(n, m, a, b)
+	return sb.String(), expect
+}
+
+func fixedCases() [][2]string {
+	return [][2]string{
+		{"1 1\n1\n1\n", "0"},
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for idx, tc := range fixedCases() {
+		out, err := runCandidate(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "fixed case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to check problem A solutions
- add verifierB.go to check problem B solutions
- add verifierC.go to check problem C solutions
- add verifierD.go to check problem D solutions
- add verifierE1.go for problem E1
- add verifierE2.go for problem E2

Each verifier generates 100 random test cases and includes a few fixed edge cases.

## Testing
- `go run verifierA.go ./A`
- `go run verifierB.go ./B`
- `go run verifierC.go ./C`
- `go build verifierD.go`
- `go build verifierE1.go`
- `go build verifierE2.go`


------
https://chatgpt.com/codex/tasks/task_e_68877d404e048324b9be8d1b0e5b18f7