### PR TITLE
Add Go verifiers for CF 1898

### DIFF
--- a/1000-1999/1800-1899/1890-1899/1898/verifierA.go
+++ b/1000-1999/1800-1899/1890-1899/1898/verifierA.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedA(n, k int, s string) string {
+	cntB := 0
+	for i := 0; i < n; i++ {
+		if s[i] == 'B' {
+			cntB++
+		}
+	}
+	if cntB == k {
+		return "0"
+	}
+	if cntB < k {
+		diff := k - cntB
+		pref := 0
+		for i := 0; i < n; i++ {
+			if s[i] == 'A' {
+				pref++
+			}
+			if pref == diff {
+				return fmt.Sprintf("1\n%d B", i+1)
+			}
+		}
+	} else {
+		diff := cntB - k
+		pref := 0
+		for i := 0; i < n; i++ {
+			if s[i] == 'B' {
+				pref++
+			}
+			if pref == diff {
+				return fmt.Sprintf("1\n%d A", i+1)
+			}
+		}
+	}
+	return ""
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(98) + 3
+	k := rng.Intn(n + 1)
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('A')
+		} else {
+			sb.WriteByte('B')
+		}
+	}
+	s := sb.String()
+	input := fmt.Sprintf("1\n%d %d\n%s\n", n, k, s)
+	expected := expectedA(n, k, s)
+	return input, expected
+}
+
+func runCase(bin, input, expect string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	m, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid first token: %v", err)
+	}
+	var got string
+	if m == 0 {
+		if len(fields) != 1 {
+			return fmt.Errorf("expected single integer")
+		}
+		got = "0"
+	} else if m == 1 {
+		if len(fields) != 3 {
+			return fmt.Errorf("expected three tokens for one operation")
+		}
+		i, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return fmt.Errorf("bad index: %v", err)
+		}
+		c := strings.ToUpper(fields[2])
+		if c != "A" && c != "B" {
+			return fmt.Errorf("bad character %s", c)
+		}
+		got = fmt.Sprintf("1\n%d %s", i, c)
+	} else {
+		return fmt.Errorf("invalid m %d", m)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1898/verifierB.go
+++ b/1000-1999/1800-1899/1890-1899/1898/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedB(a []int64) int64 {
+	ops := int64(0)
+	cur := a[len(a)-1]
+	for i := len(a) - 2; i >= 0; i-- {
+		if a[i] <= cur {
+			cur = a[i]
+		} else {
+			k := (a[i] + cur - 1) / cur
+			ops += k - 1
+			cur = a[i] / k
+		}
+	}
+	return ops
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(30) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = rng.Int63n(1000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	exp := expectedB(a)
+	return sb.String(), exp
+}
+
+func runCase(bin, input string, exp int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != 1 {
+		return fmt.Errorf("expected single integer output")
+	}
+	got, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid integer: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1898/verifierC.go
+++ b/1000-1999/1800-1899/1890-1899/1898/verifierC.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedC(N, M, K int) string {
+	rows := 2*N - 1
+	cols := 2*M - 1
+	C := make([][]byte, rows)
+	for i := 0; i < rows; i++ {
+		C[i] = make([]byte, cols)
+		for j := 0; j < cols; j++ {
+			C[i][j] = '#'
+		}
+	}
+	minMoves := N + M - 2
+	if K < minMoves || (K%2) != (minMoves%2) {
+		return "NO"
+	}
+	maxRow := 2*N - 2
+	maxCol := 2*M - 2
+	now := 0
+	if K%4 == minMoves%4 {
+		now = 0
+		for j := 1; j < maxCol; j += 2 {
+			if now == 0 {
+				C[0][j] = 'R'
+			} else {
+				C[0][j] = 'B'
+			}
+			now ^= 1
+		}
+		for i := 1; i < maxRow; i += 2 {
+			if now == 0 {
+				C[i][maxCol] = 'R'
+			} else {
+				C[i][maxCol] = 'B'
+			}
+			now ^= 1
+		}
+		if now == 0 {
+			C[maxRow-1][maxCol] = 'B'
+			C[maxRow-1][maxCol-2] = 'B'
+			C[maxRow-2][maxCol-1] = 'R'
+			C[maxRow][maxCol-1] = 'R'
+		} else {
+			C[maxRow-1][maxCol] = 'R'
+			C[maxRow-1][maxCol-2] = 'R'
+			C[maxRow-2][maxCol-1] = 'B'
+			C[maxRow][maxCol-1] = 'B'
+		}
+	} else {
+		now = 0
+		for j := 1; j < maxCol; j += 2 {
+			if now == 0 {
+				C[0][j] = 'R'
+			} else {
+				C[0][j] = 'B'
+			}
+			now ^= 1
+		}
+		for i := 1; i < maxRow; i += 2 {
+			if now == 0 {
+				C[i][maxCol] = 'R'
+			} else {
+				C[i][maxCol] = 'B'
+			}
+			now ^= 1
+		}
+		if now == 1 {
+			C[maxRow-1][maxCol] = 'B'
+			C[maxRow-1][maxCol-2] = 'B'
+			C[maxRow-2][maxCol-1] = 'R'
+			C[maxRow][maxCol-1] = 'R'
+		} else {
+			C[maxRow-1][maxCol] = 'R'
+			C[maxRow-1][maxCol-2] = 'R'
+			C[maxRow-2][maxCol-1] = 'B'
+			C[maxRow][maxCol-1] = 'B'
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for i := 0; i <= maxRow; i += 2 {
+		for j := 1; j <= maxCol; j += 2 {
+			if C[i][j] == 'B' {
+				sb.WriteString("B ")
+			} else {
+				sb.WriteString("R ")
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	for i := 1; i <= maxRow; i += 2 {
+		for j := 0; j <= maxCol; j += 2 {
+			if C[i][j] == 'B' {
+				sb.WriteString("B ")
+			} else {
+				sb.WriteString("R ")
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	N := rng.Intn(14) + 3 // 3..16
+	M := rng.Intn(14) + 3
+	K := rng.Intn(50)
+	input := fmt.Sprintf("1\n%d %d %d\n", N, M, K)
+	expect := expectedC(N, M, K)
+	return input, expect
+}
+
+func runCase(bin, input, exp string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\n---got:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1898/verifierD.go
+++ b/1000-1999/1800-1899/1890-1899/1898/verifierD.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type item struct {
+	s int64
+	p int64
+	q int64
+}
+
+func expectedD(a, b []int64) int64 {
+	n := len(a)
+	items := make([]item, n)
+	var sum int64
+	for i := 0; i < n; i++ {
+		diff := a[i] - b[i]
+		if diff < 0 {
+			diff = -diff
+		}
+		sum += diff
+		s := a[i] + b[i]
+		items[i] = item{s: s, p: s - diff, q: s + diff}
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].s < items[j].s })
+	pre := make([]int64, n)
+	cur := int64(-1 << 60)
+	for i := 0; i < n; i++ {
+		if items[i].q > cur {
+			cur = items[i].q
+		}
+		pre[i] = cur
+	}
+	suf := make([]int64, n)
+	cur = int64(-1 << 60)
+	for i := n - 1; i >= 0; i-- {
+		if items[i].p > cur {
+			cur = items[i].p
+		}
+		suf[i] = cur
+	}
+	var best int64
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			cand := items[i].p - pre[i-1]
+			if cand > best {
+				best = cand
+			}
+		}
+		if i+1 < n {
+			cand := suf[i+1] - items[i].q
+			if cand > best {
+				best = cand
+			}
+		}
+	}
+	if best < 0 {
+		best = 0
+	}
+	return sum + best
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(10) + 2
+	a := make([]int64, n)
+	b := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Int63n(1000) + 1
+	}
+	for i := 0; i < n; i++ {
+		b[i] = rng.Int63n(1000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	exp := expectedD(a, b)
+	return sb.String(), exp
+}
+
+func runCase(bin, input string, exp int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != 1 {
+		return fmt.Errorf("expected single integer output")
+	}
+	got, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid integer: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1898/verifierE.go
+++ b/1000-1999/1800-1899/1890-1899/1898/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedE(s, t string) string {
+	if len(t) == 0 {
+		return "YES"
+	}
+	for i := 1; i < len(t); i++ {
+		if t[i] < t[i-1] {
+			return "NO"
+		}
+	}
+	cntS := make([]int, 26)
+	for i := 0; i < len(s); i++ {
+		cntS[s[i]-'a']++
+	}
+	for i := 0; i < len(t); i++ {
+		idx := t[i] - 'a'
+		cntS[idx]--
+		if cntS[idx] < 0 {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(n) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + rng.Intn(26)))
+	}
+	s := sb.String()
+	var tb strings.Builder
+	for i := 0; i < m; i++ {
+		tb.WriteByte(byte('a' + rng.Intn(26)))
+	}
+	t := tb.String()
+	input := fmt.Sprintf("1\n%d %d\n%s\n%s\n", n, m, s, t)
+	expect := expectedE(s, t)
+	return input, expect
+}
+
+func runCase(bin, input, exp string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1800-1899/1890-1899/1898/verifierF.go
+++ b/1000-1999/1800-1899/1890-1899/1898/verifierF.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Point struct{ r, c int }
+
+func expectedF(n, m int, grid []string) int {
+	sr, sc := 0, 0
+	empty := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			ch := grid[i][j]
+			if ch != '#' {
+				empty++
+			}
+			if ch == 'V' {
+				sr = i
+				sc = j
+			}
+		}
+	}
+	total := empty
+	INF := n*m + 5
+	distS := make([]int, n*m)
+	for i := range distS {
+		distS[i] = INF
+	}
+	idx := func(r, c int) int { return r*m + c }
+	q := []int{}
+	start := idx(sr, sc)
+	distS[start] = 0
+	q = append(q, start)
+	dir := []int{-1, 0, 1, 0, -1}
+	for head := 0; head < len(q); head++ {
+		v := q[head]
+		r := v / m
+		c := v % m
+		for k := 0; k < 4; k++ {
+			nr := r + dir[k]
+			nc := c + dir[k+1]
+			if nr < 0 || nr >= n || nc < 0 || nc >= m || grid[nr][nc] == '#' {
+				continue
+			}
+			ni := idx(nr, nc)
+			if distS[ni] == INF {
+				distS[ni] = distS[v] + 1
+				q = append(q, ni)
+			}
+		}
+	}
+	exits := make([]Point, 0)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if i != 0 && i != n-1 && j != 0 && j != m-1 {
+				continue
+			}
+			if grid[i][j] == '#' {
+				continue
+			}
+			if distS[idx(i, j)] == INF {
+				continue
+			}
+			exits = append(exits, Point{i, j})
+		}
+	}
+	k := len(exits)
+	if k == 0 {
+		return total - 1
+	}
+	if k == 1 {
+		d := distS[idx(exits[0].r, exits[0].c)]
+		return total - (d + 1)
+	}
+	dist1 := make([]int, n*m)
+	dist2 := make([]int, n*m)
+	id1 := make([]int, n*m)
+	id2 := make([]int, n*m)
+	for i := range dist1 {
+		dist1[i] = INF
+		dist2[i] = INF
+		id1[i] = -1
+		id2[i] = -1
+	}
+	type state struct {
+		pos int
+		id  int
+		d   int
+	}
+	queue := make([]state, 0)
+	for idxE, e := range exits {
+		p := idx(e.r, e.c)
+		dist1[p] = 0
+		id1[p] = idxE
+		queue = append(queue, state{p, idxE, 0})
+	}
+	for head := 0; head < len(queue); head++ {
+		st := queue[head]
+		p := st.pos
+		id := st.id
+		d := st.d
+		if dist1[p] == d && id1[p] == id {
+			// propagate best
+		} else if dist2[p] == d && id2[p] == id {
+			// propagate second best
+		} else {
+			continue
+		}
+		r := p / m
+		c := p % m
+		for k := 0; k < 4; k++ {
+			nr := r + dir[k]
+			nc := c + dir[k+1]
+			if nr < 0 || nr >= n || nc < 0 || nc >= m || grid[nr][nc] == '#' {
+				continue
+			}
+			np := idx(nr, nc)
+			nd := d + 1
+			if nd < dist1[np] {
+				if id1[np] != id {
+					if dist1[np] < dist2[np] {
+						dist2[np] = dist1[np]
+						id2[np] = id1[np]
+					}
+				}
+				dist1[np] = nd
+				id1[np] = id
+				queue = append(queue, state{np, id, nd})
+			} else if id1[np] != id && nd < dist2[np] {
+				dist2[np] = nd
+				id2[np] = id
+				queue = append(queue, state{np, id, nd})
+			}
+		}
+	}
+	best := INF
+	for p := 0; p < n*m; p++ {
+		if distS[p] == INF {
+			continue
+		}
+		if id1[p] == -1 || id2[p] == -1 {
+			continue
+		}
+		if id1[p] == id2[p] {
+			continue
+		}
+		cost := distS[p] + dist1[p] + dist2[p] + 1
+		if cost < best {
+			best = cost
+		}
+	}
+	return total - best
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(8) + 3
+	m := rng.Intn(8) + 3
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if (i == 0 || i == n-1) && (j == 0 || j == m-1) {
+				row[j] = '#'
+				continue
+			}
+			if rng.Intn(4) == 0 {
+				row[j] = '#'
+			} else {
+				row[j] = '.'
+			}
+		}
+		grid[i] = string(row)
+	}
+	// place V
+	for {
+		r := rng.Intn(n)
+		c := rng.Intn(m)
+		if grid[r][c] != '#' {
+			b := []byte(grid[r])
+			b[c] = 'V'
+			grid[r] = string(b)
+			break
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(grid[i])
+		sb.WriteByte('\n')
+	}
+	exp := expectedF(n, m, grid)
+	return sb.String(), exp
+}
+
+func runCase(bin, input string, exp int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != 1 {
+		return fmt.Errorf("expected single integer output")
+	}
+	got, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid integer: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go-F.go in contest 1898 to validate solution binaries for each problem
- verifiers generate 100 random test cases and check outputs using reference implementations

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`


------
https://chatgpt.com/codex/tasks/task_e_688781a0f14c8324a900af04d049f4ea