### PR TITLE
Add Go verifiers for Codeforces Round 1907

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1907/verifierA.go
+++ b/1000-1999/1900-1999/1900-1909/1907/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildOfficial() (string, error) {
+	tmp := filepath.Join(os.TempDir(), fmt.Sprintf("1907A_official_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", tmp, "1907A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build official solution: %v %s", err, string(out))
+	}
+	return tmp, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	official, err := buildOfficial()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+
+	// generate 100 positions
+	cols := "abcdefgh"
+	var positions []string
+	for _, c := range cols {
+		for r := 1; r <= 8; r++ {
+			positions = append(positions, fmt.Sprintf("%c %d", c, r))
+		}
+	}
+	for len(positions) < 100 {
+		positions = append(positions, positions[len(positions)%64])
+	}
+
+	groups := [][]string{positions[:64], positions[64:]}
+	total := 0
+	for i, g := range groups {
+		input := fmt.Sprintf("%d\n", len(g))
+		for _, p := range g {
+			input += p + "\n"
+		}
+		exp, err := runBinary(official, input)
+		if err != nil {
+			fmt.Printf("official solution failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on group %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("mismatch on group %d\nexpected:\n%s\nactual:\n%s\n", i+1, exp, out)
+			os.Exit(1)
+		}
+		total += len(g)
+	}
+	fmt.Printf("All %d test cases passed.\n", total)
+}

--- a/1000-1999/1900-1999/1900-1909/1907/verifierB.go
+++ b/1000-1999/1900-1999/1900-1909/1907/verifierB.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildOfficial() (string, error) {
+	tmp := filepath.Join(os.TempDir(), fmt.Sprintf("1907B_official_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", tmp, "1907B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build official solution: %v %s", err, string(out))
+	}
+	return tmp, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	official, err := buildOfficial()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+
+	rand.Seed(1)
+	tests := make([]string, 100)
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZbB"
+	for i := 0; i < 100; i++ {
+		l := rand.Intn(20) + 1
+		var sb strings.Builder
+		for j := 0; j < l; j++ {
+			sb.WriteByte(letters[rand.Intn(len(letters))])
+		}
+		tests[i] = sb.String()
+	}
+
+	input := fmt.Sprintf("%d\n", len(tests))
+	for _, tcase := range tests {
+		input += tcase + "\n"
+	}
+
+	exp, err := runBinary(official, input)
+	if err != nil {
+		fmt.Printf("official solution failed: %v\n", err)
+		os.Exit(1)
+	}
+	out, err := runBinary(bin, input)
+	if err != nil {
+		fmt.Printf("binary failed: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+		fmt.Printf("mismatch\nexpected:\n%s\nactual:\n%s\n", exp, out)
+		os.Exit(1)
+	}
+	fmt.Println("All 100 test cases passed.")
+}

--- a/1000-1999/1900-1999/1900-1909/1907/verifierC.go
+++ b/1000-1999/1900-1999/1900-1909/1907/verifierC.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildOfficial() (string, error) {
+	tmp := filepath.Join(os.TempDir(), fmt.Sprintf("1907C_official_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", tmp, "1907C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build official solution: %v %s", err, string(out))
+	}
+	return tmp, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	official, err := buildOfficial()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+
+	rand.Seed(2)
+	t := 100
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(10) + 1
+		s := make([]byte, n)
+		for j := 0; j < n; j++ {
+			s[j] = byte('a' + rand.Intn(26))
+		}
+		input.WriteString(fmt.Sprintf("%d %s\n", n, string(s)))
+	}
+
+	exp, err := runBinary(official, input.String())
+	if err != nil {
+		fmt.Printf("official solution failed: %v\n", err)
+		os.Exit(1)
+	}
+	out, err := runBinary(bin, input.String())
+	if err != nil {
+		fmt.Printf("binary failed: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+		fmt.Printf("mismatch\nexpected:\n%s\nactual:\n%s\n", exp, out)
+		os.Exit(1)
+	}
+	fmt.Println("All 100 test cases passed.")
+}

--- a/1000-1999/1900-1999/1900-1909/1907/verifierD.go
+++ b/1000-1999/1900-1999/1900-1909/1907/verifierD.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildOfficial() (string, error) {
+	tmp := filepath.Join(os.TempDir(), fmt.Sprintf("1907D_official_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", tmp, "1907D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build official solution: %v %s", err, string(out))
+	}
+	return tmp, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	official, err := buildOfficial()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+
+	rand.Seed(3)
+	t := 100
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(4) + 1
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			l := rand.Intn(20)
+			r := l + rand.Intn(10)
+			input.WriteString(fmt.Sprintf("%d %d\n", l, r))
+		}
+	}
+
+	exp, err := runBinary(official, input.String())
+	if err != nil {
+		fmt.Printf("official solution failed: %v\n", err)
+		os.Exit(1)
+	}
+	out, err := runBinary(bin, input.String())
+	if err != nil {
+		fmt.Printf("binary failed: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+		fmt.Printf("mismatch\nexpected:\n%s\nactual:\n%s\n", exp, out)
+		os.Exit(1)
+	}
+	fmt.Println("All 100 test cases passed.")
+}

--- a/1000-1999/1900-1999/1900-1909/1907/verifierE.go
+++ b/1000-1999/1900-1999/1900-1909/1907/verifierE.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildOfficial() (string, error) {
+	tmp := filepath.Join(os.TempDir(), fmt.Sprintf("1907E_official_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", tmp, "1907E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build official solution: %v %s", err, string(out))
+	}
+	return tmp, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	official, err := buildOfficial()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+
+	rand.Seed(4)
+	t := 100
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(10000000)
+		input.WriteString(fmt.Sprintf("%d\n", n))
+	}
+
+	exp, err := runBinary(official, input.String())
+	if err != nil {
+		fmt.Printf("official solution failed: %v\n", err)
+		os.Exit(1)
+	}
+	out, err := runBinary(bin, input.String())
+	if err != nil {
+		fmt.Printf("binary failed: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+		fmt.Printf("mismatch\nexpected:\n%s\nactual:\n%s\n", exp, out)
+		os.Exit(1)
+	}
+	fmt.Println("All 100 test cases passed.")
+}

--- a/1000-1999/1900-1999/1900-1909/1907/verifierF.go
+++ b/1000-1999/1900-1999/1900-1909/1907/verifierF.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildOfficial() (string, error) {
+	tmp := filepath.Join(os.TempDir(), fmt.Sprintf("1907F_official_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", tmp, "1907F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build official solution: %v %s", err, string(out))
+	}
+	return tmp, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	official, err := buildOfficial()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+
+	rand.Seed(5)
+	t := 100
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(7) + 1
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			v := rand.Intn(10)
+			input.WriteString(fmt.Sprintf("%d ", v))
+		}
+		input.WriteString("\n")
+	}
+
+	exp, err := runBinary(official, input.String())
+	if err != nil {
+		fmt.Printf("official solution failed: %v\n", err)
+		os.Exit(1)
+	}
+	out, err := runBinary(bin, input.String())
+	if err != nil {
+		fmt.Printf("binary failed: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+		fmt.Printf("mismatch\nexpected:\n%s\nactual:\n%s\n", exp, out)
+		os.Exit(1)
+	}
+	fmt.Println("All 100 test cases passed.")
+}

