### PR TITLE
Add verifiers for contest 1876

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1876/verifierA.go
+++ b/1000-1999/1800-1899/1870-1879/1876/verifierA.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verif1876A_bin")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracle1876A_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, "1876A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	p := rng.Intn(10) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(3) + 1
+	}
+	for i := 0; i < n; i++ {
+		b[i] = rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, p)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	arg := ""
+	if len(os.Args) == 2 {
+		arg = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		arg = os.Args[2]
+	} else {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(arg)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, cleanO, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanO()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1876/verifierB.go
+++ b/1000-1999/1800-1899/1870-1879/1876/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verif1876B_bin")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracle1876B_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, "1876B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(20)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	arg := ""
+	if len(os.Args) == 2 {
+		arg = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		arg = os.Args[2]
+	} else {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(arg)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, cleanO, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanO()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1876/verifierC.go
+++ b/1000-1999/1800-1899/1870-1879/1876/verifierC.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verif1876C_bin")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracle1876C_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, "1876C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	arg := ""
+	if len(os.Args) == 2 {
+		arg = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		arg = os.Args[2]
+	} else {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(arg)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, cleanO, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanO()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1876/verifierD.go
+++ b/1000-1999/1800-1899/1870-1879/1876/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verif1876D_bin")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracle1876D_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, "1876D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(10) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	arg := ""
+	if len(os.Args) == 2 {
+		arg = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		arg = os.Args[2]
+	} else {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(arg)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, cleanO, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanO()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1876/verifierE.go
+++ b/1000-1999/1800-1899/1870-1879/1876/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verif1876E_bin")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracle1876E_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, "1876E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 2; i <= n; i++ {
+		x := rng.Intn(i-1) + 1
+		y := i
+		t := rng.Intn(2)
+		fmt.Fprintf(&sb, "%d %d %d\n", x, y, t)
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	arg := ""
+	if len(os.Args) == 2 {
+		arg = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		arg = os.Args[2]
+	} else {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(arg)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, cleanO, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanO()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1876/verifierF.go
+++ b/1000-1999/1800-1899/1870-1879/1876/verifierF.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verif1876F_bin")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracle1876F_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, "1876F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 2
+	k := (rng.Intn(n/2) + 1) * 2
+	if k > n {
+		k = n
+		if k%2 == 1 {
+			k--
+		}
+		if k < 2 {
+			k = 2
+		}
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	arg := ""
+	if len(os.Args) == 2 {
+		arg = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		arg = os.Args[2]
+	} else {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(arg)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, cleanO, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanO()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1870-1879/1876/verifierG.go
+++ b/1000-1999/1800-1899/1870-1879/1876/verifierG.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verif1876G_bin")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracle1876G_bin")
+	cmd := exec.Command("go", "build", "-o", tmp, "1876G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = int64(rng.Intn(10) + 1)
+	}
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := l + rng.Intn(n-l+1)
+		x := rng.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", l, r, x)
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	arg := ""
+	if len(os.Args) == 2 {
+		arg = os.Args[1]
+	} else if len(os.Args) == 3 && os.Args[1] == "--" {
+		arg = os.Args[2]
+	} else {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin, clean, err := prepareBinary(arg)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if clean != nil {
+		defer clean()
+	}
+	oracle, cleanO, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanO()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G of contest 1876
- verifiers compile the target program or Go source, compile the official oracle, and compare outputs on 100 random tests
- support running as `go run verifierX.go -- path/to/binary`

## Testing
- `go run verifierA.go -- 1876A.go`
- `go run verifierB.go -- 1876B.go`
- `go run verifierC.go -- 1876C.go`
- `go run verifierD.go -- 1876D.go`
- `go run verifierE.go -- 1876E.go`
- `go run verifierF.go -- 1876F.go`
- `go run verifierG.go -- 1876G.go`

------
https://chatgpt.com/codex/tasks/task_e_68877b9c12648324902f899a8ae1176d