### PR TITLE
Add Go verifiers for contest 1884

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1884/verifierA.go
+++ b/1000-1999/1800-1899/1880-1889/1884/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func digitSum(x int) int {
+	sum := 0
+	for x > 0 {
+		sum += x % 10
+		x /= 10
+	}
+	return sum
+}
+
+func solve(x, k int) int {
+	for {
+		if digitSum(x)%k == 0 {
+			return x
+		}
+		x++
+	}
+}
+
+func generateTests() [][2]int {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([][2]int, 0, 100)
+	// some fixed edge cases
+	tests = append(tests, [2]int{1, 1}, [2]int{1, 10}, [2]int{1000000000, 10})
+	for len(tests) < 100 {
+		x := rng.Intn(1000000000) + 1
+		k := rng.Intn(10) + 1
+		tests = append(tests, [2]int{x, k})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candA")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d %d\n", tc[0], tc[1])
+		expected := strconv.Itoa(solve(tc[0], tc[1]))
+		output, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if output != expected {
+			fmt.Printf("case %d failed: x=%d k=%d expected %s got %s\n", i+1, tc[0], tc[1], expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1800-1899/1880-1889/1884/verifierB.go
+++ b/1000-1999/1800-1899/1880-1889/1884/verifierB.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, s string) []int {
+	zeros := make([]int, 0, n)
+	for i, ch := range s {
+		if ch == '0' {
+			zeros = append(zeros, i+1) // positions 1-indexed
+		}
+	}
+	k := len(zeros)
+	prefix := make([]int, k+1)
+	for i := 0; i < k; i++ {
+		prefix[i+1] = prefix[i] + zeros[i]
+	}
+	res := make([]int, n)
+	for i := 1; i <= n; i++ {
+		if i > k {
+			res[i-1] = -1
+			continue
+		}
+		targetSum := (n-i+1)*i + i*(i-1)/2
+		sumZeros := prefix[k] - prefix[k-i]
+		cost := targetSum - sumZeros
+		res[i-1] = cost
+	}
+	return res
+}
+
+func generateTests() []struct {
+	n int
+	s string
+} {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]struct {
+		n int
+		s string
+	}, 0, 100)
+	tests = append(tests, struct {
+		n int
+		s string
+	}{1, "0"}, struct {
+		n int
+		s string
+	}{1, "1"})
+	for len(tests) < 100 {
+		n := rng.Intn(20) + 1
+		b := make([]byte, n)
+		for i := range b {
+			if rng.Intn(2) == 0 {
+				b[i] = '0'
+			} else {
+				b[i] = '1'
+			}
+		}
+		tests = append(tests, struct {
+			n int
+			s string
+		}{n, string(b)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d\n%s\n", tc.n, tc.s)
+		expInts := solveCase(tc.n, tc.s)
+		expStrs := make([]string, len(expInts))
+		for j, v := range expInts {
+			expStrs[j] = strconv.Itoa(v)
+		}
+		expected := strings.Join(expStrs, " ")
+		output, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != expected {
+			fmt.Printf("case %d failed:\ninput:\n%d\n%s\nexpected: %s\ngot: %s\n", i+1, tc.n, tc.s, expected, strings.TrimSpace(output))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1800-1899/1880-1889/1884/verifierC.go
+++ b/1000-1999/1800-1899/1880-1889/1884/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n    int
+	m    int
+	segs [][2]int
+}
+
+func generateTest(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(20) + n
+	segs := make([][2]int, 0, n)
+	seen := map[[2]int]struct{}{}
+	for len(segs) < n {
+		l := rng.Intn(m) + 1
+		r := rng.Intn(m-l+1) + l
+		pair := [2]int{l, r}
+		if _, ok := seen[pair]; ok {
+			continue
+		}
+		seen[pair] = struct{}{}
+		segs = append(segs, pair)
+	}
+	return testCase{n, m, segs}
+}
+
+func caseToInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for _, p := range tc.segs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candC")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1884C.go")
+	refPath, err := prepareBinary(refSrc, "refC")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateTest(rng)
+		input := caseToInput(tc)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1884/verifierD.go
+++ b/1000-1999/1800-1899/1880-1889/1884/verifierD.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n   int
+	arr []int
+}
+
+func generateTest(rng *rand.Rand) testCase {
+	n := rng.Intn(30) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n) + 1
+	}
+	return testCase{n, arr}
+}
+
+func caseToInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candD")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1884D.go")
+	refPath, err := prepareBinary(refSrc, "refD")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateTest(rng)
+		input := caseToInput(tc)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1880-1889/1884/verifierE.go
+++ b/1000-1999/1800-1899/1880-1889/1884/verifierE.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n   int
+	arr []int64
+}
+
+func generateTest(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(20) + 1)
+	}
+	return testCase{n, arr}
+}
+
+func caseToInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "1884E.go")
+	refPath, err := prepareBinary(refSrc, "refE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateTest(rng)
+		input := caseToInput(tc)
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 1884 problems A–E
- each verifier generates 100 random tests and compares output with the reference or builtin solver

## Testing
- `go run verifierA.go ./a.out`
- `go run verifierB.go ./b.out`
- `go run verifierC.go ./c.out`
- `go run verifierD.go ./d.out`
- `go run verifierE.go ./e.out`


------
https://chatgpt.com/codex/tasks/task_e_68877dcc8470832490d854368707d9d0