--- a/1000-1999/1900-1999/1900-1909/1907/verifierG.go
+++ b/1000-1999/1900-1999/1900-1909/1907/verifierG.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildOfficial() (string, error) {
+	tmp := filepath.Join(os.TempDir(), fmt.Sprintf("1907G_official_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", tmp, "1907G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build official solution: %v %s", err, string(out))
+	}
+	return tmp, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	official, err := buildOfficial()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+
+	rand.Seed(6)
+	t := 100
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rand.Intn(5) + 2
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				input.WriteByte('0')
+			} else {
+				input.WriteByte('1')
+			}
+		}
+		input.WriteString("\n")
+		for j := 0; j < n; j++ {
+			v := rand.Intn(n) + 1
+			if v == j+1 {
+				v = (v % n) + 1
+			}
+			input.WriteString(fmt.Sprintf("%d ", v))
+		}
+		input.WriteString("\n")
+	}
+
+	exp, err := runBinary(official, input.String())
+	if err != nil {
+		fmt.Printf("official solution failed: %v\n", err)
+		os.Exit(1)
+	}
+	out, err := runBinary(bin, input.String())
+	if err != nil {
+		fmt.Printf("binary failed: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+		fmt.Printf("mismatch\nexpected:\n%s\nactual:\n%s\n", exp, out)
+		os.Exit(1)
+	}
+	fmt.Println("All 100 test cases passed.")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go..verifierG.go for contest 1907
- each verifier builds the official solution and checks 100 generated tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_688784175388832489a82c49fdda039f