### PR TITLE
Add solution verifiers for contest 1922

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1922/verifierA.go
+++ b/1000-1999/1900-1999/1920-1929/1922/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1922A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		var a, b, c strings.Builder
+		for j := 0; j < n; j++ {
+			a.WriteByte(byte('a' + rand.Intn(26)))
+			b.WriteByte(byte('a' + rand.Intn(26)))
+			c.WriteByte(byte('a' + rand.Intn(26)))
+		}
+		tests[i] = fmt.Sprintf("1\n%d\n%s\n%s\n%s\n", n, a.String(), b.String(), c.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1920-1929/1922/verifierB.go
+++ b/1000-1999/1900-1999/1920-1929/1922/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1922B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(2)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(50) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(n+1)))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1920-1929/1922/verifierC.go
+++ b/1000-1999/1900-1999/1920-1929/1922/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1922C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(3)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 2
+		a := make([]int, n)
+		cur := rand.Intn(5)
+		a[0] = cur
+		prevDiff := rand.Intn(10) + 1
+		for j := 1; j < n; j++ {
+			diff := rand.Intn(10) + 1
+			for diff == prevDiff {
+				diff = rand.Intn(10) + 1
+			}
+			cur += diff
+			a[j] = cur
+			prevDiff = diff
+		}
+		m := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[j]))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for j := 0; j < m; j++ {
+			x := rand.Intn(n) + 1
+			y := rand.Intn(n) + 1
+			for y == x {
+				y = rand.Intn(n) + 1
+			}
+			sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1920-1929/1922/verifierD.go
+++ b/1000-1999/1900-1999/1920-1929/1922/verifierD.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1922D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(4)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(100)+1))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(100)+1))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1920-1929/1922/verifierE.go
+++ b/1000-1999/1900-1999/1920-1929/1922/verifierE.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1922E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(5)
+	tests := make([]string, 100)
+	for i := range tests {
+		x := rand.Int63n(1e12-1) + 2
+		tests[i] = fmt.Sprintf("1\n%d\n", x)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1920-1929/1922/verifierF.go
+++ b/1000-1999/1900-1999/1920-1929/1922/verifierF.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1922F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []string {
+	rand.Seed(6)
+	tests := make([]string, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 1
+		x := rand.Intn(n) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(x)+1))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		exp, err := run(ref, t)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := run(candidate, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != out {
+			fmt.Printf("wrong answer on test %d\nexpected: %s\ngot: %s\n", i+1, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- implement verifiers for contest 1922 problems A–F
- each verifier builds the official Go solution and tests 100 randomly generated cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go run verifierA.go ./candA.bin`
- `go run verifierB.go ./candB.bin`
- `go run verifierE.go ./candE.bin`

------
https://chatgpt.com/codex/tasks/task_e_6887883207e88324a7da4152a6898ea8