### PR TITLE
Add Go verifiers for contest 1924

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1924/verifierA.go
+++ b/1000-1999/1900-1999/1920-1929/1924/verifierA.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "cand*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func buildOracle() (string, func(), error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1924A.go")
+	tmp, err := os.CreateTemp("", "oracle*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	if out, err := exec.Command("go", "build", "-o", tmp.Name(), src).CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	if k > 26 {
+		k = 26
+	}
+	m := rng.Intn(20) + n
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	var sb strings.Builder
+	for i := 0; i < m; i++ {
+		sb.WriteByte(letters[rng.Intn(k)])
+	}
+	return fmt.Sprintf("1\n%d %d %d\n%s\n", n, k, m, sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	oracle, ocleanup, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer ocleanup()
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1924/verifierB.go
+++ b/1000-1999/1900-1999/1920-1929/1924/verifierB.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "cand*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func buildOracle() (string, func(), error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1924B.go")
+	tmp, err := os.CreateTemp("", "oracle*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	if out, err := exec.Command("go", "build", "-o", tmp.Name(), src).CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 2
+	m := rng.Intn(n-1) + 2
+	q := rng.Intn(5) + 1
+
+	used := map[int]bool{1: true, n: true}
+	pos := []int{1, n}
+	for len(pos) < m {
+		x := rng.Intn(n-2) + 2
+		if !used[x] {
+			used[x] = true
+			pos = append(pos, x)
+		}
+	}
+	sort.Ints(pos)
+	vals := make([]int, m)
+	for i := range vals {
+		vals[i] = rng.Intn(100) + 1
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+	for i, x := range pos {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", x))
+	}
+	sb.WriteByte('\n')
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+
+	for j := 0; j < q; j++ {
+		if j == 0 || rng.Intn(2) == 0 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", l, r))
+		} else {
+			x := rng.Intn(n-2) + 2
+			for used[x] {
+				x = rng.Intn(n-2) + 2
+			}
+			used[x] = true
+			v := rng.Intn(100) + 1
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", x, v))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	oracle, ocleanup, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer ocleanup()
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1924/verifierC.go
+++ b/1000-1999/1900-1999/1920-1929/1924/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "cand*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func buildOracle() (string, func(), error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1924C.go")
+	tmp, err := os.CreateTemp("", "oracle*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	if out, err := exec.Command("go", "build", "-o", tmp.Name(), src).CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	N := rng.Int63n(1000) + 1
+	return fmt.Sprintf("1\n%d\n", N)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	oracle, ocleanup, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer ocleanup()
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1924/verifierD.go
+++ b/1000-1999/1900-1999/1920-1929/1924/verifierD.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "cand*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func buildOracle() (string, func(), error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1924D.go")
+	tmp, err := os.CreateTemp("", "oracle*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	if out, err := exec.Command("go", "build", "-o", tmp.Name(), src).CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	maxk := n
+	if m < maxk {
+		maxk = m
+	}
+	k := rng.Intn(maxk) + 1
+	return fmt.Sprintf("1\n%d %d %d\n", n, m, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	oracle, ocleanup, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer ocleanup()
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1924/verifierE.go
+++ b/1000-1999/1900-1999/1920-1929/1924/verifierE.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "cand*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func buildOracle() (string, func(), error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1924E.go")
+	tmp, err := os.CreateTemp("", "oracle*")
+	if err != nil {
+		return "", nil, err
+	}
+	tmp.Close()
+	if out, err := exec.Command("go", "build", "-o", tmp.Name(), src).CombinedOutput(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	k := int64(rng.Intn(n*m+5) + 1)
+	if k < 2 {
+		k = 2
+	}
+	return fmt.Sprintf("1\n%d %d %d\n", n, m, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	oracle, ocleanup, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer ocleanup()
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1924/verifierF.go
+++ b/1000-1999/1900-1999/1920-1929/1924/verifierF.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "cand*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func runOnce(exe string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, exe)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	for i := 0; i < 100; i++ {
+		if err := runOnce(cand); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add automatic verifiers for all contest 1924 problems (A–F)
- each verifier compiles the provided candidate solution and compares it against the reference implementation from this repo using 100 randomly generated test cases
- interactive problem F verifier simply checks the binary runs successfully

## Testing
- `go build 1000-1999/1900-1999/1920-1929/1924/verifierA.go`
- `go build 1000-1999/1900-1999/1920-1929/1924/verifierB.go`
- `go build 1000-1999/1900-1999/1920-1929/1924/verifierC.go`
- `go build 1000-1999/1900-1999/1920-1929/1924/verifierD.go`
- `go build 1000-1999/1900-1999/1920-1929/1924/verifierE.go`
- `go build 1000-1999/1900-1999/1920-1929/1924/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688788be39388324875b7d862b8ca077