### PR TITLE
Add verifiers for Codeforces contest 1915

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1915/verifierA.go
+++ b/1000-1999/1900-1999/1910-1919/1915/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(a, b, c int) string {
+	if a == b {
+		return fmt.Sprintf("%d", c)
+	}
+	if a == c {
+		return fmt.Sprintf("%d", b)
+	}
+	return fmt.Sprintf("%d", a)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	x := rng.Intn(10)
+	y := rng.Intn(10)
+	for y == x {
+		y = rng.Intn(10)
+	}
+	pos := rng.Intn(3)
+	nums := [3]int{}
+	for i := 0; i < 3; i++ {
+		if i == pos {
+			nums[i] = y
+		} else {
+			nums[i] = x
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d %d\n", nums[0], nums[1], nums[2])
+	input := sb.String()
+	expected := solveCase(nums[0], nums[1], nums[2])
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := generateCase(rng)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1915/verifierB.go
+++ b/1000-1999/1900-1999/1910-1919/1915/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(rows [3]string) string {
+	letters := []rune{'A', 'B', 'C'}
+	for i := 0; i < 3; i++ {
+		if strings.ContainsRune(rows[i], '?') {
+			used := map[rune]bool{}
+			for _, ch := range rows[i] {
+				if ch != '?' {
+					used[ch] = true
+				}
+			}
+			for _, l := range letters {
+				if !used[l] {
+					return string(l)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	letters := []byte{'A', 'B', 'C'}
+	rng.Shuffle(3, func(i, j int) { letters[i], letters[j] = letters[j], letters[i] })
+	rows := [3]string{}
+	for i := 0; i < 3; i++ {
+		row := []byte{letters[(i)%3], letters[(i+1)%3], letters[(i+2)%3]}
+		rows[i] = string(row)
+	}
+	r := rng.Intn(3)
+	c := rng.Intn(3)
+	rowBytes := []byte(rows[r])
+	rowBytes[c] = '?'
+	rows[r] = string(rowBytes)
+
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	for i := 0; i < 3; i++ {
+		sb.WriteString(rows[i])
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expected := solveCase(rows)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := generateCase(rng)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1915/verifierC.go
+++ b/1000-1999/1900-1999/1910-1919/1915/verifierC.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(nums []int64) string {
+	sum := int64(0)
+	for _, x := range nums {
+		sum += x
+	}
+	root := int64(math.Sqrt(float64(sum)))
+	if root*root == sum {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	nums := make([]int64, n)
+	for i := 0; i < n; i++ {
+		nums[i] = int64(rng.Intn(50) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", nums[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected := solveCase(nums)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := generateCase(rng)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1915/verifierD.go
+++ b/1000-1999/1900-1999/1910-1919/1915/verifierD.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func splitSyllables(s string) string {
+	isVowel := func(c byte) bool { return c == 'a' || c == 'e' }
+	n := len(s)
+	vPos := []int{}
+	for i := 0; i < n; i++ {
+		if isVowel(s[i]) {
+			vPos = append(vPos, i)
+		}
+	}
+	boundaries := make(map[int]bool)
+	for i := 0; i+1 < len(vPos); i++ {
+		diff := vPos[i+1] - vPos[i]
+		if diff == 2 {
+			boundaries[vPos[i]] = true
+		} else if diff == 3 {
+			boundaries[vPos[i]+1] = true
+		}
+	}
+	var buf bytes.Buffer
+	for i := 0; i < n; i++ {
+		buf.WriteByte(s[i])
+		if boundaries[i] {
+			buf.WriteByte('.')
+		}
+	}
+	return buf.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	vowels := []byte{'a', 'e'}
+	cons := []byte{'b', 'c', 'd'}
+	syl := rng.Intn(5) + 1
+	var word strings.Builder
+	for i := 0; i < syl; i++ {
+		word.WriteByte(cons[rng.Intn(len(cons))])
+		word.WriteByte(vowels[rng.Intn(len(vowels))])
+		if rng.Intn(2) == 0 {
+			word.WriteByte(cons[rng.Intn(len(cons))])
+		}
+	}
+	w := word.String()
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n%s\n", len(w), w)
+	input := sb.String()
+	expected := splitSyllables(w)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := generateCase(rng)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1915/verifierE.go
+++ b/1000-1999/1900-1999/1910-1919/1915/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(nums []int64) string {
+	prefix := int64(0)
+	seen := map[int64]bool{0: true}
+	ok := false
+	for i, x := range nums {
+		if (i+1)%2 == 1 {
+			prefix += x
+		} else {
+			prefix -= x
+		}
+		if seen[prefix] {
+			ok = true
+		}
+		seen[prefix] = true
+	}
+	if ok {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	nums := make([]int64, n)
+	for i := 0; i < n; i++ {
+		nums[i] = int64(rng.Intn(20) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", nums[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected := solveCase(nums)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := generateCase(rng)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1915/verifierF.go
+++ b/1000-1999/1900-1999/1910-1919/1915/verifierF.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type Fenwick struct {
+	n    int
+	tree []int64
+}
+
+func newFenwick(n int) *Fenwick {
+	return &Fenwick{n: n, tree: make([]int64, n+2)}
+}
+
+func (f *Fenwick) add(i int, v int64) {
+	for i <= f.n {
+		f.tree[i] += v
+		i += i & -i
+	}
+}
+
+func (f *Fenwick) sum(i int) int64 {
+	s := int64(0)
+	for i > 0 {
+		s += f.tree[i]
+		i &= i - 1
+	}
+	return s
+}
+
+func solveCase(people [][2]int) string {
+	sort.Slice(people, func(i, j int) bool { return people[i][0] < people[j][0] })
+	n := len(people)
+	bs := make([]int, n)
+	for i := 0; i < n; i++ {
+		bs[i] = people[i][1]
+	}
+	sortedBs := append([]int(nil), bs...)
+	sort.Ints(sortedBs)
+	comp := make(map[int]int, n)
+	for i, v := range sortedBs {
+		comp[v] = i + 1
+	}
+	bit := newFenwick(n)
+	ans := int64(0)
+	for i := 0; i < n; i++ {
+		idx := comp[bs[i]]
+		ans += int64(i) - bit.sum(idx)
+		bit.add(idx, 1)
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	used := map[int]bool{}
+	vals := make([]int, 0, 2*n)
+	for len(vals) < 2*n {
+		x := rng.Intn(200) - 100
+		if !used[x] {
+			used[x] = true
+			vals = append(vals, x)
+		}
+	}
+	people := make([][2]int, n)
+	for i := 0; i < n; i++ {
+		a := vals[2*i]
+		b := vals[2*i+1]
+		if a > b {
+			a, b = b, a
+		}
+		people[i] = [2]int{a, b}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", people[i][0], people[i][1])
+	}
+	input := sb.String()
+	expected := solveCase(people)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := generateCase(rng)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1915/verifierG.go
+++ b/1000-1999/1900-1999/1910-1919/1915/verifierG.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type Edge struct {
+	to   int
+	cost int64
+}
+
+type Item struct {
+	dist int64
+	node int
+	slow int
+}
+
+type PriorityQueue []Item
+
+func (pq PriorityQueue) Len() int            { return len(pq) }
+func (pq PriorityQueue) Less(i, j int) bool  { return pq[i].dist < pq[j].dist }
+func (pq PriorityQueue) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PriorityQueue) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[:n-1]
+	return item
+}
+
+const INF int64 = 1 << 60
+
+func solveCase(n int, edges [][3]int, s []int) string {
+	g := make([][]Edge, n+1)
+	for _, e := range edges {
+		u, v, w := e[0], e[1], int64(e[2])
+		g[u] = append(g[u], Edge{to: v, cost: w})
+		g[v] = append(g[v], Edge{to: u, cost: w})
+	}
+	maxS := 1000
+	dist := make([][]int64, n+1)
+	for i := 0; i <= n; i++ {
+		dist[i] = make([]int64, maxS+1)
+		for j := 0; j <= maxS; j++ {
+			dist[i][j] = INF
+		}
+	}
+	pq := &PriorityQueue{}
+	startSlow := s[1]
+	dist[1][startSlow] = 0
+	heap.Push(pq, Item{dist: 0, node: 1, slow: startSlow})
+	for pq.Len() > 0 {
+		cur := heap.Pop(pq).(Item)
+		if cur.dist != dist[cur.node][cur.slow] {
+			continue
+		}
+		u := cur.node
+		d := cur.dist
+		slow := cur.slow
+		for _, e := range g[u] {
+			v := e.to
+			ns := slow
+			if s[v] < ns {
+				ns = s[v]
+			}
+			nd := d + e.cost*int64(slow)
+			if nd < dist[v][ns] {
+				dist[v][ns] = nd
+				heap.Push(pq, Item{dist: nd, node: v, slow: ns})
+			}
+		}
+	}
+	ans := INF
+	for i := 1; i <= maxS; i++ {
+		if dist[n][i] < ans {
+			ans = dist[n][i]
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-n+1) + n - 1
+	edges := make([][3]int, 0, m)
+	// ensure connectivity by chain
+	for i := 1; i < n; i++ {
+		w := rng.Intn(10) + 1
+		edges = append(edges, [3]int{i, i + 1, w})
+	}
+	existing := map[[2]int]bool{}
+	for i := 1; i < n; i++ {
+		existing[[2]int{i, i + 1}] = true
+		existing[[2]int{i + 1, i}] = true
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		key := [2]int{u, v}
+		if existing[key] {
+			continue
+		}
+		existing[[2]int{u, v}] = true
+		existing[[2]int{v, u}] = true
+		w := rng.Intn(10) + 1
+		edges = append(edges, [3]int{u, v, w})
+	}
+	s := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		s[i] = rng.Intn(10) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, len(edges))
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e[0], e[1], e[2])
+	}
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", s[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected := solveCase(n, edges, s)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := generateCase(rng)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1915 problems A-G
- verifiers generate at least 100 randomized tests
- run arbitrary binaries or Go sources via `go run`

## Testing
- `go build 1000-1999/1900-1999/1910-1919/1915/verifierA.go`
- `go build 1000-1999/1900-1999/1910-1919/1915/verifierB.go`
- `go build 1000-1999/1900-1999/1910-1919/1915/verifierC.go`
- `go build 1000-1999/1900-1999/1910-1919/1915/verifierD.go`
- `go build 1000-1999/1900-1999/1910-1919/1915/verifierE.go`
- `go build 1000-1999/1900-1999/1910-1919/1915/verifierF.go`
- `go build 1000-1999/1900-1999/1910-1919/1915/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68878647c3608324b4264ef68c66bbb0