### PR TITLE
Add verifiers for contest 1900

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1900/verifierA.go
+++ b/1000-1999/1900-1999/1900-1909/1900/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(n int, s string) int {
+	empty := 0
+	hasTriple := false
+	for i := 0; i < n; i++ {
+		if s[i] == '.' {
+			empty++
+		}
+		if i+2 < n && s[i] == '.' && s[i+1] == '.' && s[i+2] == '.' {
+			hasTriple = true
+		}
+	}
+	if empty == 0 {
+		return 0
+	}
+	if hasTriple {
+		return 2
+	}
+	return empty
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(5) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(100) + 1
+		bytesStr := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				bytesStr[j] = '.'
+			} else {
+				bytesStr[j] = '#'
+			}
+		}
+		s := string(bytesStr)
+		in.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+		out.WriteString(fmt.Sprintf("%d\n", solveCase(n, s)))
+	}
+	return testCase{input: in.String(), expected: out.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCase{{input: "1\n1\n.\n", expected: "1\n"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1900/verifierB.go
+++ b/1000-1999/1900-1999/1900-1909/1900/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveOne(a, b, c int) (int, int, int) {
+	one := 0
+	two := 0
+	three := 0
+	if b%2 == c%2 {
+		one = 1
+	}
+	if a%2 == c%2 {
+		two = 1
+	}
+	if a%2 == b%2 {
+		three = 1
+	}
+	return one, two, three
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(10) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		a := rng.Intn(100) + 1
+		b := rng.Intn(100) + 1
+		c := rng.Intn(100) + 1
+		in.WriteString(fmt.Sprintf("%d %d %d\n", a, b, c))
+		o, tw, th := solveOne(a, b, c)
+		out.WriteString(fmt.Sprintf("%d %d %d\n", o, tw, th))
+	}
+	return testCase{input: in.String(), expected: out.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCase{{input: "1\n1 1 1\n", expected: "1 1 1\n"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1900/verifierC.go
+++ b/1000-1999/1900-1999/1900-1909/1900/verifierC.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveOne(n int, s string, l, r []int) int {
+	type node struct{ idx, cost int }
+	stack := []node{{1, 0}}
+	ans := int(1e9)
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		i := cur.idx
+		if l[i] == 0 && r[i] == 0 {
+			if cur.cost < ans {
+				ans = cur.cost
+			}
+		}
+		if l[i] != 0 {
+			c := cur.cost
+			if s[i-1] != 'L' {
+				c++
+			}
+			stack = append(stack, node{l[i], c})
+		}
+		if r[i] != 0 {
+			c := cur.cost
+			if s[i-1] != 'R' {
+				c++
+			}
+			stack = append(stack, node{r[i], c})
+		}
+	}
+	return ans
+}
+
+func generateTree(rng *rand.Rand, n int) ([]int, []int) {
+	l := make([]int, n+1)
+	r := make([]int, n+1)
+	parents := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		for {
+			p := rng.Intn(i-1) + 1
+			side := rng.Intn(2)
+			if side == 0 && l[p] == 0 {
+				l[p] = i
+				parents[i] = p
+				break
+			} else if side == 1 && r[p] == 0 {
+				r[p] = i
+				parents[i] = p
+				break
+			}
+		}
+	}
+	return l, r
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(3) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(10) + 1
+		bytesStr := make([]byte, n)
+		for j := 0; j < n; j++ {
+			pick := rng.Intn(3)
+			if pick == 0 {
+				bytesStr[j] = 'U'
+			} else if pick == 1 {
+				bytesStr[j] = 'L'
+			} else {
+				bytesStr[j] = 'R'
+			}
+		}
+		s := string(bytesStr)
+		l, r := generateTree(rng, n)
+		in.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+		for j := 1; j <= n; j++ {
+			in.WriteString(fmt.Sprintf("%d %d\n", l[j], r[j]))
+		}
+		out.WriteString(fmt.Sprintf("%d\n", solveOne(n, s, l, r)))
+	}
+	return testCase{input: in.String(), expected: out.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	// small deterministic case
+	in := "1\n1\nU\n0 0\n"
+	out := fmt.Sprintf("%d\n", solveOne(1, "U", []int{0, 0}, []int{0, 0}))
+	cases := []testCase{{input: in, expected: out}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1900/verifierD.go
+++ b/1000-1999/1900-1999/1900-1909/1900/verifierD.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+const maxV = 100000
+
+var phi []int64
+
+func initPhi() {
+	phi = make([]int64, maxV+1)
+	for i := 0; i <= maxV; i++ {
+		phi[i] = int64(i)
+	}
+	for i := 2; i <= maxV; i++ {
+		if phi[i] == int64(i) {
+			for j := i; j <= maxV; j += i {
+				phi[j] -= phi[j] / int64(i)
+			}
+		}
+	}
+}
+
+func divisors(x int) []int {
+	res := []int{}
+	for d := 1; d*d <= x; d++ {
+		if x%d == 0 {
+			res = append(res, d)
+			if d*d != x {
+				res = append(res, x/d)
+			}
+		}
+	}
+	return res
+}
+
+func solveOne(arr []int) int64 {
+	n := len(arr)
+	sort.Ints(arr)
+	freq := make([]int64, maxV+1)
+	ans := int64(0)
+	for j, val := range arr {
+		ds := divisors(val)
+		total := int64(0)
+		for _, d := range ds {
+			total += phi[d] * freq[d]
+		}
+		ans += total * int64(n-j-1)
+		for _, d := range ds {
+			freq[d]++
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(3) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(8) + 3
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(1000) + 1
+		}
+		in.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				in.WriteByte(' ')
+			}
+			in.WriteString(fmt.Sprintf("%d", arr[j]))
+		}
+		in.WriteByte('\n')
+		out.WriteString(fmt.Sprintf("%d\n", solveOne(arr)))
+	}
+	return testCase{input: in.String(), expected: out.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	initPhi()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	// simple deterministic test
+	arr := []int{2, 3, 6}
+	in := "1\n3\n2 3 6\n"
+	out := fmt.Sprintf("%d\n", solveOne(arr))
+	cases := []testCase{{input: in, expected: out}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1900/verifierE.go
+++ b/1000-1999/1900-1999/1900-1909/1900/verifierE.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveOne(n, m int, val []int64, edges [][2]int) (int, int64) {
+	g := make([][]int, n)
+	for _, e := range edges {
+		g[e[0]] = append(g[e[0]], e[1])
+	}
+
+	index := make([]int, n)
+	low := make([]int, n)
+	onStack := make([]bool, n)
+	stack := make([]int, 0, n)
+	compID := make([]int, n)
+	compCnt := 0
+	idx := 0
+	compSize := []int{}
+	compSum := []int64{}
+
+	var dfs func(int)
+	dfs = func(v int) {
+		idx++
+		index[v] = idx
+		low[v] = idx
+		stack = append(stack, v)
+		onStack[v] = true
+		for _, to := range g[v] {
+			if index[to] == 0 {
+				dfs(to)
+				if low[to] < low[v] {
+					low[v] = low[to]
+				}
+			} else if onStack[to] && index[to] < low[v] {
+				low[v] = index[to]
+			}
+		}
+		if low[v] == index[v] {
+			size := 0
+			sum := int64(0)
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				onStack[w] = false
+				compID[w] = compCnt
+				size++
+				sum += val[w]
+				if w == v {
+					break
+				}
+			}
+			compSize = append(compSize, size)
+			compSum = append(compSum, sum)
+			compCnt++
+		}
+	}
+	for i := 0; i < n; i++ {
+		if index[i] == 0 {
+			dfs(i)
+		}
+	}
+
+	dag := make([]map[int]struct{}, compCnt)
+	for i := 0; i < compCnt; i++ {
+		dag[i] = make(map[int]struct{})
+	}
+	for v := 0; v < n; v++ {
+		cv := compID[v]
+		for _, u := range g[v] {
+			cu := compID[u]
+			if cv != cu {
+				dag[cv][cu] = struct{}{}
+			}
+		}
+	}
+
+	adj := make([][]int, compCnt)
+	indeg := make([]int, compCnt)
+	for i := 0; i < compCnt; i++ {
+		for nb := range dag[i] {
+			adj[i] = append(adj[i], nb)
+			indeg[nb]++
+		}
+	}
+
+	order := make([]int, 0, compCnt)
+	q := make([]int, 0, compCnt)
+	for i := 0; i < compCnt; i++ {
+		if indeg[i] == 0 {
+			q = append(q, i)
+		}
+	}
+	for qi := 0; qi < len(q); qi++ {
+		v := q[qi]
+		order = append(order, v)
+		for _, u := range adj[v] {
+			indeg[u]--
+			if indeg[u] == 0 {
+				q = append(q, u)
+			}
+		}
+	}
+
+	dpLen := make([]int, compCnt)
+	dpSum := make([]int64, compCnt)
+	for i := compCnt - 1; i >= 0; i-- {
+		v := order[i]
+		dpLen[v] = compSize[v]
+		dpSum[v] = compSum[v]
+		for _, u := range adj[v] {
+			candLen := compSize[v] + dpLen[u]
+			candSum := compSum[v] + dpSum[u]
+			if candLen > dpLen[v] {
+				dpLen[v] = candLen
+				dpSum[v] = candSum
+			} else if candLen == dpLen[v] && candSum < dpSum[v] {
+				dpSum[v] = candSum
+			}
+		}
+	}
+
+	bestLen := 0
+	bestSum := int64(0)
+	first := true
+	for i := 0; i < compCnt; i++ {
+		if first || dpLen[i] > bestLen || (dpLen[i] == bestLen && dpSum[i] < bestSum) {
+			bestLen = dpLen[i]
+			bestSum = dpSum[i]
+			first = false
+		}
+	}
+	return bestLen, bestSum
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(3) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(n*n + 1)
+		vals := make([]int64, n)
+		for j := 0; j < n; j++ {
+			vals[j] = int64(rng.Intn(20))
+		}
+		edges := make([][2]int, m)
+		for j := 0; j < m; j++ {
+			edges[j][0] = rng.Intn(n)
+			edges[j][1] = rng.Intn(n)
+		}
+		in.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				in.WriteByte(' ')
+			}
+			in.WriteString(fmt.Sprintf("%d", vals[j]))
+		}
+		in.WriteByte('\n')
+		for _, e := range edges {
+			in.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+		}
+		l, s := solveOne(n, m, vals, edges)
+		out.WriteString(fmt.Sprintf("%d %d\n", l, s))
+	}
+	return testCase{input: in.String(), expected: out.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	// simple case with 1 node
+	in := "1\n1 0\n5\n"
+	l, s := solveOne(1, 0, []int64{5}, nil)
+	out := fmt.Sprintf("%d %d\n", l, s)
+	cases := []testCase{{input: in, expected: out}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1900/verifierF.go
+++ b/1000-1999/1900-1999/1900-1909/1900/verifierF.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func f(arr []int) int {
+	x := append([]int(nil), arr...)
+	opMin := true
+	for len(x) > 1 {
+		var y []int
+		if opMin {
+			for i := range x {
+				if i == 0 {
+					if len(x) == 1 || x[i] < x[i+1] {
+						y = append(y, x[i])
+					}
+				} else if i == len(x)-1 {
+					if x[i] < x[i-1] {
+						y = append(y, x[i])
+					}
+				} else if x[i] < x[i-1] && x[i] < x[i+1] {
+					y = append(y, x[i])
+				}
+			}
+		} else {
+			for i := range x {
+				if i == 0 {
+					if len(x) == 1 || x[i] > x[i+1] {
+						y = append(y, x[i])
+					}
+				} else if i == len(x)-1 {
+					if x[i] > x[i-1] {
+						y = append(y, x[i])
+					}
+				} else if x[i] > x[i-1] && x[i] > x[i+1] {
+					y = append(y, x[i])
+				}
+			}
+		}
+		if len(y) == 0 {
+			// shouldn't happen for permutations, but guard
+			y = append(y, x[0])
+		}
+		x = y
+		opMin = !opMin
+	}
+	return x[0]
+}
+
+func solveOne(n, q int, a []int, queries [][2]int) []int {
+	res := make([]int, q)
+	for i, qu := range queries {
+		l, r := qu[0], qu[1]
+		arr := append([]int(nil), a[l:r]...)
+		res[i] = f(arr)
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 1
+	q := rng.Intn(5) + 1
+	perm := rand.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	queries := make([][2]int, q)
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		in.WriteString(fmt.Sprintf("%d", perm[i]))
+	}
+	in.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		queries[i] = [2]int{l - 1, r} // zero based for solve
+		in.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	ans := solveOne(n, q, perm, queries)
+	for _, v := range ans {
+		out.WriteString(fmt.Sprintf("%d\n", v))
+	}
+	return testCase{input: in.String(), expected: out.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	// trivial case
+	in := "1 1\n1\n1 1\n"
+	ans := solveOne(1, 1, []int{1}, [][2]int{{0, 1}})
+	out := fmt.Sprintf("%d\n", ans[0])
+	cases := []testCase{{input: in, expected: out}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new Go verifiers for problems A-F of contest 1900
- each verifier runs ~100 random tests and checks output of any binary

## Testing
- `gofmt -w verifierA.go`
- `gofmt -w verifierB.go`
- `gofmt -w verifierC.go`
- `gofmt -w verifierD.go`
- `gofmt -w verifierE.go`
- `gofmt -w verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6887822cffd88324bba566f4691320ac