### PR TITLE
Add verifiers for Codeforces Round 1920

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1920/verifierA.go
+++ b/1000-1999/1900-1999/1920-1929/1920/verifierA.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type constraint struct {
+	a int
+	x int
+}
+
+func solveCase(cons []constraint) int {
+	lo := 0
+	hi := int(1e9)
+	banned := map[int]struct{}{}
+	for _, c := range cons {
+		switch c.a {
+		case 1:
+			if c.x > lo {
+				lo = c.x
+			}
+		case 2:
+			if c.x < hi {
+				hi = c.x
+			}
+		case 3:
+			banned[c.x] = struct{}{}
+		}
+	}
+	if lo > hi {
+		return 0
+	}
+	count := hi - lo + 1
+	for x := range banned {
+		if x >= lo && x <= hi {
+			count--
+		}
+	}
+	if count < 0 {
+		count = 0
+	}
+	return count
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(99) + 2 // 2..100
+	cons := make([]constraint, n)
+	has1, has2 := false, false
+	for i := 0; i < n; i++ {
+		a := rng.Intn(3) + 1
+		if i == n-1 { // ensure both types appear
+			if !has1 {
+				a = 1
+			} else if !has2 {
+				a = 2
+			}
+		}
+		x := rng.Intn(1_000_000_000) + 1
+		cons[i] = constraint{a, x}
+		if a == 1 {
+			has1 = true
+		}
+		if a == 2 {
+			has2 = true
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, c := range cons {
+		fmt.Fprintf(&sb, "%d %d\n", c.a, c.x)
+	}
+	ans := solveCase(cons)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1920/verifierB.go
+++ b/1000-1999/1900-1999/1920-1929/1920/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveCaseB(n, k, x int, arr []int) int64 {
+	sort.Slice(arr, func(i, j int) bool { return arr[i] > arr[j] })
+	prefix := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] + int64(arr[i])
+	}
+	if k > n {
+		k = n
+	}
+	ans := int64(-1 << 60)
+	for j := 0; j <= k; j++ {
+		idx := j + x
+		if idx > n {
+			idx = n
+		}
+		val := prefix[n] - 2*prefix[idx] + prefix[j]
+		if val > ans {
+			ans = val
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	x := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(1000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d %d\n", n, k, x)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	ans := solveCaseB(n, k, x, append([]int(nil), arr...))
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1920/verifierC.go
+++ b/1000-1999/1900-1999/1920-1929/1920/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solveCaseC(n int, arr []int) int {
+	divisors := make([]int, 0)
+	for d := 1; d*d <= n; d++ {
+		if n%d == 0 {
+			divisors = append(divisors, d)
+			if d*d != n {
+				divisors = append(divisors, n/d)
+			}
+		}
+	}
+	ans := 0
+	for _, k := range divisors {
+		gcdAll := 0
+		for r := 0; r < k && gcdAll != 1; r++ {
+			base := arr[r]
+			g := 0
+			for i := r + k; i < n; i += k {
+				diff := arr[i] - base
+				if diff < 0 {
+					diff = -diff
+				}
+				g = gcd(g, diff)
+				if g == 1 {
+					break
+				}
+			}
+			gcdAll = gcd(gcdAll, g)
+		}
+		if gcdAll == 0 || gcdAll > 1 {
+			ans++
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	ans := solveCaseC(n, arr)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1920/verifierD.go
+++ b/1000-1999/1900-1999/1920-1929/1920/verifierD.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Op struct {
+	b int
+	x int64
+}
+
+const INF int64 = 1e18
+
+func solveCaseD(ops []Op, queries []int64) []int64 {
+	n := len(ops)
+	lens := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		if ops[i-1].b == 1 {
+			if lens[i-1] < INF {
+				lens[i] = lens[i-1] + 1
+				if lens[i] > INF {
+					lens[i] = INF
+				}
+			} else {
+				lens[i] = INF
+			}
+		} else {
+			if lens[i-1] == 0 {
+				lens[i] = 0
+			} else if lens[i-1] >= INF/(ops[i-1].x+1) {
+				lens[i] = INF
+			} else {
+				lens[i] = lens[i-1] * (ops[i-1].x + 1)
+				if lens[i] > INF {
+					lens[i] = INF
+				}
+			}
+		}
+	}
+	res := make([]int64, len(queries))
+	for qi, k := range queries {
+		idx := n
+		for {
+			l, r := 1, idx
+			pos := idx
+			for l <= r {
+				m := (l + r) / 2
+				if lens[m] >= k {
+					pos = m
+					r = m - 1
+				} else {
+					l = m + 1
+				}
+			}
+			op := ops[pos-1]
+			if op.b == 1 {
+				res[qi] = op.x
+				break
+			}
+			k = (k-1)%lens[pos-1] + 1
+			idx = pos - 1
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []int64, []int64) {
+	n := rng.Intn(4) + 1
+	q := rng.Intn(4) + 1
+	ops := make([]Op, n)
+	ops[0] = Op{1, int64(rng.Intn(5) + 1)}
+	for i := 1; i < n; i++ {
+		b := rng.Intn(2) + 1
+		if b == 1 {
+			ops[i] = Op{1, int64(rng.Intn(5) + 1)}
+		} else {
+			ops[i] = Op{2, int64(rng.Intn(3) + 1)}
+		}
+	}
+	lens := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		if ops[i-1].b == 1 {
+			lens[i] = lens[i-1] + 1
+		} else {
+			lens[i] = lens[i-1] * (ops[i-1].x + 1)
+		}
+		if lens[i] > INF {
+			lens[i] = INF
+		}
+	}
+	queries := make([]int64, q)
+	for i := 0; i < q; i++ {
+		if lens[n] == 0 {
+			queries[i] = 1
+		} else {
+			queries[i] = int64(rng.Intn(int(lens[n])) + 1)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for _, op := range ops {
+		fmt.Fprintf(&sb, "%d %d\n", op.b, op.x)
+	}
+	for i := 0; i < q; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", queries[i])
+	}
+	sb.WriteByte('\n')
+	expect := solveCaseD(ops, queries)
+	return sb.String(), expect, queries
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect, _ := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != len(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\ninput:\n%s", i+1, len(expect), len(fields), in)
+			os.Exit(1)
+		}
+		for j, f := range fields {
+			var v int64
+			if _, err := fmt.Sscan(f, &v); err != nil || v != expect[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed at position %d expected %d got %s\ninput:\n%s", i+1, j+1, expect[j], f, in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1920/verifierE.go
+++ b/1000-1999/1900-1999/1920-1929/1920/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func solveCaseE(n, k int) int64 {
+	dp := make([][]int64, n+1)
+	for i := 0; i <= n; i++ {
+		dp[i] = make([]int64, k)
+	}
+	for a0 := 0; a0 < k; a0++ {
+		for a1 := 0; a1 < k-a0; a1++ {
+			w := (a0 + 1) * (a1 + 1)
+			if w <= n {
+				dp[w][a1]++
+			}
+		}
+	}
+	for s := 1; s <= n; s++ {
+		for prev := 0; prev < k; prev++ {
+			val := dp[s][prev]
+			if val == 0 {
+				continue
+			}
+			for nxt := 0; nxt < k-prev; nxt++ {
+				w := (prev + 1) * (nxt + 1)
+				ns := s + w
+				if ns <= n {
+					dp[ns][nxt] = (dp[ns][nxt] + val) % mod
+				}
+			}
+		}
+	}
+	var res int64
+	for last := 0; last < k; last++ {
+		res = (res + dp[n][last]) % mod
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	ans := solveCaseE(n, k)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1920/verifierF1.go
+++ b/1000-1999/1900-1999/1920-1929/1920/verifierF1.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var n, m, q int
+var grid [][]byte
+var dist []int
+
+func idx(r, c int) int { return r*m + c }
+
+func inBounds(r, c int) bool { return r >= 0 && r < n && c >= 0 && c < m }
+
+func computeDist() {
+	dist = make([]int, n*m)
+	for i := range dist {
+		dist[i] = -1
+	}
+	queue := make([]int, 0)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 'v' {
+				id := idx(i, j)
+				dist[id] = 0
+				queue = append(queue, id)
+			}
+		}
+	}
+	for head := 0; head < len(queue); head++ {
+		v := queue[head]
+		r, c := v/m, v%m
+		d := dist[v] + 1
+		if r > 0 {
+			u := v - m
+			if dist[u] == -1 {
+				dist[u] = d
+				queue = append(queue, u)
+			}
+		}
+		if r+1 < n {
+			u := v + m
+			if dist[u] == -1 {
+				dist[u] = d
+				queue = append(queue, u)
+			}
+		}
+		if c > 0 {
+			u := v - 1
+			if dist[u] == -1 {
+				dist[u] = d
+				queue = append(queue, u)
+			}
+		}
+		if c+1 < m {
+			u := v + 1
+			if dist[u] == -1 {
+				dist[u] = d
+				queue = append(queue, u)
+			}
+		}
+	}
+}
+
+func buildComponent(start, t int) []bool {
+	comp := make([]bool, n*m)
+	if dist[start] < t {
+		return comp
+	}
+	queue := []int{start}
+	comp[start] = true
+	for head := 0; head < len(queue); head++ {
+		v := queue[head]
+		r, c := v/m, v%m
+		if r > 0 {
+			u := v - m
+			if !comp[u] && grid[r-1][c] != '#' && dist[u] >= t {
+				comp[u] = true
+				queue = append(queue, u)
+			}
+		}
+		if r+1 < n {
+			u := v + m
+			if !comp[u] && grid[r+1][c] != '#' && dist[u] >= t {
+				comp[u] = true
+				queue = append(queue, u)
+			}
+		}
+		if c > 0 {
+			u := v - 1
+			if !comp[u] && grid[r][c-1] != '#' && dist[u] >= t {
+				comp[u] = true
+				queue = append(queue, u)
+			}
+		}
+		if c+1 < m {
+			u := v + 1
+			if !comp[u] && grid[r][c+1] != '#' && dist[u] >= t {
+				comp[u] = true
+				queue = append(queue, u)
+			}
+		}
+	}
+	return comp
+}
+
+func islandToBorder(comp []bool) bool {
+	visited := make([]bool, n*m)
+	queue := make([]int, 0)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '#' {
+				id := idx(i, j)
+				visited[id] = true
+				queue = append(queue, id)
+			}
+		}
+	}
+	dirs := [8][2]int{{-1, 0}, {1, 0}, {0, -1}, {0, 1}, {-1, -1}, {-1, 1}, {1, -1}, {1, 1}}
+	for head := 0; head < len(queue); head++ {
+		v := queue[head]
+		r, c := v/m, v%m
+		if r == 0 || r == n-1 || c == 0 || c == m-1 {
+			return true
+		}
+		for _, d := range dirs {
+			nr, nc := r+d[0], c+d[1]
+			if !inBounds(nr, nc) {
+				continue
+			}
+			ni := idx(nr, nc)
+			if comp[ni] || visited[ni] {
+				continue
+			}
+			visited[ni] = true
+			queue = append(queue, ni)
+		}
+	}
+	return false
+}
+
+func check(start, t int) bool {
+	if dist[start] < t {
+		return false
+	}
+	comp := buildComponent(start, t)
+	if islandToBorder(comp) {
+		return false
+	}
+	return true
+}
+
+func solveQuery(x, y int) int {
+	start := idx(x-1, y-1)
+	left, right := 0, dist[start]
+	ans := 0
+	for left <= right {
+		mid := (left + right) / 2
+		if check(start, mid) {
+			ans = mid
+			left = mid + 1
+		} else {
+			right = mid - 1
+		}
+	}
+	return ans
+}
+
+func solveCaseF1(g [][]byte, queries [][2]int) []int {
+	grid = g
+	n = len(g)
+	m = len(g[0])
+	computeDist()
+	res := make([]int, len(queries))
+	for i, q := range queries {
+		res[i] = solveQuery(q[0], q[1])
+	}
+	return res
+}
+
+func genGrid(rng *rand.Rand) ([][]byte, [][2]int) {
+	n = rng.Intn(5) + 3
+	m = rng.Intn(5) + 3
+	g := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		g[i] = make([]byte, m)
+		for j := 0; j < m; j++ {
+			g[i][j] = '.'
+		}
+	}
+	ir := rng.Intn(n-2) + 1
+	ic := rng.Intn(m-2) + 1
+	g[ir][ic] = '#'
+	vr := rng.Intn(n)
+	vc := rng.Intn(m)
+	for vr == ir && vc == ic {
+		vr = rng.Intn(n)
+		vc = rng.Intn(m)
+	}
+	g[vr][vc] = 'v'
+	qcnt := rng.Intn(5) + 1
+	qs := make([][2]int, qcnt)
+	for i := 0; i < qcnt; i++ {
+		r, c := rng.Intn(n), rng.Intn(m)
+		for g[r][c] == '#' {
+			r, c = rng.Intn(n), rng.Intn(m)
+		}
+		qs[i] = [2]int{r + 1, c + 1}
+	}
+	return g, qs
+}
+
+func formatInput(g [][]byte, qs [][2]int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", len(g), len(g[0]), len(qs)))
+	for i := 0; i < len(g); i++ {
+		sb.WriteString(string(g[i]))
+		sb.WriteByte('\n')
+	}
+	for i, q := range qs {
+		sb.WriteString(fmt.Sprintf("%d %d", q[0], q[1]))
+		if i+1 < len(qs) {
+			sb.WriteByte('\n')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		g, qs := genGrid(rng)
+		expected := solveCaseF1(g, qs)
+		input := formatInput(g, qs)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != len(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\ninput:\n%s", i+1, len(expected), len(fields), input)
+			os.Exit(1)
+		}
+		for j, f := range fields {
+			var v int
+			if _, err := fmt.Sscan(f, &v); err != nil || v != expected[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed at position %d expected %d got %s\ninput:\n%s", i+1, j+1, expected[j], f, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1920/verifierF2.go
+++ b/1000-1999/1900-1999/1920-1929/1920/verifierF2.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var n, m, q int
+var grid [][]byte
+var dist []int
+
+func idx(r, c int) int { return r*m + c }
+
+func inBounds(r, c int) bool { return r >= 0 && r < n && c >= 0 && c < m }
+
+func computeDist() {
+	dist = make([]int, n*m)
+	for i := range dist {
+		dist[i] = -1
+	}
+	queue := make([]int, 0)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 'v' {
+				id := idx(i, j)
+				dist[id] = 0
+				queue = append(queue, id)
+			}
+		}
+	}
+	for head := 0; head < len(queue); head++ {
+		v := queue[head]
+		r, c := v/m, v%m
+		d := dist[v] + 1
+		if r > 0 {
+			u := v - m
+			if dist[u] == -1 {
+				dist[u] = d
+				queue = append(queue, u)
+			}
+		}
+		if r+1 < n {
+			u := v + m
+			if dist[u] == -1 {
+				dist[u] = d
+				queue = append(queue, u)
+			}
+		}
+		if c > 0 {
+			u := v - 1
+			if dist[u] == -1 {
+				dist[u] = d
+				queue = append(queue, u)
+			}
+		}
+		if c+1 < m {
+			u := v + 1
+			if dist[u] == -1 {
+				dist[u] = d
+				queue = append(queue, u)
+			}
+		}
+	}
+}
+
+func buildComponent(start, t int) []bool {
+	comp := make([]bool, n*m)
+	if dist[start] < t {
+		return comp
+	}
+	queue := []int{start}
+	comp[start] = true
+	for head := 0; head < len(queue); head++ {
+		v := queue[head]
+		r, c := v/m, v%m
+		if r > 0 {
+			u := v - m
+			if !comp[u] && grid[r-1][c] != '#' && dist[u] >= t {
+				comp[u] = true
+				queue = append(queue, u)
+			}
+		}
+		if r+1 < n {
+			u := v + m
+			if !comp[u] && grid[r+1][c] != '#' && dist[u] >= t {
+				comp[u] = true
+				queue = append(queue, u)
+			}
+		}
+		if c > 0 {
+			u := v - 1
+			if !comp[u] && grid[r][c-1] != '#' && dist[u] >= t {
+				comp[u] = true
+				queue = append(queue, u)
+			}
+		}
+		if c+1 < m {
+			u := v + 1
+			if !comp[u] && grid[r][c+1] != '#' && dist[u] >= t {
+				comp[u] = true
+				queue = append(queue, u)
+			}
+		}
+	}
+	return comp
+}
+
+func islandToBorder(comp []bool) bool {
+	visited := make([]bool, n*m)
+	queue := make([]int, 0)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '#' {
+				id := idx(i, j)
+				visited[id] = true
+				queue = append(queue, id)
+			}
+		}
+	}
+	dirs := [8][2]int{{-1, 0}, {1, 0}, {0, -1}, {0, 1}, {-1, -1}, {-1, 1}, {1, -1}, {1, 1}}
+	for head := 0; head < len(queue); head++ {
+		v := queue[head]
+		r, c := v/m, v%m
+		if r == 0 || r == n-1 || c == 0 || c == m-1 {
+			return true
+		}
+		for _, d := range dirs {
+			nr, nc := r+d[0], c+d[1]
+			if !inBounds(nr, nc) {
+				continue
+			}
+			ni := idx(nr, nc)
+			if comp[ni] || visited[ni] {
+				continue
+			}
+			visited[ni] = true
+			queue = append(queue, ni)
+		}
+	}
+	return false
+}
+
+func check(start, t int) bool {
+	if dist[start] < t {
+		return false
+	}
+	comp := buildComponent(start, t)
+	if islandToBorder(comp) {
+		return false
+	}
+	return true
+}
+
+func solveQuery(x, y int) int {
+	start := idx(x-1, y-1)
+	left, right := 0, dist[start]
+	ans := 0
+	for left <= right {
+		mid := (left + right) / 2
+		if check(start, mid) {
+			ans = mid
+			left = mid + 1
+		} else {
+			right = mid - 1
+		}
+	}
+	return ans
+}
+
+func solveCaseF1(g [][]byte, queries [][2]int) []int {
+	grid = g
+	n = len(g)
+	m = len(g[0])
+	computeDist()
+	res := make([]int, len(queries))
+	for i, q := range queries {
+		res[i] = solveQuery(q[0], q[1])
+	}
+	return res
+}
+
+func genGrid(rng *rand.Rand) ([][]byte, [][2]int) {
+	n = rng.Intn(5) + 3
+	m = rng.Intn(5) + 3
+	g := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		g[i] = make([]byte, m)
+		for j := 0; j < m; j++ {
+			g[i][j] = '.'
+		}
+	}
+	ir := rng.Intn(n-2) + 1
+	ic := rng.Intn(m-2) + 1
+	g[ir][ic] = '#'
+	vr := rng.Intn(n)
+	vc := rng.Intn(m)
+	for vr == ir && vc == ic {
+		vr = rng.Intn(n)
+		vc = rng.Intn(m)
+	}
+	g[vr][vc] = 'v'
+	qcnt := rng.Intn(20) + 1
+	qs := make([][2]int, qcnt)
+	for i := 0; i < qcnt; i++ {
+		r, c := rng.Intn(n), rng.Intn(m)
+		for g[r][c] == '#' {
+			r, c = rng.Intn(n), rng.Intn(m)
+		}
+		qs[i] = [2]int{r + 1, c + 1}
+	}
+	return g, qs
+}
+
+func formatInput(g [][]byte, qs [][2]int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", len(g), len(g[0]), len(qs)))
+	for i := 0; i < len(g); i++ {
+		sb.WriteString(string(g[i]))
+		sb.WriteByte('\n')
+	}
+	for i, q := range qs {
+		sb.WriteString(fmt.Sprintf("%d %d", q[0], q[1]))
+		if i+1 < len(qs) {
+			sb.WriteByte('\n')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		g, qs := genGrid(rng)
+		expected := solveCaseF1(g, qs)
+		input := formatInput(g, qs)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != len(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\ninput:\n%s", i+1, len(expected), len(fields), input)
+			os.Exit(1)
+		}
+		for j, f := range fields {
+			var v int
+			if _, err := fmt.Sscan(f, &v); err != nil || v != expected[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed at position %d expected %d got %s\ninput:\n%s", i+1, j+1, expected[j], f, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F2 of contest 1920
- each verifier generates 100 random test cases and checks program output

## Testing
- `go build 1000-1999/1900-1999/1920-1929/1920/verifierA.go`
- `go build 1000-1999/1900-1999/1920-1929/1920/verifierB.go`
- `go build 1000-1999/1900-1999/1920-1929/1920/verifierC.go`
- `go build 1000-1999/1900-1999/1920-1929/1920/verifierD.go`
- `go build 1000-1999/1900-1999/1920-1929/1920/verifierE.go`
- `go build 1000-1999/1900-1999/1920-1929/1920/verifierF1.go`
- `go build 1000-1999/1900-1999/1920-1929/1920/verifierF2.go`

------
https://chatgpt.com/codex/tasks/task_e_688787a6581083248f9b252b809f10bc