### PR TITLE
Add Go verifiers for Codeforces Round 1891

### DIFF
--- a/1000-1999/1800-1899/1890-1899/1891/verifierA.go
+++ b/1000-1999/1800-1899/1890-1899/1891/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	rand.Seed(42)
+	t := 100
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 1
+		fmt.Fprintf(&b, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", rand.Intn(1001))
+		}
+		b.WriteByte('\n')
+	}
+	return b.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func runReference(input []byte) ([]byte, error) {
+	cmd := exec.Command("go", "run", "1891A.go")
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+
+	expOut, err := runReference(input)
+	if err != nil {
+		fmt.Println("error running reference:", err)
+		os.Exit(1)
+	}
+
+	gotOut, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+
+	expLines := strings.Fields(strings.TrimSpace(string(expOut)))
+	gotLines := strings.Fields(strings.TrimSpace(string(gotOut)))
+	if len(expLines) != len(gotLines) {
+		fmt.Printf("mismatch line count: expected %d got %d\n", len(expLines), len(gotLines))
+		os.Exit(1)
+	}
+	for i := range expLines {
+		if expLines[i] != gotLines[i] {
+			fmt.Printf("mismatch on line %d: expected %s got %s\n", i+1, expLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1891/verifierB.go
+++ b/1000-1999/1800-1899/1890-1899/1891/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	rand.Seed(42)
+	t := 100
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 1
+		q := rand.Intn(20) + 1
+		fmt.Fprintf(&b, "%d %d\n", n, q)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", rand.Intn(100)+1)
+		}
+		b.WriteByte('\n')
+		for j := 0; j < q; j++ {
+			if j > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", rand.Intn(30)+1)
+		}
+		b.WriteByte('\n')
+	}
+	return b.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func runReference(input []byte) ([]byte, error) {
+	cmd := exec.Command("go", "run", "1891B.go")
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+
+	expOut, err := runReference(input)
+	if err != nil {
+		fmt.Println("error running reference:", err)
+		os.Exit(1)
+	}
+
+	gotOut, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+
+	expLines := strings.Fields(strings.TrimSpace(string(expOut)))
+	gotLines := strings.Fields(strings.TrimSpace(string(gotOut)))
+	if len(expLines) != len(gotLines) {
+		fmt.Printf("mismatch line count: expected %d got %d\n", len(expLines), len(gotLines))
+		os.Exit(1)
+	}
+	for i := range expLines {
+		if expLines[i] != gotLines[i] {
+			fmt.Printf("mismatch on line %d: expected %s got %s\n", i+1, expLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1891/verifierC.go
+++ b/1000-1999/1800-1899/1890-1899/1891/verifierC.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	rand.Seed(42)
+	t := 100
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 1
+		fmt.Fprintf(&b, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", rand.Intn(100)+1)
+		}
+		b.WriteByte('\n')
+	}
+	return b.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func runReference(input []byte) ([]byte, error) {
+	cmd := exec.Command("go", "run", "1891C.go")
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+
+	expOut, err := runReference(input)
+	if err != nil {
+		fmt.Println("error running reference:", err)
+		os.Exit(1)
+	}
+
+	gotOut, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+
+	expLines := strings.Fields(strings.TrimSpace(string(expOut)))
+	gotLines := strings.Fields(strings.TrimSpace(string(gotOut)))
+	if len(expLines) != len(gotLines) {
+		fmt.Printf("mismatch line count: expected %d got %d\n", len(expLines), len(gotLines))
+		os.Exit(1)
+	}
+	for i := range expLines {
+		if expLines[i] != gotLines[i] {
+			fmt.Printf("mismatch on line %d: expected %s got %s\n", i+1, expLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1891/verifierD.go
+++ b/1000-1999/1800-1899/1890-1899/1891/verifierD.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	rand.Seed(42)
+	q := 100
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d\n", q)
+	var last int64 = 4
+	for i := 0; i < q; i++ {
+		l := last + int64(rand.Intn(5))
+		r := l + int64(rand.Intn(5))
+		if r < l {
+			r = l
+		}
+		fmt.Fprintf(&b, "%d %d\n", l, r)
+		last = r
+	}
+	return b.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func runReference(input []byte) ([]byte, error) {
+	cmd := exec.Command("go", "run", "1891D.go")
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+
+	expOut, err := runReference(input)
+	if err != nil {
+		fmt.Println("error running reference:", err)
+		os.Exit(1)
+	}
+
+	gotOut, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+
+	expLines := strings.Fields(strings.TrimSpace(string(expOut)))
+	gotLines := strings.Fields(strings.TrimSpace(string(gotOut)))
+	if len(expLines) != len(gotLines) {
+		fmt.Printf("mismatch line count: expected %d got %d\n", len(expLines), len(gotLines))
+		os.Exit(1)
+	}
+	for i := range expLines {
+		if expLines[i] != gotLines[i] {
+			fmt.Printf("mismatch on line %d: expected %s got %s\n", i+1, expLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1891/verifierE.go
+++ b/1000-1999/1800-1899/1890-1899/1891/verifierE.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	rand.Seed(42)
+	t := 100
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(n + 1)
+		fmt.Fprintf(&b, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", rand.Intn(10))
+		}
+		b.WriteByte('\n')
+	}
+	return b.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func runReference(input []byte) ([]byte, error) {
+	cmd := exec.Command("go", "run", "1891E.go")
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+
+	expOut, err := runReference(input)
+	if err != nil {
+		fmt.Println("error running reference:", err)
+		os.Exit(1)
+	}
+
+	gotOut, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+
+	expLines := strings.Fields(strings.TrimSpace(string(expOut)))
+	gotLines := strings.Fields(strings.TrimSpace(string(gotOut)))
+	if len(expLines) != len(gotLines) {
+		fmt.Printf("mismatch line count: expected %d got %d\n", len(expLines), len(gotLines))
+		os.Exit(1)
+	}
+	for i := range expLines {
+		if expLines[i] != gotLines[i] {
+			fmt.Printf("mismatch on line %d: expected %s got %s\n", i+1, expLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1891/verifierF.go
+++ b/1000-1999/1800-1899/1890-1899/1891/verifierF.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	rand.Seed(42)
+	T := 100
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d\n", T)
+	for t := 0; t < T; t++ {
+		q := rand.Intn(5) + 1
+		fmt.Fprintf(&b, "%d\n", q)
+		sz := 1
+		for i := 0; i < q; i++ {
+			if sz == 1 || rand.Intn(2) == 0 {
+				v := rand.Intn(sz) + 1
+				fmt.Fprintf(&b, "1 %d\n", v)
+				sz++
+			} else {
+				v := rand.Intn(sz) + 1
+				x := rand.Intn(11) - 5
+				fmt.Fprintf(&b, "2 %d %d\n", v, x)
+			}
+		}
+	}
+	return b.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func runReference(input []byte) ([]byte, error) {
+	cmd := exec.Command("go", "run", "1891F.go")
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+
+	expOut, err := runReference(input)
+	if err != nil {
+		fmt.Println("error running reference:", err)
+		os.Exit(1)
+	}
+
+	gotOut, err := runBinary(os.Args[1], input)
+	if err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+
+	expLines := strings.Fields(strings.TrimSpace(string(expOut)))
+	gotLines := strings.Fields(strings.TrimSpace(string(gotOut)))
+	if len(expLines) != len(gotLines) {
+		fmt.Printf("mismatch line count: expected %d got %d\n", len(expLines), len(gotLines))
+		os.Exit(1)
+	}
+	for i := range expLines {
+		if expLines[i] != gotLines[i] {
+			fmt.Printf("mismatch on line %d: expected %s got %s\n", i+1, expLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for problems A–F of contest 1891
- verifiers generate 100 random test cases and compare candidate output to the reference solutions

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68877fb6ab0c83248acc85746932bfbd