### PR TITLE
Add verifiers for contest 1901

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1901/verifierA.go
+++ b/1000-1999/1900-1999/1900-1909/1901/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type result struct {
+	out string
+	err error
+}
+
+func buildRef() (string, error) {
+	refSrc := filepath.Join(filepath.Dir(os.Args[0]), "1901A.go")
+	bin := filepath.Join(os.TempDir(), fmt.Sprintf("refA_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", bin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func runBinary(path, input string) result {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return result{strings.TrimSpace(out.String()), err}
+}
+
+func genTest() string {
+	n := rand.Intn(50) + 1       // 1..50
+	x := rand.Intn(99) + 2       // 2..100
+	vals := rand.Perm(x - 1)[:n] // choose n distinct from 0..x-2
+	for i := range vals {
+		vals[i]++ // shift to 1..x-1
+	}
+	sort.Ints(vals)
+	sb := &strings.Builder{}
+	fmt.Fprintf(sb, "1\n%d %d\n", n, x)
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	rand.Seed(1)
+
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < 100; i++ {
+		tc := genTest()
+		exp := runBinary(refBin, tc)
+		if exp.err != nil {
+			fmt.Fprintf(os.Stderr, "reference run failed on test %d: %v\n", i+1, exp.err)
+			os.Exit(1)
+		}
+		got := runBinary(binary, tc)
+		if got.err != nil {
+			fmt.Fprintf(os.Stderr, "binary failed on test %d: %v\n", i+1, got.err)
+			os.Exit(1)
+		}
+		if exp.out != got.out {
+			fmt.Printf("mismatch on test %d\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc, exp.out, got.out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1901/verifierB.go
+++ b/1000-1999/1900-1999/1900-1909/1901/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type result struct {
+	out string
+	err error
+}
+
+func buildRef() (string, error) {
+	refSrc := filepath.Join(filepath.Dir(os.Args[0]), "1901B.go")
+	bin := filepath.Join(os.TempDir(), fmt.Sprintf("refB_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", bin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func runBinary(path, input string) result {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return result{strings.TrimSpace(out.String()), err}
+}
+
+func genTest() string {
+	n := rand.Intn(20) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rand.Int63n(1000)
+	}
+	if arr[0] == 0 {
+		arr[0] = 1
+	}
+	sb := &strings.Builder{}
+	fmt.Fprintf(sb, "1\n%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(2)
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	for i := 0; i < 100; i++ {
+		tc := genTest()
+		exp := runBinary(refBin, tc)
+		if exp.err != nil {
+			fmt.Fprintf(os.Stderr, "reference run failed on test %d: %v\n", i+1, exp.err)
+			os.Exit(1)
+		}
+		got := runBinary(binary, tc)
+		if got.err != nil {
+			fmt.Fprintf(os.Stderr, "binary failed on test %d: %v\n", i+1, got.err)
+			os.Exit(1)
+		}
+		if exp.out != got.out {
+			fmt.Printf("mismatch on test %d\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc, exp.out, got.out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1901/verifierC.go
+++ b/1000-1999/1900-1999/1900-1909/1901/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type result struct {
+	out string
+	err error
+}
+
+func buildRef() (string, error) {
+	refSrc := filepath.Join(filepath.Dir(os.Args[0]), "1901C.go")
+	bin := filepath.Join(os.TempDir(), fmt.Sprintf("refC_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", bin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func runBinary(path, input string) result {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return result{strings.TrimSpace(out.String()), err}
+}
+
+func genTest() string {
+	n := rand.Intn(10) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rand.Int63n(1000)
+	}
+	sb := &strings.Builder{}
+	fmt.Fprintf(sb, "1\n%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(3)
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	for i := 0; i < 100; i++ {
+		tc := genTest()
+		exp := runBinary(refBin, tc)
+		if exp.err != nil {
+			fmt.Fprintf(os.Stderr, "reference run failed on test %d: %v\n", i+1, exp.err)
+			os.Exit(1)
+		}
+		got := runBinary(binary, tc)
+		if got.err != nil {
+			fmt.Fprintf(os.Stderr, "binary failed on test %d: %v\n", i+1, got.err)
+			os.Exit(1)
+		}
+		if exp.out != got.out {
+			fmt.Printf("mismatch on test %d\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc, exp.out, got.out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1901/verifierD.go
+++ b/1000-1999/1900-1999/1900-1909/1901/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type result struct {
+	out string
+	err error
+}
+
+func buildRef() (string, error) {
+	refSrc := filepath.Join(filepath.Dir(os.Args[0]), "1901D.go")
+	bin := filepath.Join(os.TempDir(), fmt.Sprintf("refD_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", bin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func runBinary(path, input string) result {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return result{strings.TrimSpace(out.String()), err}
+}
+
+func genTest() string {
+	n := rand.Intn(10) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rand.Int63n(1000) + 1
+	}
+	sb := &strings.Builder{}
+	fmt.Fprintf(sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(4)
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	for i := 0; i < 100; i++ {
+		tc := genTest()
+		exp := runBinary(refBin, tc)
+		if exp.err != nil {
+			fmt.Fprintf(os.Stderr, "reference run failed on test %d: %v\n", i+1, exp.err)
+			os.Exit(1)
+		}
+		got := runBinary(binary, tc)
+		if got.err != nil {
+			fmt.Fprintf(os.Stderr, "binary failed on test %d: %v\n", i+1, got.err)
+			os.Exit(1)
+		}
+		if exp.out != got.out {
+			fmt.Printf("mismatch on test %d\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc, exp.out, got.out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1901/verifierE.go
+++ b/1000-1999/1900-1999/1900-1909/1901/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type result struct {
+	out string
+	err error
+}
+
+func buildRef() (string, error) {
+	refSrc := filepath.Join(filepath.Dir(os.Args[0]), "1901E.go")
+	bin := filepath.Join(os.TempDir(), fmt.Sprintf("refE_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", bin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func runBinary(path, input string) result {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return result{strings.TrimSpace(out.String()), err}
+}
+
+func genTreeEdges(n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func genTest() string {
+	n := rand.Intn(8) + 2
+	vals := make([]int64, n)
+	for i := 0; i < n; i++ {
+		vals[i] = rand.Int63n(2001) - 1000
+	}
+	edges := genTreeEdges(n)
+	sb := &strings.Builder{}
+	fmt.Fprintf(sb, "1\n%d\n", n)
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		fmt.Fprintf(sb, "%d %d\n", e[0], e[1])
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(5)
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	for i := 0; i < 100; i++ {
+		tc := genTest()
+		exp := runBinary(refBin, tc)
+		if exp.err != nil {
+			fmt.Fprintf(os.Stderr, "reference run failed on test %d: %v\n", i+1, exp.err)
+			os.Exit(1)
+		}
+		got := runBinary(binary, tc)
+		if got.err != nil {
+			fmt.Fprintf(os.Stderr, "binary failed on test %d: %v\n", i+1, got.err)
+			os.Exit(1)
+		}
+		if exp.out != got.out {
+			fmt.Printf("mismatch on test %d\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc, exp.out, got.out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1901/verifierF.go
+++ b/1000-1999/1900-1999/1900-1909/1901/verifierF.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type result struct {
+	out string
+	err error
+}
+
+func buildRef() (string, error) {
+	refSrc := filepath.Join(filepath.Dir(os.Args[0]), "1901F.go")
+	bin := filepath.Join(os.TempDir(), fmt.Sprintf("refF_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", bin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func runBinary(path, input string) result {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return result{strings.TrimSpace(out.String()), err}
+}
+
+func genTest() string {
+	n := rand.Intn(8) + 3
+	a := make([]int64, n)
+	b := make([]int64, n)
+	for i := 1; i < n-1; i++ {
+		a[i] = rand.Int63n(1000)
+		b[i] = rand.Int63n(1000)
+	}
+	sb := &strings.Builder{}
+	fmt.Fprintf(sb, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(6)
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	for i := 0; i < 100; i++ {
+		tc := genTest()
+		exp := runBinary(refBin, tc)
+		if exp.err != nil {
+			fmt.Fprintf(os.Stderr, "reference run failed on test %d: %v\n", i+1, exp.err)
+			os.Exit(1)
+		}
+		got := runBinary(binary, tc)
+		if got.err != nil {
+			fmt.Fprintf(os.Stderr, "binary failed on test %d: %v\n", i+1, got.err)
+			os.Exit(1)
+		}
+		if exp.out != got.out {
+			fmt.Printf("mismatch on test %d\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc, exp.out, got.out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 1901 problems A–F
- each verifier builds the official solution, generates 100 random tests, and compares outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go vet verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68878273097083248f3f1add090a98b8