### PR TITLE
Add verifiers for 1909 A-D

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1909/verifierA.go
+++ b/1000-1999/1900-1999/1900-1909/1909/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func solve(n int, pts []point) string {
+	needU, needR, needD, needL := false, false, false, false
+	for _, p := range pts {
+		if p.y > 0 {
+			needU = true
+		}
+		if p.y < 0 {
+			needD = true
+		}
+		if p.x > 0 {
+			needR = true
+		}
+		if p.x < 0 {
+			needL = true
+		}
+	}
+	cnt := 0
+	if needU {
+		cnt++
+	}
+	if needR {
+		cnt++
+	}
+	if needD {
+		cnt++
+	}
+	if needL {
+		cnt++
+	}
+	if cnt <= 3 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	pts := make([]point, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(21) - 10
+		y := rng.Intn(21) - 10
+		pts[i] = point{x, y}
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	expect := solve(n, pts)
+	return sb.String(), expect
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1909/verifierB.go
+++ b/1000-1999/1900-1999/1900-1909/1909/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solve(arr []int64) int64 {
+	base := arr[0]
+	var g int64
+	for i := 1; i < len(arr); i++ {
+		diff := arr[i] - base
+		if diff < 0 {
+			diff = -diff
+		}
+		g = gcd(g, diff)
+	}
+	return g * 2
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(2001) - 1000)
+		sb.WriteString(fmt.Sprintf("%d ", arr[i]))
+	}
+	sb.WriteString("\n")
+	expect := fmt.Sprintf("%d", solve(arr))
+	return sb.String(), expect
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1909/verifierC.go
+++ b/1000-1999/1900-1999/1900-1909/1909/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solve(l, r, c []int) int64 {
+	n := len(l)
+	sort.Ints(l)
+	sort.Ints(r)
+	sort.Slice(c, func(i, j int) bool { return c[i] > c[j] })
+	diff := make([]int, n)
+	pool := make([]int, 0, n)
+	idx := 0
+	for i, rv := range r {
+		for idx < n && l[idx] < rv {
+			pool = append(pool, l[idx])
+			idx++
+		}
+		lv := pool[len(pool)-1]
+		pool = pool[:len(pool)-1]
+		diff[i] = rv - lv
+	}
+	sort.Ints(diff)
+	var ans int64
+	for i := 0; i < n; i++ {
+		ans += int64(diff[i]) * int64(c[i])
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	l := make([]int, n)
+	r := make([]int, n)
+	c := make([]int, n)
+	used := map[int]bool{}
+	for i := 0; i < n; i++ {
+		for {
+			lv := rng.Intn(100)
+			rv := lv + rng.Intn(20) + 1
+			if !used[lv] && !used[rv] {
+				used[lv] = true
+				used[rv] = true
+				l[i] = lv
+				r[i] = rv
+				break
+			}
+		}
+		c[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", l[i]))
+	}
+	sb.WriteString("\n")
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", r[i]))
+	}
+	sb.WriteString("\n")
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", c[i]))
+	}
+	sb.WriteString("\n")
+	expect := fmt.Sprintf("%d", solve(append([]int(nil), l...), append([]int(nil), r...), append([]int(nil), c...)))
+	return sb.String(), expect
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1900-1909/1909/verifierD.go
+++ b/1000-1999/1900-1999/1900-1909/1909/verifierD.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solve(n int, k int64, a []int64) int64 {
+	g := int64(0)
+	allZero := true
+	b := make([]int64, n)
+	for i, v := range a {
+		b[i] = v - k
+		if b[i] != 0 {
+			allZero = false
+		}
+		if b[i] < 0 {
+			b[i] = -b[i]
+		}
+		g = gcd(g, b[i])
+	}
+	if allZero {
+		return 0
+	}
+	divisors := []int64{}
+	for d := int64(1); d*d <= g; d++ {
+		if g%d == 0 {
+			divisors = append(divisors, d)
+			if d != g/d {
+				divisors = append(divisors, g/d)
+			}
+		}
+	}
+	ans := int64(-1)
+	for _, d := range divisors {
+		for _, div := range []int64{d, -d} {
+			Tval := k + div
+			if Tval <= 0 {
+				continue
+			}
+			ok := true
+			sumQ := int64(0)
+			for i := 0; i < n; i++ {
+				if (a[i]-k)%div != 0 {
+					ok = false
+					break
+				}
+				q := (a[i] - k) / div
+				if q <= 0 {
+					ok = false
+					break
+				}
+				sumQ += q
+			}
+			if ok {
+				ops := sumQ - int64(n)
+				if ans == -1 || ops < ans {
+					ans = ops
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	k := int64(rng.Intn(20) + 1)
+	a := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(30) + 1)
+		sb.WriteString(fmt.Sprintf("%d ", a[i]))
+	}
+	sb.WriteString("\n")
+	expect := fmt.Sprintf("%d", solve(n, k, append([]int64(nil), a...)))
+	return sb.String(), expect
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for contest 1909 problems A–D
- each verifier generates 100 random tests and checks the provided binary output

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`


------
https://chatgpt.com/codex/tasks/task_e_688784a3bcb48324b81c68db299871c9