### PR TITLE
Add Go verifiers for contest 1914

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1914/verifierA.go
+++ b/1000-1999/1900-1999/1910-1919/1914/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1914A.go")
+	bin := filepath.Join(os.TempDir(), "1914A_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(500) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('A' + rand.Intn(26)))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1914/verifierB.go
+++ b/1000-1999/1900-1999/1910-1919/1914/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1914B.go")
+	bin := filepath.Join(os.TempDir(), "1914B_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(49) + 2 // 2..50
+	k := rand.Intn(n)
+	return []byte(fmt.Sprintf("1\n%d %d\n", n, k))
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1914/verifierC.go
+++ b/1000-1999/1900-1999/1910-1919/1914/verifierC.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1914C.go")
+	bin := filepath.Join(os.TempDir(), "1914C_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 1
+	k := rand.Intn(20) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(1000) + 1
+		b[i] = rand.Intn(1000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", b[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1914/verifierD.go
+++ b/1000-1999/1900-1999/1910-1919/1914/verifierD.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1914D.go")
+	bin := filepath.Join(os.TempDir(), "1914D_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(8) + 3 // 3..10
+	a := make([]int, n)
+	b := make([]int, n)
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(100) + 1
+		b[i] = rand.Intn(100) + 1
+		c[i] = rand.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", b[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1914/verifierE1.go
+++ b/1000-1999/1900-1999/1910-1919/1914/verifierE1.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1914E1.go")
+	bin := filepath.Join(os.TempDir(), "1914E1_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 2 // 2..6
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(10) + 1
+		b[i] = rand.Intn(10) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", b[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1914/verifierE2.go
+++ b/1000-1999/1900-1999/1910-1919/1914/verifierE2.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1914E2.go")
+	bin := filepath.Join(os.TempDir(), "1914E2_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 2
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(100) + 1
+		b[i] = rand.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", b[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1914/verifierF.go
+++ b/1000-1999/1900-1999/1910-1919/1914/verifierF.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1914F.go")
+	bin := filepath.Join(os.TempDir(), "1914F_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 2
+	parents := make([]int, n-1)
+	for i := 0; i < n-1; i++ {
+		parents[i] = rand.Intn(i+1) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n-1; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", parents[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1914/verifierG1.go
+++ b/1000-1999/1900-1999/1910-1919/1914/verifierG1.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1914G1.go")
+	bin := filepath.Join(os.TempDir(), "1914G1_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 2
+	colors := make([]int, 2*n)
+	idxs := rand.Perm(2 * n)
+	for i := 0; i < n; i++ {
+		colors[idxs[2*i]] = i + 1
+		colors[idxs[2*i+1]] = i + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < 2*n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", colors[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG1.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1914/verifierG2.go
+++ b/1000-1999/1900-1999/1910-1919/1914/verifierG2.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1914G2.go")
+	bin := filepath.Join(os.TempDir(), "1914G2_ref.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 2
+	colors := make([]int, 2*n)
+	idxs := rand.Perm(2 * n)
+	for i := 0; i < n; i++ {
+		colors[idxs[2*i]] = i + 1
+		colors[idxs[2*i+1]] = i + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < 2*n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", colors[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG2.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1914 problems (A through G2)
- each verifier compiles the reference solution, generates 100 random tests and compares outputs

## Testing
- `go build 1000-1999/1900-1999/1910-1919/1914/verifierA.go`
- `go build 1000-1999/1900-1999/1910-1919/1914/verifierB.go`
- `go build 1000-1999/1900-1999/1910-1919/1914/verifierC.go`
- `go build 1000-1999/1900-1999/1910-1919/1914/verifierD.go`
- `go build 1000-1999/1900-1999/1910-1919/1914/verifierE1.go`
- `go build 1000-1999/1900-1999/1910-1919/1914/verifierE2.go`
- `go build 1000-1999/1900-1999/1910-1919/1914/verifierF.go`
- `go build 1000-1999/1900-1999/1910-1919/1914/verifierG1.go`
- `go build 1000-1999/1900-1999/1910-1919/1914/verifierG2.go`


------
https://chatgpt.com/codex/tasks/task_e_68878601c84483248b29a3b026bc724f