### PR TITLE
Add Go verifiers for CF 1919

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1919/verifierA.go
+++ b/1000-1999/1900-1999/1910-1919/1919/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1919A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		a := rng.Int63n(1000) + 1
+		b := rng.Int63n(1000) + 1
+		fmt.Fprintf(&sb, "%d %d\n", a, b)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1919/verifierB.go
+++ b/1000-1999/1900-1999/1910-1919/1919/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1919B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('+')
+			} else {
+				sb.WriteByte('-')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1919/verifierC.go
+++ b/1000-1999/1900-1999/1910-1919/1919/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1919C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(8) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			val := rng.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("%d ", val))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1919/verifierD.go
+++ b/1000-1999/1900-1999/1910-1919/1919/verifierD.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1919D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(8) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			sb.WriteString(fmt.Sprintf("%d ", rng.Intn(n)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1919/verifierE.go
+++ b/1000-1999/1900-1999/1910-1919/1919/verifierE.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func bruteCount(p []int) int {
+	n := len(p)
+	cnt := 0
+	arr := make([]int, n)
+	cmp := make([]int, n)
+	for mask := 0; mask < (1 << n); mask++ {
+		sum := 0
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				sum += 1
+				arr[i] = sum
+			} else {
+				sum -= 1
+				arr[i] = sum
+			}
+		}
+		copy(cmp, arr)
+		sort.Ints(cmp)
+		ok := true
+		for i := 0; i < n; i++ {
+			if cmp[i] != p[i] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			cnt++
+		}
+	}
+	return cnt % mod
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		n := rng.Intn(5) + 1
+		a := make([]int, n)
+		sum := 0
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				a[j] = 1
+			} else {
+				a[j] = -1
+			}
+			sum += a[j]
+		}
+		pref := make([]int, n)
+		s := 0
+		for j := 0; j < n; j++ {
+			s += a[j]
+			pref[j] = s
+		}
+		sort.Ints(pref)
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", pref[j])
+		}
+		sb.WriteByte('\n')
+		count := bruteCount(pref)
+		out.WriteString(fmt.Sprintf("%d\n", count))
+	}
+	return sb.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := genCase(rng)
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1919/verifierF1.go
+++ b/1000-1999/1900-1999/1910-1919/1919/verifierF1.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refF1.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1919F1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	q := rng.Intn(3) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	c := make([]int, n-1)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(5)
+		b[i] = rng.Intn(5)
+	}
+	for i := 0; i < n-1; i++ {
+		c[i] = rng.Intn(5)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", a[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", b[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n-1; i++ {
+		fmt.Fprintf(&sb, "%d ", c[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		p := rng.Intn(n) + 1
+		x := rng.Intn(5)
+		y := rng.Intn(5)
+		z := rng.Intn(5)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", p, x, y, z)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF1.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1919/verifierF2.go
+++ b/1000-1999/1900-1999/1910-1919/1919/verifierF2.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refF2.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1919F2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	q := rng.Intn(3) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	c := make([]int, n-1)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(5)
+		b[i] = rng.Intn(5)
+	}
+	for i := 0; i < n-1; i++ {
+		c[i] = rng.Intn(5)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", a[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", b[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n-1; i++ {
+		fmt.Fprintf(&sb, "%d ", c[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		p := rng.Intn(n) + 1
+		x := rng.Intn(5)
+		y := rng.Intn(5)
+		z := rng.Intn(5)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", p, x, y, z)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF2.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1919/verifierG.go
+++ b/1000-1999/1900-1999/1910-1919/1919/verifierG.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func computeMatrix(n int, edges [][2]int) []string {
+	g := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	res := make([]string, n)
+	for root := 1; root <= n; root++ {
+		parent := make([]int, n+1)
+		order := make([]int, 0, n)
+		stack := []int{root}
+		parent[root] = -1
+		for len(stack) > 0 {
+			v := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			order = append(order, v)
+			for _, to := range g[v] {
+				if to == parent[v] {
+					continue
+				}
+				parent[to] = v
+				stack = append(stack, to)
+			}
+		}
+		win := make([]bool, n+1)
+		for i := len(order) - 1; i >= 0; i-- {
+			v := order[i]
+			good := false
+			for _, to := range g[v] {
+				if to == parent[v] {
+					continue
+				}
+				if !win[to] {
+					good = true
+				}
+			}
+			win[v] = good
+		}
+		var sb strings.Builder
+		for start := 1; start <= n; start++ {
+			if win[start] {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('0')
+			}
+		}
+		res[root-1] = sb.String()
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(4) + 2
+	edges := generateTree(rng, n)
+	matrix := computeMatrix(n, edges)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		sb.WriteString(matrix[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String(), matrix
+}
+
+func parseEdges(out string, n int) ([][2]int, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 1 {
+		return nil, fmt.Errorf("no output")
+	}
+	if strings.ToUpper(strings.TrimSpace(lines[0])) != "YES" {
+		return nil, fmt.Errorf("expected YES")
+	}
+	if len(lines)-1 != n-1 {
+		return nil, fmt.Errorf("expected %d edges", n-1)
+	}
+	edges := make([][2]int, 0, n-1)
+	for i := 1; i < len(lines); i++ {
+		fields := strings.Fields(lines[i])
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("edge format")
+		}
+		u, err1 := strconv.Atoi(fields[0])
+		v, err2 := strconv.Atoi(fields[1])
+		if err1 != nil || err2 != nil || u < 1 || u > n || v < 1 || v > n {
+			return nil, fmt.Errorf("invalid edge")
+		}
+		edges = append(edges, [2]int{u, v})
+	}
+	return edges, nil
+}
+
+func isTree(n int, edges [][2]int) bool {
+	if len(edges) != n-1 {
+		return false
+	}
+	g := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	vis := make([]bool, n+1)
+	stack := []int{1}
+	vis[1] = true
+	count := 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		count++
+		for _, to := range g[v] {
+			if !vis[to] {
+				vis[to] = true
+				stack = append(stack, to)
+			}
+		}
+	}
+	return count == n
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, matrix := genCase(rng)
+		out, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		nLines := strings.Count(input, "\n") - 1
+		candEdges, err := parseEdges(out, nLines)
+		if err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%soutput:\n%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+		if !isTree(nLines, candEdges) {
+			fmt.Printf("case %d failed: output is not a tree\ninput:\n%soutput:\n%s\n", i+1, input, out)
+			os.Exit(1)
+		}
+		want := computeMatrix(nLines, candEdges)
+		valid := true
+		for j := 0; j < nLines; j++ {
+			if matrix[j] != want[j] {
+				valid = false
+				break
+			}
+		}
+		if !valid {
+			fmt.Printf("case %d failed: tree does not match matrix\ninput:\n%soutput:\n%s\n", i+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1910-1919/1919/verifierH.go
+++ b/1000-1999/1900-1999/1910-1919/1919/verifierH.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runExe(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseEdges(out string, n int) ([][2]int, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != n-1 {
+		return nil, fmt.Errorf("expected %d edges", n-1)
+	}
+	edges := make([][2]int, 0, n-1)
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("bad edge")
+		}
+		u, err1 := strconv.Atoi(fields[0])
+		v, err2 := strconv.Atoi(fields[1])
+		if err1 != nil || err2 != nil || u < 1 || u > n || v < 1 || v > n {
+			return nil, fmt.Errorf("invalid edge")
+		}
+		edges = append(edges, [2]int{u, v})
+	}
+	return edges, nil
+}
+
+func isTree(n int, edges [][2]int) bool {
+	if len(edges) != n-1 {
+		return false
+	}
+	g := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	vis := make([]bool, n+1)
+	stack := []int{1}
+	vis[1] = true
+	cnt := 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		cnt++
+		for _, to := range g[v] {
+			if !vis[to] {
+				vis[to] = true
+				stack = append(stack, to)
+			}
+		}
+	}
+	return cnt == n
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 3
+		input := fmt.Sprintf("%d\n", n)
+		out, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		edges, err := parseEdges(out, n)
+		if err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%soutput:\n%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+		if !isTree(n, edges) {
+			fmt.Printf("case %d failed: output is not a tree\ninput:\n%soutput:\n%s\n", i+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to test any binary for problem A
- add similar verifiers B–H with random test generation
- brute-force enumeration for problem E
- tree-based checking logic for problem G
- verify simple tree output for interactive problem H

## Testing
- `go build 1000-1999/1900-1999/1910-1919/1919/verifierA.go`
- `go build 1000-1999/1900-1999/1910-1919/1919/verifierB.go`
- `go build 1000-1999/1900-1999/1910-1919/1919/verifierC.go`
- `go build 1000-1999/1900-1999/1910-1919/1919/verifierD.go`
- `go build 1000-1999/1900-1999/1910-1919/1919/verifierE.go`
- `go build 1000-1999/1900-1999/1910-1919/1919/verifierF1.go`
- `go build 1000-1999/1900-1999/1910-1919/1919/verifierF2.go`
- `go build 1000-1999/1900-1999/1910-1919/1919/verifierG.go`
- `go build 1000-1999/1900-1999/1910-1919/1919/verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_688787602d3083249090ee85c2a21f99