### PR TITLE
Add solution verifiers for contest 1896

### DIFF
--- a/1000-1999/1800-1899/1890-1899/1896/verifierA.go
+++ b/1000-1999/1800-1899/1890-1899/1896/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	r := rand.New(rand.NewSource(42))
+	t := 100
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(8) + 3
+		fmt.Fprintln(&buf, n)
+		perm := r.Perm(n)
+		for j, v := range perm {
+			if j > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprint(&buf, v+1)
+		}
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes()
+}
+
+func run(cmd *exec.Cmd, input []byte) ([]byte, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+	refOut, err := run(exec.Command("go", "run", "1896A.go"), input)
+	if err != nil {
+		fmt.Println("reference solution error:", err)
+		fmt.Print(string(refOut))
+		os.Exit(1)
+	}
+	out, err := run(exec.Command(os.Args[1]), input)
+	if err != nil {
+		fmt.Println("solution runtime error:", err)
+		fmt.Print(string(out))
+		os.Exit(1)
+	}
+	refLines := strings.Split(strings.TrimSpace(string(refOut)), "\n")
+	outLines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(refLines) != len(outLines) {
+		fmt.Printf("mismatched lines: expected %d got %d\n", len(refLines), len(outLines))
+		os.Exit(1)
+	}
+	for i := range refLines {
+		if strings.TrimSpace(refLines[i]) != strings.TrimSpace(outLines[i]) {
+			fmt.Printf("mismatch on line %d: expected %q got %q\n", i+1, refLines[i], outLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1896/verifierB.go
+++ b/1000-1999/1800-1899/1890-1899/1896/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	r := rand.New(rand.NewSource(42))
+	t := 100
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(11) + 2 // 2..12
+		fmt.Fprintln(&buf, n)
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			if r.Intn(2) == 0 {
+				sb.WriteByte('A')
+			} else {
+				sb.WriteByte('B')
+			}
+		}
+		fmt.Fprintln(&buf, sb.String())
+	}
+	return buf.Bytes()
+}
+
+func run(cmd *exec.Cmd, input []byte) ([]byte, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+	refOut, err := run(exec.Command("go", "run", "1896B.go"), input)
+	if err != nil {
+		fmt.Println("reference solution error:", err)
+		fmt.Print(string(refOut))
+		os.Exit(1)
+	}
+	out, err := run(exec.Command(os.Args[1]), input)
+	if err != nil {
+		fmt.Println("solution runtime error:", err)
+		fmt.Print(string(out))
+		os.Exit(1)
+	}
+	refLines := strings.Split(strings.TrimSpace(string(refOut)), "\n")
+	outLines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(refLines) != len(outLines) {
+		fmt.Printf("mismatched lines: expected %d got %d\n", len(refLines), len(outLines))
+		os.Exit(1)
+	}
+	for i := range refLines {
+		if strings.TrimSpace(refLines[i]) != strings.TrimSpace(outLines[i]) {
+			fmt.Printf("mismatch on line %d: expected %q got %q\n", i+1, refLines[i], outLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1896/verifierC.go
+++ b/1000-1999/1800-1899/1890-1899/1896/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	r := rand.New(rand.NewSource(42))
+	t := 100
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(5) + 1
+		x := r.Intn(n + 1)
+		fmt.Fprintln(&buf, n, x)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprint(&buf, r.Intn(2*n)+1)
+		}
+		buf.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprint(&buf, r.Intn(2*n)+1)
+		}
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes()
+}
+
+func run(cmd *exec.Cmd, input []byte) ([]byte, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+	refOut, err := run(exec.Command("go", "run", "1896C.go"), input)
+	if err != nil {
+		fmt.Println("reference solution error:", err)
+		fmt.Print(string(refOut))
+		os.Exit(1)
+	}
+	out, err := run(exec.Command(os.Args[1]), input)
+	if err != nil {
+		fmt.Println("solution runtime error:", err)
+		fmt.Print(string(out))
+		os.Exit(1)
+	}
+	refLines := strings.Split(strings.TrimSpace(string(refOut)), "\n")
+	outLines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(refLines) != len(outLines) {
+		fmt.Printf("mismatched lines: expected %d got %d\n", len(refLines), len(outLines))
+		os.Exit(1)
+	}
+	for i := range refLines {
+		if strings.TrimSpace(refLines[i]) != strings.TrimSpace(outLines[i]) {
+			fmt.Printf("mismatch on line %d: expected %q got %q\n", i+1, refLines[i], outLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1896/verifierE.go
+++ b/1000-1999/1800-1899/1890-1899/1896/verifierE.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	r := rand.New(rand.NewSource(42))
+	t := 100
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(8) + 1
+		fmt.Fprintln(&buf, n)
+		perm := r.Perm(n)
+		for j, v := range perm {
+			if j > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprint(&buf, v+1)
+		}
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes()
+}
+
+func run(cmd *exec.Cmd, input []byte) ([]byte, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+	refOut, err := run(exec.Command("go", "run", "1896E.go"), input)
+	if err != nil {
+		fmt.Println("reference solution error:", err)
+		fmt.Print(string(refOut))
+		os.Exit(1)
+	}
+	out, err := run(exec.Command(os.Args[1]), input)
+	if err != nil {
+		fmt.Println("solution runtime error:", err)
+		fmt.Print(string(out))
+		os.Exit(1)
+	}
+	refLines := strings.Split(strings.TrimSpace(string(refOut)), "\n")
+	outLines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(refLines) != len(outLines) {
+		fmt.Printf("mismatched lines: expected %d got %d\n", len(refLines), len(outLines))
+		os.Exit(1)
+	}
+	for i := range refLines {
+		if strings.TrimSpace(refLines[i]) != strings.TrimSpace(outLines[i]) {
+			fmt.Printf("mismatch on line %d: expected %q got %q\n", i+1, refLines[i], outLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1896/verifierF.go
+++ b/1000-1999/1800-1899/1890-1899/1896/verifierF.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	r := rand.New(rand.NewSource(42))
+	t := 100
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(4) + 1
+		fmt.Fprintln(&buf, n)
+		var sb strings.Builder
+		for j := 0; j < 2*n; j++ {
+			if r.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		fmt.Fprintln(&buf, sb.String())
+	}
+	return buf.Bytes()
+}
+
+func run(cmd *exec.Cmd, input []byte) ([]byte, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+	refOut, err := run(exec.Command("go", "run", "1896F.go"), input)
+	if err != nil {
+		fmt.Println("reference solution error:", err)
+		fmt.Print(string(refOut))
+		os.Exit(1)
+	}
+	out, err := run(exec.Command(os.Args[1]), input)
+	if err != nil {
+		fmt.Println("solution runtime error:", err)
+		fmt.Print(string(out))
+		os.Exit(1)
+	}
+	refLines := strings.Split(strings.TrimSpace(string(refOut)), "\n")
+	outLines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(refLines) != len(outLines) {
+		fmt.Printf("mismatched lines: expected %d got %d\n", len(refLines), len(outLines))
+		os.Exit(1)
+	}
+	for i := range refLines {
+		if strings.TrimSpace(refLines[i]) != strings.TrimSpace(outLines[i]) {
+			fmt.Printf("mismatch on line %d: expected %q got %q\n", i+1, refLines[i], outLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1896/verifierG.go
+++ b/1000-1999/1800-1899/1890-1899/1896/verifierG.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generateInput() []byte {
+	r := rand.New(rand.NewSource(42))
+	t := 100
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(3) + 2
+		fmt.Fprintln(&buf, n)
+		fmt.Fprintln(&buf, "manual")
+		perm := r.Perm(n * n)
+		for j, v := range perm {
+			if j > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprint(&buf, v+1)
+		}
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes()
+}
+
+func run(cmd *exec.Cmd, input []byte) ([]byte, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+	refOut, err := run(exec.Command("go", "run", "1896G.go"), input)
+	if err != nil {
+		fmt.Println("reference solution error:", err)
+		fmt.Print(string(refOut))
+		os.Exit(1)
+	}
+	out, err := run(exec.Command(os.Args[1]), input)
+	if err != nil {
+		fmt.Println("solution runtime error:", err)
+		fmt.Print(string(out))
+		os.Exit(1)
+	}
+	refLines := strings.Split(strings.TrimSpace(string(refOut)), "\n")
+	outLines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(refLines) != len(outLines) {
+		fmt.Printf("mismatched lines: expected %d got %d\n", len(refLines), len(outLines))
+		os.Exit(1)
+	}
+	for i := range refLines {
+		if strings.TrimSpace(refLines[i]) != strings.TrimSpace(outLines[i]) {
+			fmt.Printf("mismatch on line %d: expected %q got %q\n", i+1, refLines[i], outLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1896/verifierH1.go
+++ b/1000-1999/1800-1899/1890-1899/1896/verifierH1.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func genString(r *rand.Rand, length int, maxCount int) string {
+	zeros := maxCount
+	ones := maxCount
+	var sb strings.Builder
+	for i := 0; i < length; i++ {
+		choice := r.Intn(3)
+		if choice == 0 && zeros > 0 {
+			sb.WriteByte('0')
+			zeros--
+		} else if choice == 1 && ones > 0 {
+			sb.WriteByte('1')
+			ones--
+		} else {
+			sb.WriteByte('?')
+		}
+	}
+	return sb.String()
+}
+
+func generateInput() []byte {
+	r := rand.New(rand.NewSource(42))
+	t := 100
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		k := r.Intn(3) + 1
+		fmt.Fprintln(&buf, k)
+		length := 1 << (k + 1)
+		maxCount := 1 << k
+		s := genString(r, length, maxCount)
+		tStr := genString(r, length, maxCount)
+		fmt.Fprintln(&buf, s)
+		fmt.Fprintln(&buf, tStr)
+	}
+	return buf.Bytes()
+}
+
+func run(cmd *exec.Cmd, input []byte) ([]byte, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierH1.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+	refOut, err := run(exec.Command("go", "run", "1896H1.go"), input)
+	if err != nil {
+		fmt.Println("reference solution error:", err)
+		fmt.Print(string(refOut))
+		os.Exit(1)
+	}
+	out, err := run(exec.Command(os.Args[1]), input)
+	if err != nil {
+		fmt.Println("solution runtime error:", err)
+		fmt.Print(string(out))
+		os.Exit(1)
+	}
+	refLines := strings.Split(strings.TrimSpace(string(refOut)), "\n")
+	outLines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(refLines) != len(outLines) {
+		fmt.Printf("mismatched lines: expected %d got %d\n", len(refLines), len(outLines))
+		os.Exit(1)
+	}
+	for i := range refLines {
+		if strings.TrimSpace(refLines[i]) != strings.TrimSpace(outLines[i]) {
+			fmt.Printf("mismatch on line %d: expected %q got %q\n", i+1, refLines[i], outLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1896/verifierH2.go
+++ b/1000-1999/1800-1899/1890-1899/1896/verifierH2.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func genString(r *rand.Rand, length int, maxCount int) string {
+	zeros := maxCount
+	ones := maxCount
+	var sb strings.Builder
+	for i := 0; i < length; i++ {
+		choice := r.Intn(3)
+		if choice == 0 && zeros > 0 {
+			sb.WriteByte('0')
+			zeros--
+		} else if choice == 1 && ones > 0 {
+			sb.WriteByte('1')
+			ones--
+		} else {
+			sb.WriteByte('?')
+		}
+	}
+	return sb.String()
+}
+
+func generateInput() []byte {
+	r := rand.New(rand.NewSource(42))
+	t := 100
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, t)
+	for i := 0; i < t; i++ {
+		k := r.Intn(3) + 1
+		fmt.Fprintln(&buf, k)
+		length := 1 << (k + 1)
+		maxCount := 1 << k
+		s := genString(r, length, maxCount)
+		tStr := genString(r, length, maxCount)
+		fmt.Fprintln(&buf, s)
+		fmt.Fprintln(&buf, tStr)
+	}
+	return buf.Bytes()
+}
+
+func run(cmd *exec.Cmd, input []byte) ([]byte, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierH2.go /path/to/binary")
+		os.Exit(1)
+	}
+	input := generateInput()
+	refOut, err := run(exec.Command("go", "run", "1896H2.go"), input)
+	if err != nil {
+		fmt.Println("reference solution error:", err)
+		fmt.Print(string(refOut))
+		os.Exit(1)
+	}
+	out, err := run(exec.Command(os.Args[1]), input)
+	if err != nil {
+		fmt.Println("solution runtime error:", err)
+		fmt.Print(string(out))
+		os.Exit(1)
+	}
+	refLines := strings.Split(strings.TrimSpace(string(refOut)), "\n")
+	outLines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(refLines) != len(outLines) {
+		fmt.Printf("mismatched lines: expected %d got %d\n", len(refLines), len(outLines))
+		os.Exit(1)
+	}
+	for i := range refLines {
+		if strings.TrimSpace(refLines[i]) != strings.TrimSpace(outLines[i]) {
+			fmt.Printf("mismatch on line %d: expected %q got %q\n", i+1, refLines[i], outLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–H2 of contest 1896
- each verifier generates 100 random test cases
- reference outputs are produced by running the provided Go solutions
- verifiers check a given binary against the reference output

## Testing
- `go vet` *(fails: no packages specified)*


------
https://chatgpt.com/codex/tasks/task_e_6887811521888324ad171d9d6e9ee2f4