### PR TITLE
Add Go verifiers for CF 1894

### DIFF
--- a/1000-1999/1800-1899/1890-1899/1894/verifierA.go
+++ b/1000-1999/1800-1899/1890-1899/1894/verifierA.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func winnerFor(X, Y int, s string) (byte, bool) {
+	setsA, setsB := 0, 0
+	winsA, winsB := 0, 0
+	for i := 0; i < len(s); i++ {
+		if setsA == Y || setsB == Y {
+			return 0, false
+		}
+		if s[i] == 'A' {
+			winsA++
+		} else {
+			winsB++
+		}
+		if winsA == X {
+			setsA++
+			winsA, winsB = 0, 0
+			if setsA == Y {
+				if i != len(s)-1 {
+					return 0, false
+				}
+				return 'A', true
+			}
+		} else if winsB == X {
+			setsB++
+			winsA, winsB = 0, 0
+			if setsB == Y {
+				if i != len(s)-1 {
+					return 0, false
+				}
+				return 'B', true
+			}
+		}
+	}
+	return 0, false
+}
+
+func expectedResult(s string) string {
+	n := len(s)
+	winners := make(map[byte]struct{})
+	for x := 1; x <= n; x++ {
+		for y := 1; y <= n; y++ {
+			if w, ok := winnerFor(x, y, s); ok {
+				winners[w] = struct{}{}
+			}
+		}
+	}
+	if len(winners) == 1 {
+		for k := range winners {
+			return string(k) + "\n"
+		}
+	}
+	return "?\n"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	for {
+		X := rng.Intn(3) + 1
+		Y := rng.Intn(3) + 1
+		var sb strings.Builder
+		setsA, setsB := 0, 0
+		for setsA < Y && setsB < Y {
+			winsA, winsB := 0, 0
+			for winsA < X && winsB < X {
+				if sb.Len() >= 20 {
+					break
+				}
+				if rng.Intn(2) == 0 {
+					sb.WriteByte('A')
+					winsA++
+				} else {
+					sb.WriteByte('B')
+					winsB++
+				}
+			}
+			if winsA == X {
+				setsA++
+			} else if winsB == X {
+				setsB++
+			} else {
+				break
+			}
+			if sb.Len() > 20 {
+				break
+			}
+		}
+		if (setsA == Y || setsB == Y) && sb.Len() <= 20 {
+			s := sb.String()
+			input := fmt.Sprintf("1\n%d\n%s\n", len(s), s)
+			expected := expectedResult(s)
+			return input, expected
+		}
+	}
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1894/verifierB.go
+++ b/1000-1999/1800-1899/1890-1899/1894/verifierB.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, []int, bool) {
+	n := rng.Intn(100) + 1
+	arr := make([]int, n)
+	counts := make(map[int]int)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) + 1
+		counts[arr[i]]++
+	}
+	dup := 0
+	for _, c := range counts {
+		if c > 1 {
+			dup++
+		}
+	}
+	expect := dup >= 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), arr, expect
+}
+
+func checkOutput(arr []int, out string, expect bool) error {
+	out = strings.TrimSpace(out)
+	if !expect {
+		if out != "-1" {
+			return fmt.Errorf("expected -1 got %q", out)
+		}
+		return nil
+	}
+	fields := strings.Fields(out)
+	if len(fields) != len(arr) {
+		return fmt.Errorf("expected %d numbers got %d", len(arr), len(fields))
+	}
+	b := make([]int, len(arr))
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("invalid number %q", f)
+		}
+		if v < 1 || v > 3 {
+			return fmt.Errorf("number out of range: %d", v)
+		}
+		b[i] = v
+	}
+	cond1, cond2, cond3 := false, false, false
+	n := len(arr)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if arr[i] != arr[j] {
+				continue
+			}
+			if b[i] == 1 && b[j] == 2 || b[i] == 2 && b[j] == 1 {
+				cond1 = true
+			}
+			if b[i] == 1 && b[j] == 3 || b[i] == 3 && b[j] == 1 {
+				cond2 = true
+			}
+			if b[i] == 2 && b[j] == 3 || b[i] == 3 && b[j] == 2 {
+				cond3 = true
+			}
+		}
+	}
+	cnt := 0
+	if cond1 {
+		cnt++
+	}
+	if cond2 {
+		cnt++
+	}
+	if cond3 {
+		cnt++
+	}
+	if cnt != 2 {
+		return fmt.Errorf("exactly two conditions should hold, got %d", cnt)
+	}
+	return nil
+}
+
+func runCase(bin, input string, arr []int, expect bool) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return checkOutput(arr, out.String(), expect)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, arr, expect := generateCase(rng)
+		if err := runCase(bin, in, arr, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 1894
- each verifier generates 100 random valid tests and checks a given binary
- verifiers can execute either compiled binaries or `.go` source files

## Testing
- `go run verifierA.go ./1894A`
- `go run verifierB.go ./1894B`


------
https://chatgpt.com/codex/tasks/task_e_68878088d2608324ac430c2e94abf0a1