### PR TITLE
Add Go verifiers for Codeforces 1895

### DIFF
--- a/1000-1999/1800-1899/1890-1899/1895/verifierA.go
+++ b/1000-1999/1800-1899/1890-1899/1895/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(x, y, k int) int {
+	if y <= x {
+		return x
+	}
+	if y-x <= k {
+		return y
+	}
+	return 2*y - x - k
+}
+
+func genCase(rng *rand.Rand) (int, int, int) {
+	x := rng.Intn(100) + 1
+	y := rng.Intn(100) + 1
+	for y == x {
+		y = rng.Intn(100) + 1
+	}
+	k := rng.Intn(101)
+	return x, y, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		x, y, k := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", x, y, k))
+		expect := fmt.Sprint(solveA(x, y, k))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1895/verifierB.go
+++ b/1000-1999/1800-1899/1890-1899/1895/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solveB(n int, arr []int) string {
+	sort.Ints(arr)
+	pairs := make([][2]int, n)
+	total := n * 2
+	for i := 0; i < n; i++ {
+		pairs[i][0] = arr[i]
+		pairs[i][1] = arr[total-1-i]
+	}
+	ans := 0
+	for i := 0; i+1 < n; i++ {
+		ans += abs(pairs[i][0] - pairs[i+1][0])
+		ans += abs(pairs[i][1] - pairs[i+1][1])
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", ans))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", pairs[i][0], pairs[i][1]))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) (int, []int) {
+	n := rng.Intn(4) + 1
+	arr := make([]int, 2*n)
+	for i := 0; i < 2*n; i++ {
+		arr[i] = rng.Intn(100)
+	}
+	return n, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, arr := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		expect := solveB(n, append([]int(nil), arr...))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\n got:\n%s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1895/verifierC.go
+++ b/1000-1999/1800-1899/1890-1899/1895/verifierC.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(strs []string) string {
+	n := len(strs)
+	var freq [6][46]int
+	var pref [6][6][46][46]int
+	lens := make([]int, n)
+	sums := make([]int, n)
+	prefixes := make([][]int, n)
+	for i := 0; i < n; i++ {
+		s := strs[i]
+		l := len(s)
+		lens[i] = l
+		prefix := make([]int, l+1)
+		sum := 0
+		for j := 0; j < l; j++ {
+			d := int(s[j] - '0')
+			sum += d
+			prefix[j+1] = sum
+			if j+1 < l {
+				pref[l][j+1][prefix[j+1]][sum]++
+			}
+		}
+		sums[i] = sum
+		prefixes[i] = prefix
+		freq[l][sum]++
+	}
+	ans := 0
+	for idx := 0; idx < n; idx++ {
+		lS := lens[idx]
+		sumS := sums[idx]
+		preS := prefixes[idx]
+		for lenT := 1; lenT <= 5; lenT++ {
+			L := lS + lenT
+			if L%2 == 1 {
+				continue
+			}
+			half := L / 2
+			if half <= lS {
+				d := 2*preS[half] - sumS
+				if d >= lenT && d <= 9*lenT && d >= 0 && d < 46 {
+					ans += freq[lenT][d]
+				}
+			} else {
+				prefLen := half - lS
+				if prefLen >= lenT {
+					continue
+				}
+				maxPrefSum := 9 * prefLen
+				if maxPrefSum > 45 {
+					maxPrefSum = 45
+				}
+				for ps := 1; ps <= maxPrefSum; ps++ {
+					sumT := sumS + 2*ps
+					if sumT < lenT || sumT > 9*lenT || sumT >= 46 {
+						continue
+					}
+					ans += pref[lenT][prefLen][ps][sumT]
+				}
+			}
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func genCase(rng *rand.Rand) []string {
+	n := rng.Intn(5) + 1
+	strs := make([]string, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(5) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('0' + rng.Intn(10))
+		}
+		strs[i] = string(b)
+	}
+	return strs
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		strs := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(strs)))
+		for _, s := range strs {
+			sb.WriteString(s)
+			sb.WriteByte('\n')
+		}
+		expect := solveC(strs)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1895/verifierD.go
+++ b/1000-1999/1800-1899/1890-1899/1895/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func countOnes(n, bit int) int {
+	cycle := 1 << (bit + 1)
+	full := n / cycle
+	cnt := full * (1 << bit)
+	rem := n % cycle
+	if rem > (1 << bit) {
+		cnt += rem - (1 << bit)
+	}
+	return cnt
+}
+
+func solveD(n int, arr []int) string {
+	pref := make([]int, n)
+	cur := 0
+	for i := 1; i < n; i++ {
+		cur ^= arr[i-1]
+		pref[i] = cur
+	}
+	bits := 20
+	cntPref := make([]int, bits)
+	for _, v := range pref {
+		for j := 0; j < bits; j++ {
+			if (v>>j)&1 == 1 {
+				cntPref[j]++
+			}
+		}
+	}
+	cntRange := make([]int, bits)
+	for j := 0; j < bits; j++ {
+		cntRange[j] = countOnes(n, j)
+	}
+	key := 0
+	for j := 0; j < bits; j++ {
+		if cntPref[j] != cntRange[j] {
+			key |= 1 << j
+		}
+	}
+	var sb strings.Builder
+	for i, v := range pref {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v ^ key))
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (int, []int) {
+	n := rng.Intn(10) + 2
+	arr := make([]int, n-1)
+	for i := range arr {
+		arr[i] = rng.Intn(512)
+	}
+	return n, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, arr := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		expect := solveD(n, arr)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1895/verifierE.go
+++ b/1000-1999/1800-1899/1890-1899/1895/verifierE.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(n int, ax, ay []int, bx, by []int) string {
+	total := n + len(bx)
+	edges := make([][]int, total)
+	rev := make([][]int, total)
+	outdeg := make([]int, total)
+
+	m := len(bx)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if bx[j] > ay[i] {
+				edges[i] = append(edges[i], n+j)
+				rev[n+j] = append(rev[n+j], i)
+			}
+		}
+		outdeg[i] = len(edges[i])
+	}
+	for j := 0; j < m; j++ {
+		for i := 0; i < n; i++ {
+			if ax[i] > by[j] {
+				edges[n+j] = append(edges[n+j], i)
+				rev[i] = append(rev[i], n+j)
+			}
+		}
+		outdeg[n+j] = len(edges[n+j])
+	}
+
+	state := make([]int, total)
+	queue := make([]int, 0)
+	for i := 0; i < total; i++ {
+		if outdeg[i] == 0 {
+			state[i] = 2
+			queue = append(queue, i)
+		}
+	}
+	for len(queue) > 0 {
+		v := queue[0]
+		queue = queue[1:]
+		for _, u := range rev[v] {
+			if state[u] != 0 {
+				continue
+			}
+			if state[v] == 2 {
+				state[u] = 1
+				queue = append(queue, u)
+			} else {
+				outdeg[u]--
+				if outdeg[u] == 0 {
+					state[u] = 2
+					queue = append(queue, u)
+				}
+			}
+		}
+	}
+	win, draw, lose := 0, 0, 0
+	for i := 0; i < n; i++ {
+		if state[i] == 1 {
+			win++
+		} else if state[i] == 2 {
+			lose++
+		} else {
+			draw++
+		}
+	}
+	return fmt.Sprintf("%d %d %d", win, draw, lose)
+}
+
+func genCase(rng *rand.Rand) (int, []int, []int, []int, []int) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	ax := make([]int, n)
+	ay := make([]int, n)
+	for i := 0; i < n; i++ {
+		ax[i] = rng.Intn(50)
+		ay[i] = rng.Intn(50)
+	}
+	bx := make([]int, m)
+	by := make([]int, m)
+	for i := 0; i < m; i++ {
+		bx[i] = rng.Intn(50)
+		by[i] = rng.Intn(50)
+	}
+	return n, ax, ay, bx, by
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, ax, ay, bx, by := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(ax[j]))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(ay[j]))
+		}
+		sb.WriteByte('\n')
+		m := len(bx)
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(bx[j]))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(by[j]))
+		}
+		sb.WriteByte('\n')
+		expect := solveE(n, ax, ay, bx, by)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1895/verifierF.go
+++ b/1000-1999/1800-1899/1890-1899/1895/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type state struct {
+	pos  int
+	val  int64
+	seen bool
+}
+
+const MOD int64 = 1_000_000_007
+
+func solveF(n int64, x, k int64) int64 {
+	maxVal := x + k*(n-1)
+	memo := make(map[state]int64)
+	var dfs func(pos int, val int64, seen bool) int64
+	dfs = func(pos int, val int64, seen bool) int64 {
+		if val < 0 || val > maxVal {
+			return 0
+		}
+		if pos == int(n) {
+			if seen {
+				return 1
+			}
+			return 0
+		}
+		st := state{pos, val, seen}
+		if v, ok := memo[st]; ok {
+			return v
+		}
+		var res int64
+		for d := -k; d <= k; d++ {
+			nv := val + d
+			ns := seen || (nv >= x && nv <= x+k-1)
+			res = (res + dfs(pos+1, nv, ns)) % MOD
+		}
+		memo[st] = res
+		return res
+	}
+	var total int64
+	for start := int64(0); start <= maxVal; start++ {
+		total = (total + dfs(1, start, start >= x && start <= x+k-1)) % MOD
+	}
+	return total
+}
+
+func genCase(rng *rand.Rand) (int64, int64, int64) {
+	n := int64(rng.Intn(4) + 1)
+	x := int64(rng.Intn(5))
+	k := int64(rng.Intn(3) + 1)
+	return n, x, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, x, k := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x, k))
+		expect := fmt.Sprint(solveF(n, x, k))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1895/verifierG.go
+++ b/1000-1999/1800-1899/1890-1899/1895/verifierG.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveG(n int, s string, r, b []int64) int64 {
+	base := int64(0)
+	for i := 0; i < n; i++ {
+		base += b[i]
+	}
+	onesTotal := 0
+	for i := 0; i < n; i++ {
+		if s[i] == '1' {
+			onesTotal++
+		}
+	}
+	inf := int64(math.MinInt64 / 4)
+	dp := make([]int64, onesTotal+1)
+	for i := range dp {
+		dp[i] = inf
+	}
+	dp[0] = 0
+	onesSeen := 0
+	for idx := 0; idx < n; idx++ {
+		diff := r[idx] - b[idx]
+		if s[idx] == '1' {
+			for k := onesSeen; k >= 0; k-- {
+				if dp[k] == inf {
+					continue
+				}
+				cand := dp[k] + diff
+				if cand > dp[k+1] {
+					dp[k+1] = cand
+				}
+			}
+			onesSeen++
+		} else {
+			for k := 0; k <= onesSeen; k++ {
+				if dp[k] == inf {
+					continue
+				}
+				cand := dp[k] + diff - int64(k)
+				if cand > dp[k] {
+					dp[k] = cand
+				}
+			}
+		}
+	}
+	ans := int64(math.MinInt64)
+	for k := 0; k <= onesSeen; k++ {
+		if dp[k] > ans {
+			ans = dp[k]
+		}
+	}
+	return base + ans
+}
+
+func genCase(rng *rand.Rand) (int, string, []int64, []int64) {
+	n := rng.Intn(5) + 1
+	b := make([]int64, n)
+	r := make([]int64, n)
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		b[i] = int64(rng.Intn(10))
+	}
+	for i := 0; i < n; i++ {
+		r[i] = int64(rng.Intn(10))
+	}
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	return n, sb.String(), r, b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, s, rArr, bArr := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(rArr[j]))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(bArr[j]))
+		}
+		sb.WriteByte('\n')
+		expect := fmt.Sprint(solveG(n, s, rArr, bArr))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1895 problems A–G
- each verifier generates 100 random tests and checks a candidate binary using the reference logic

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_688780cee7f883249dbe41627761dada