### PR TITLE
Add verifiers for contest 1893

### DIFF
--- a/1000-1999/1800-1899/1890-1899/1893/verifierA.go
+++ b/1000-1999/1800-1899/1890-1899/1893/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseA struct {
+	n int
+	k int
+	b []int
+}
+
+func expectedA(n, k int, b []int) string {
+	steps := k
+	if steps > n {
+		steps = n
+	}
+	s := 0
+	for i := 0; i < steps; i++ {
+		idx := n - s - 1
+		if idx < 0 {
+			idx %= n
+			idx += n
+		}
+		idx %= n
+		x := b[idx]
+		if x < 1 || x > n {
+			return "No"
+		}
+		s = (s + x) % n
+	}
+	return "Yes"
+}
+
+func genTestsA() []testCaseA {
+	rand.Seed(1)
+	tests := make([]testCaseA, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(8) + 1
+		k := rand.Intn(12) + 1
+		b := make([]int, n)
+		for i := range b {
+			if rand.Intn(4) == 0 {
+				b[i] = rand.Intn(n+3) + 1
+			} else {
+				b[i] = rand.Intn(n) + 1
+			}
+		}
+		tests = append(tests, testCaseA{n: n, k: k, b: b})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseA) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+	for i, v := range tc.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedA(tc.n, tc.k, tc.b)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s (n=%d k=%d b=%v)", expect, got, tc.n, tc.k, tc.b)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1893/verifierB.go
+++ b/1000-1999/1800-1899/1890-1899/1893/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCaseB struct {
+	a []int
+	b []int
+}
+
+func expectedB(a, b []int) string {
+	bs := append([]int(nil), b...)
+	sort.Sort(sort.Reverse(sort.IntSlice(bs)))
+	ans := make([]int, 0, len(a)+len(b))
+	p := 0
+	for _, bi := range bs {
+		for p < len(a) && a[p] >= bi {
+			ans = append(ans, a[p])
+			p++
+		}
+		ans = append(ans, bi)
+	}
+	for p < len(a) {
+		ans = append(ans, a[p])
+		p++
+	}
+	var sb strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func genTestsB() []testCaseB {
+	rand.Seed(2)
+	tests := make([]testCaseB, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(5) + 1
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rand.Intn(50)
+		}
+		sort.Sort(sort.Reverse(sort.IntSlice(a)))
+		b := make([]int, m)
+		for i := range b {
+			b[i] = rand.Intn(50)
+		}
+		tests = append(tests, testCaseB{a: a, b: b})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseB) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", len(tc.a), len(tc.b)))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedB(tc.a, tc.b)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s (a=%v b=%v)", expect, got, tc.a, tc.b)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1893/verifierC.go
+++ b/1000-1999/1800-1899/1890-1899/1893/verifierC.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type pair struct {
+	idx int
+	cnt int64
+}
+
+type setData struct {
+	l, r, total int64
+	n           int
+	a           []int64
+	c           []int64
+}
+
+type testCaseC struct {
+	m    int
+	sets []setData
+}
+
+func expectedC(tc testCaseC) string {
+	m := tc.m
+	sets := tc.sets
+	valMap := make(map[int64][]pair)
+	uniq := make(map[int64]struct{})
+	var L, R int64
+	for i := 0; i < m; i++ {
+		L += sets[i].l
+		R += sets[i].r
+		for j := 0; j < sets[i].n; j++ {
+			v := sets[i].a[j]
+			valMap[v] = append(valMap[v], pair{idx: i, cnt: sets[i].c[j]})
+			uniq[v] = struct{}{}
+		}
+	}
+	values := make([]int64, 0, len(uniq))
+	for v := range uniq {
+		values = append(values, v)
+	}
+	sort.Slice(values, func(i, j int) bool { return values[i] < values[j] })
+	prev := L - 1
+	gap := false
+	for _, v := range values {
+		if v < L {
+			continue
+		}
+		if v > R {
+			break
+		}
+		if v > prev+1 {
+			gap = true
+			break
+		}
+		prev = v
+	}
+	if !gap && prev < R {
+		gap = true
+	}
+	if gap {
+		return "0"
+	}
+	baseCap := R - L
+	best := int64(1<<63 - 1)
+	for _, S := range values {
+		if S < L || S > R {
+			continue
+		}
+		F0 := int64(0)
+		nonSCap := baseCap
+		extraCap := int64(0)
+		for _, p := range valMap[S] {
+			set := sets[p.idx]
+			t := set.total - p.cnt
+			base := int64(0)
+			if t < set.l {
+				base = set.l - t
+			}
+			minrt := set.r
+			if t < minrt {
+				minrt = t
+			}
+			capi := int64(0)
+			if minrt > set.l {
+				capi = minrt - set.l
+			}
+			nonSCap += capi - (set.r - set.l)
+			extra := set.r - set.l - capi
+			remain := p.cnt - base
+			if remain < extra {
+				extra = remain
+			}
+			if extra < 0 {
+				extra = 0
+			}
+			extraCap += extra
+			F0 += base
+		}
+		need := int64(0)
+		if S-L > nonSCap {
+			need = S - L - nonSCap
+		}
+		if need <= extraCap {
+			cand := F0 + need
+			if cand < best {
+				best = cand
+			}
+		}
+	}
+	return fmt.Sprint(best)
+}
+
+func genTestsC() []testCaseC {
+	rand.Seed(3)
+	tests := make([]testCaseC, 0, 100)
+	for len(tests) < 100 {
+		m := rand.Intn(3) + 1
+		sets := make([]setData, m)
+		for i := 0; i < m; i++ {
+			n := rand.Intn(3) + 1
+			a := make([]int64, n)
+			used := map[int64]struct{}{}
+			for j := 0; j < n; j++ {
+				val := rand.Int63n(10) + 1
+				for {
+					if _, ok := used[val]; !ok {
+						used[val] = struct{}{}
+						break
+					}
+					val = rand.Int63n(10) + 1
+				}
+				a[j] = val
+			}
+			sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+			c := make([]int64, n)
+			var total int64
+			for j := 0; j < n; j++ {
+				c[j] = int64(rand.Intn(3) + 1)
+				total += c[j]
+			}
+			l := int64(rand.Intn(int(total)) + 1)
+			r := l + int64(rand.Intn(int(total-l+1)))
+			sets[i] = setData{l: l, r: r, total: total, n: n, a: a, c: c}
+		}
+		tests = append(tests, testCaseC{m: m, sets: sets})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseC) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", tc.m))
+	for _, s := range tc.sets {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", s.n, s.l, s.r))
+		for i, v := range s.a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range s.c {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+	}
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedC(tc)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1893/verifierD.go
+++ b/1000-1999/1800-1899/1890-1899/1893/verifierD.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Node struct {
+	cnt int
+	val int
+}
+
+type MaxHeap struct{ data []Node }
+
+func (h *MaxHeap) greater(i, j int) bool {
+	a, b := h.data[i], h.data[j]
+	if a.cnt == b.cnt {
+		return a.val > b.val
+	}
+	return a.cnt > b.cnt
+}
+
+func (h *MaxHeap) Push(x Node) {
+	h.data = append(h.data, x)
+	i := len(h.data) - 1
+	for i > 0 {
+		p := (i - 1) / 2
+		if h.greater(i, p) {
+			h.data[i], h.data[p] = h.data[p], h.data[i]
+			i = p
+		} else {
+			break
+		}
+	}
+}
+
+func (h *MaxHeap) Pop() Node {
+	n := len(h.data)
+	top := h.data[0]
+	if n == 1 {
+		h.data = h.data[:0]
+		return top
+	}
+	h.data[0] = h.data[n-1]
+	h.data = h.data[:n-1]
+	i := 0
+	for {
+		l := 2*i + 1
+		r := 2*i + 2
+		largest := i
+		if l < len(h.data) && h.greater(l, largest) {
+			largest = l
+		}
+		if r < len(h.data) && h.greater(r, largest) {
+			largest = r
+		}
+		if largest == i {
+			break
+		}
+		h.data[i], h.data[largest] = h.data[largest], h.data[i]
+		i = largest
+	}
+	return top
+}
+
+type testCaseD struct {
+	n int
+	m int
+	a []int
+	s []int
+	d []int
+}
+
+func expectedD(tc testCaseD) (string, bool) {
+	n, m := tc.n, tc.m
+	cnt := make([]int, n+1)
+	for _, x := range tc.a {
+		if x >= 1 && x <= n {
+			cnt[x]++
+		}
+	}
+	h := &MaxHeap{}
+	for x := 1; x <= n; x++ {
+		if cnt[x] > 0 {
+			h.Push(Node{cnt: cnt[x], val: x})
+		}
+	}
+	ans := make([][]int, m)
+	for i := 0; i < m; i++ {
+		ans[i] = make([]int, tc.s[i])
+		for j := 0; j < tc.s[i]; j++ {
+			if j >= tc.d[i] {
+				prev := ans[i][j-tc.d[i]]
+				if cnt[prev] > 0 {
+					h.Push(Node{cnt: cnt[prev], val: prev})
+				}
+			}
+			if len(h.data) == 0 {
+				return "-1", false
+			}
+			node := h.Pop()
+			ans[i][j] = node.val
+			cnt[node.val]--
+		}
+		for j := tc.s[i]; j < tc.s[i]+tc.d[i]; j++ {
+			prev := ans[i][j-tc.d[i]]
+			if cnt[prev] > 0 {
+				h.Push(Node{cnt: cnt[prev], val: prev})
+			}
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < m; i++ {
+		for j := 0; j < len(ans[i]); j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(ans[i][j]))
+		}
+		if i+1 < m {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String(), true
+}
+
+func genTestsD() []testCaseD {
+	rand.Seed(4)
+	tests := make([]testCaseD, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(6) + 1
+		m := rand.Intn(3) + 1
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rand.Intn(n) + 1
+		}
+		s := make([]int, m)
+		remaining := n
+		for i := 0; i < m; i++ {
+			if i == m-1 {
+				s[i] = remaining
+			} else {
+				max := remaining - (m - i - 1)
+				s[i] = rand.Intn(max) + 1
+				remaining -= s[i]
+			}
+		}
+		d := make([]int, m)
+		for i := range d {
+			d[i] = rand.Intn(s[i]) + 1
+		}
+		tests = append(tests, testCaseD{n: n, m: m, a: a, s: s, d: d})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseD) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.s {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.d {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect, ok := expectedD(tc)
+	if !ok {
+		if got != "-1" {
+			return fmt.Errorf("expected -1 got %s", got)
+		}
+		return nil
+	}
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1893/verifierE.go
+++ b/1000-1999/1800-1899/1890-1899/1893/verifierE.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod int64 = 998244353
+
+type edgeE struct {
+	a int
+	b int
+	d int64
+}
+
+type testCaseE struct {
+	n     int
+	m     int
+	edges []edgeE
+}
+
+func mul(x, y [4]int64) [4]int64 {
+	return [4]int64{
+		(x[0]*y[0] + x[1]*y[2]) % mod,
+		(x[0]*y[1] + x[1]*y[3]) % mod,
+		(x[2]*y[0] + x[3]*y[2]) % mod,
+		(x[2]*y[1] + x[3]*y[3]) % mod,
+	}
+}
+
+func powJacob(n int64) [4]int64 {
+	res := [4]int64{1, 0, 0, 1}
+	base := [4]int64{1, 2, 1, 0}
+	for n > 0 {
+		if n&1 == 1 {
+			res = mul(res, base)
+		}
+		base = mul(base, base)
+		n >>= 1
+	}
+	return res
+}
+
+func jacobsthal(n int64) int64 {
+	if n == 0 {
+		return 0
+	}
+	p := powJacob(n - 1)
+	return p[0] % mod
+}
+
+func expectedE(tc testCaseE) string {
+	n, m := tc.n, tc.m
+	deg := make([]int, n+1)
+	var total int64
+	for _, e := range tc.edges {
+		deg[e.a]++
+		deg[e.b]++
+		total += e.d + 1
+	}
+	if m != n {
+		return "0"
+	}
+	for i := 1; i <= n; i++ {
+		if deg[i] != 2 {
+			return "0"
+		}
+	}
+	ans := jacobsthal(total - 1)
+	ans = ans * 12 % mod
+	return fmt.Sprint(ans)
+}
+
+func genTestsE() []testCaseE {
+	rand.Seed(5)
+	tests := make([]testCaseE, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(n + 1)
+		if rand.Intn(2) == 0 {
+			m = n
+		}
+		edges := make([]edgeE, m)
+		for i := 0; i < m; i++ {
+			a := rand.Intn(n) + 1
+			b := rand.Intn(n) + 1
+			for b == a {
+				b = rand.Intn(n) + 1
+			}
+			d := rand.Int63n(3)
+			edges[i] = edgeE{a: a, b: b, d: d}
+		}
+		tests = append(tests, testCaseE{n: n, m: m, edges: edges})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseE) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for _, e := range tc.edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.a, e.b, e.d))
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedE(tc)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go solution verifiers for problems A–E of contest 1893
- each verifier generates 100 tests and checks a supplied binary

## Testing
- `go build 1000-1999/1800-1899/1890-1899/1893/verifierA.go`
- `go build 1000-1999/1800-1899/1890-1899/1893/verifierB.go`
- `go build 1000-1999/1800-1899/1890-1899/1893/verifierC.go`
- `go build 1000-1999/1800-1899/1890-1899/1893/verifierD.go`
- `go build 1000-1999/1800-1899/1890-1899/1893/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_68878042c23c8324b8098df76f365054