### PR TITLE
Add verifiers for Codeforces Round 1917

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1917/verifierA.go
+++ b/1000-1999/1900-1999/1910-1919/1917/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1917A.go")
+	bin := filepath.Join(os.TempDir(), "oracle1917A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1\n0\n",
+		"1\n3\n1 2 3\n",
+		"1\n2\n-1 -2\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	t := 1
+	n := rng.Intn(5) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(11) - 5
+	}
+	b := strings.Builder{}
+	b.WriteString(fmt.Sprintf("%d\n%d\n", t, n))
+	for i, v := range arr {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprint(v))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1900-1999/1910-1919/1917/verifierB.go
+++ b/1000-1999/1900-1999/1910-1919/1917/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1917B.go")
+	bin := filepath.Join(os.TempDir(), "oracle1917B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1\na\n",
+		"1\n5\nabcde\n",
+		"1\n3\naaa\n",
+	}
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	s := randString(rng, n)
+	return fmt.Sprintf("1\n%d\n%s\n", n, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1900-1999/1910-1919/1917/verifierC.go
+++ b/1000-1999/1900-1999/1910-1919/1917/verifierC.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1917C.go")
+	bin := filepath.Join(os.TempDir(), "oracle1917C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1 1 1\n0\n1\n",
+		"1\n2 2 3\n0 1\n1 2\n",
+		"1\n3 2 4\n1 1 1\n1 2\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(4) + 1
+	d := rng.Intn(20) + k
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(n + 1)
+	}
+	v := make([]int, k)
+	for i := range v {
+		v[i] = rng.Intn(n) + 1
+	}
+	b := strings.Builder{}
+	b.WriteString("1\n")
+	b.WriteString(fmt.Sprintf("%d %d %d\n", n, k, d))
+	for i, x := range a {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprint(x))
+	}
+	b.WriteString("\n")
+	for i, x := range v {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprint(x))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1900-1999/1910-1919/1917/verifierD.go
+++ b/1000-1999/1900-1999/1910-1919/1917/verifierD.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1917D.go")
+	bin := filepath.Join(os.TempDir(), "oracle1917D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1 1\n1\n0\n",
+		"1\n2 2\n1 3\n0 1\n",
+		"1\n3 2\n3 5 1\n1 0\n",
+	}
+}
+
+func randPerm(rng *rand.Rand, n int) []int {
+	a := make([]int, n)
+	for i := range a {
+		a[i] = i
+	}
+	rng.Shuffle(n, func(i, j int) { a[i], a[j] = a[j], a[i] })
+	return a
+}
+
+func randOddPerm(rng *rand.Rand, n int) []int {
+	a := make([]int, n)
+	vals := make([]int, n)
+	for i := 0; i < n; i++ {
+		vals[i] = 2*i + 1
+	}
+	rng.Shuffle(n, func(i, j int) { vals[i], vals[j] = vals[j], vals[i] })
+	copy(a, vals)
+	return a
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(4) + 1
+	p := randOddPerm(rng, n)
+	q := randPerm(rng, k)
+	b := strings.Builder{}
+	b.WriteString("1\n")
+	b.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, x := range p {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprint(x))
+	}
+	b.WriteString("\n")
+	for i, x := range q {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprint(x))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1900-1999/1910-1919/1917/verifierE.go
+++ b/1000-1999/1900-1999/1910-1919/1917/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1917E.go")
+	bin := filepath.Join(os.TempDir(), "oracle1917E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n2 0\n",
+		"1\n2 3\n",
+		"1\n4 6\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := 2 * (rng.Intn(5) + 1)
+	k := rng.Intn(n*n + 1)
+	return fmt.Sprintf("1\n%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1900-1999/1910-1919/1917/verifierF.go
+++ b/1000-1999/1900-1999/1910-1919/1917/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1917F.go")
+	bin := filepath.Join(os.TempDir(), "oracle1917F.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n2 3\n1 2\n",
+		"1\n3 5\n1 2 3\n",
+		"1\n2 4\n2 2\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	d := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(d) + 1
+	}
+	b := strings.Builder{}
+	b.WriteString("1\n")
+	b.WriteString(fmt.Sprintf("%d %d\n", n, d))
+	for i, x := range arr {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprint(x))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1917
- each verifier builds the reference solution and runs at least 100 random tests

## Testing
- `go build 1000-1999/1900-1999/1910-1919/1917/verifierA.go`
- `go build 1000-1999/1900-1999/1910-1919/1917/verifierB.go`
- `go build 1000-1999/1900-1999/1910-1919/1917/verifierC.go`
- `go build 1000-1999/1900-1999/1910-1919/1917/verifierD.go`
- `go build 1000-1999/1900-1999/1910-1919/1917/verifierE.go`
- `go build 1000-1999/1900-1999/1910-1919/1917/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688786d3c5308324b0804983f2b085c1