### PR TITLE
Add verifiers for contest 1899

### DIFF
--- a/1000-1999/1800-1899/1890-1899/1899/verifierA.go
+++ b/1000-1999/1800-1899/1890-1899/1899/verifierA.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solve(n int) string {
+	if n%3 == 0 {
+		return "Second"
+	}
+	return "First"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(1000) + 1
+		input := fmt.Sprintf("1\n%d\n", n)
+		expected := solve(n)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: n=%d expected %q got %q\n", i+1, n, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1899/verifierB.go
+++ b/1000-1999/1800-1899/1890-1899/1899/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func segmentDiff(prefix []int64, k int) int64 {
+	n := len(prefix) - 1
+	maxSum := int64(math.MinInt64)
+	minSum := int64(math.MaxInt64)
+	for i := k; i <= n; i += k {
+		sum := prefix[i] - prefix[i-k]
+		if sum > maxSum {
+			maxSum = sum
+		}
+		if sum < minSum {
+			minSum = sum
+		}
+	}
+	return maxSum - minSum
+}
+
+func solve(a []int64) int64 {
+	n := len(a)
+	prefix := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] + a[i]
+	}
+	var ans int64
+	for d := 1; d*d <= n; d++ {
+		if n%d == 0 {
+			diff := segmentDiff(prefix, d)
+			if diff > ans {
+				ans = diff
+			}
+			if d != n/d {
+				diff2 := segmentDiff(prefix, n/d)
+				if diff2 > ans {
+					ans = diff2
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 1
+		a := make([]int64, n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rng.Int63n(1000) + 1
+			a[j] = val
+			fmt.Fprintf(&sb, "%d", val)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := fmt.Sprintf("%d\n", solve(a))
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sq\n got:%q\n", i+1, input, strings.TrimSpace(expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1899/verifierC.go
+++ b/1000-1999/1800-1899/1890-1899/1899/verifierC.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solve(a []int) int {
+	cur := a[0]
+	best := cur
+	for i := 1; i < len(a); i++ {
+		if (a[i]^a[i-1])&1 == 1 {
+			if cur+a[i] > a[i] {
+				cur += a[i]
+			} else {
+				cur = a[i]
+			}
+		} else {
+			cur = a[i]
+		}
+		if cur > best {
+			best = cur
+		}
+	}
+	return best
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 1
+		a := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rng.Intn(2001) - 1000
+			a[j] = val
+			fmt.Fprintf(&sb, "%d", val)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := fmt.Sprintf("%d\n", solve(a))
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sq\n got:%q\n", i+1, input, strings.TrimSpace(expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1899/verifierD.go
+++ b/1000-1999/1800-1899/1890-1899/1899/verifierD.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solve(a []int) int64 {
+	freq := make(map[int]int)
+	for _, v := range a {
+		freq[v]++
+	}
+	var ans int64
+	for _, c := range freq {
+		ans += int64(c*(c-1)) / 2
+	}
+	if c1, ok1 := freq[1]; ok1 {
+		if c2, ok2 := freq[2]; ok2 {
+			ans += int64(c1 * c2)
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 1
+		a := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rng.Intn(6) + 1
+			a[j] = val
+			fmt.Fprintf(&sb, "%d", val)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := fmt.Sprintf("%d\n", solve(a))
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sq\n got:%q\n", i+1, input, strings.TrimSpace(expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1899/verifierE.go
+++ b/1000-1999/1800-1899/1890-1899/1899/verifierE.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solve(a []int) int {
+	minVal := a[0]
+	pos := 0
+	for i := 1; i < len(a); i++ {
+		if a[i] < minVal {
+			minVal = a[i]
+			pos = i
+		}
+	}
+	for i := pos + 1; i < len(a); i++ {
+		if a[i] < a[i-1] {
+			return -1
+		}
+	}
+	return pos
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 1
+		a := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rng.Intn(1000) + 1
+			a[j] = val
+			fmt.Fprintf(&sb, "%d", val)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := fmt.Sprintf("%d\n", solve(a))
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%sq\n got:%q\n", i+1, input, strings.TrimSpace(expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1899/verifierF.go
+++ b/1000-1999/1800-1899/1890-1899/1899/verifierF.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1899F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 3
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, q)
+	for i := 0; i < q; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		d := rng.Intn(n-2) + 2
+		fmt.Fprintf(&sb, "%d", d)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expected, err := runBinary(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1899/verifierG.go
+++ b/1000-1999/1800-1899/1890-1899/1899/verifierG.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleG")
+	cmd := exec.Command("go", "build", "-o", oracle, "1899G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTree(rng *rand.Rand, n int) string {
+	var sb strings.Builder
+	for i := 2; i <= n; i++ {
+		parent := rng.Intn(i-1) + 1
+		fmt.Fprintf(&sb, "%d %d\n", parent, i)
+	}
+	return sb.String()
+}
+
+func shuffle(rng *rand.Rand, a []int) {
+	for i := len(a) - 1; i > 0; i-- {
+		j := rng.Intn(i + 1)
+		a[i], a[j] = a[j], a[i]
+	}
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, q)
+	sb.WriteString(generateTree(rng, n))
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = i + 1
+	}
+	shuffle(rng, p)
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		x := rng.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", l, r, x)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expected, err := runBinary(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1899 problems A–G
- each verifier runs 100 random tests against a provided binary
- for complex tasks F and G, build oracles from the reference solutions

## Testing
- `go build 1000-1999/1800-1899/1890-1899/1899/verifierA.go`
- `go build 1000-1999/1800-1899/1890-1899/1899/verifierB.go`
- `go build 1000-1999/1800-1899/1890-1899/1899/verifierC.go`
- `go build 1000-1999/1800-1899/1890-1899/1899/verifierD.go`
- `go build 1000-1999/1800-1899/1890-1899/1899/verifierE.go`
- `go build 1000-1999/1800-1899/1890-1899/1899/verifierF.go`
- `go build 1000-1999/1800-1899/1890-1899/1899/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_688781e6f22c83249099a58ae5bc2780