### PR TITLE
Add Go verifiers for contest 1926

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1926/verifierA.go
+++ b/1000-1999/1900-1999/1920-1929/1926/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(s string) string {
+	cntA := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == 'A' {
+			cntA++
+		}
+	}
+	if cntA > len(s)-cntA {
+		return "A"
+	}
+	return "B"
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	var all []string
+	for i := 0; i < 32; i++ {
+		var sb strings.Builder
+		for j := 4; j >= 0; j-- {
+			if i&(1<<j) != 0 {
+				sb.WriteByte('A')
+			} else {
+				sb.WriteByte('B')
+			}
+		}
+		all = append(all, sb.String())
+	}
+	var tests []string
+	for len(tests) < 100 {
+		tests = append(tests, all...)
+	}
+	tests = tests[:100]
+
+	for idx, s := range tests {
+		in := fmt.Sprintf("1\n%s\n", s)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		exp := expected(s)
+		if got != exp {
+			fmt.Printf("test %d failed: input=%s expected=%s got=%s\n", idx+1, s, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1920-1929/1926/verifierB.go
+++ b/1000-1999/1900-1999/1920-1929/1926/verifierB.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(grid []string) string {
+	n := len(grid)
+	minR, maxR := n, -1
+	minC, maxC := n, -1
+	ones := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if grid[i][j] == '1' {
+				ones++
+				if i < minR {
+					minR = i
+				}
+				if i > maxR {
+					maxR = i
+				}
+				if j < minC {
+					minC = j
+				}
+				if j > maxC {
+					maxC = j
+				}
+			}
+		}
+	}
+	height := maxR - minR + 1
+	width := maxC - minC + 1
+	if height == width {
+		ok := true
+		for i := minR; i <= maxR && ok; i++ {
+			for j := minC; j <= maxC; j++ {
+				if grid[i][j] != '1' {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok && ones == height*width {
+			return "SQUARE"
+		}
+	}
+	return "TRIANGLE"
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func makeSquare(n, k, r, c int) []string {
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, n)
+		for j := range row {
+			row[j] = '0'
+		}
+		grid[i] = string(row)
+	}
+	for i := 0; i < k; i++ {
+		row := []byte(grid[r+i])
+		for j := 0; j < k; j++ {
+			row[c+j] = '1'
+		}
+		grid[r+i] = string(row)
+	}
+	return grid
+}
+
+func makeTriangle(n, k, r, c int, down bool) []string {
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, n)
+		for j := range row {
+			row[j] = '0'
+		}
+		grid[i] = string(row)
+	}
+	if down {
+		for i := 0; i < k; i++ {
+			row := []byte(grid[r+i])
+			start := c + i
+			for j := 0; j < 2*(k-i)-1; j++ {
+				row[start+j] = '1'
+			}
+			grid[r+i] = string(row)
+		}
+	} else {
+		for i := 0; i < k; i++ {
+			row := []byte(grid[r+k-1-i])
+			start := c + i
+			for j := 0; j < 2*(k-i)-1; j++ {
+				row[start+j] = '1'
+			}
+			grid[r+k-1-i] = string(row)
+		}
+	}
+	return grid
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	var tests [][]string
+	n := 7
+	// squares
+	for size := 2; len(tests) < 50 && size <= 4; size++ {
+		for r := 0; r+size <= n && len(tests) < 50; r++ {
+			for c := 0; c+size <= n && len(tests) < 50; c++ {
+				tests = append(tests, makeSquare(n, size, r, c))
+			}
+		}
+	}
+	// triangles
+	for size := 2; len(tests) < 100 && size <= 4; size++ {
+		for r := 0; r+size <= n && len(tests) < 100; r++ {
+			for c := 0; c+2*size-1 <= n && len(tests) < 100; c++ {
+				tests = append(tests, makeTriangle(n, size, r, c, false))
+			}
+		}
+	}
+	for idx, grid := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", len(grid)))
+		for _, row := range grid {
+			sb.WriteString(row)
+			sb.WriteByte('\n')
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		exp := expected(grid)
+		if got != exp {
+			fmt.Printf("test %d failed: expected=%s got=%s\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1920-1929/1926/verifierC.go
+++ b/1000-1999/1900-1999/1920-1929/1926/verifierC.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const maxN = 200000
+
+var prefix [maxN + 1]int64
+var sumDigits [maxN + 1]int
+
+func init() {
+	for i := 1; i <= maxN; i++ {
+		sumDigits[i] = sumDigits[i/10] + i%10
+		prefix[i] = prefix[i-1] + int64(sumDigits[i])
+	}
+}
+
+func expected(n int) string {
+	if n > maxN {
+		n = maxN
+	}
+	return fmt.Sprint(prefix[n])
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	var tests []int
+	for i := 1; i <= 99; i++ {
+		n := i * 2000
+		if n > maxN {
+			n = maxN
+		}
+		tests = append(tests, n)
+	}
+	tests = append(tests, maxN)
+
+	for idx, n := range tests {
+		in := fmt.Sprintf("1\n%d\n", n)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		exp := expected(n)
+		if got != exp {
+			fmt.Printf("test %d failed: n=%d expected=%s got=%s\n", idx+1, n, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1920-1929/1926/verifierD.go
+++ b/1000-1999/1900-1999/1920-1929/1926/verifierD.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mask = (1 << 31) - 1
+
+func expected(arr []int) string {
+	freq := make(map[int]int)
+	pairs := 0
+	for _, x := range arr {
+		c := mask ^ x
+		if freq[c] > 0 {
+			freq[c]--
+			pairs++
+		} else {
+			freq[x]++
+		}
+	}
+	return fmt.Sprint(len(arr) - pairs)
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	var tests [][]int
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(mask)
+		}
+		tests = append(tests, arr)
+	}
+	for idx, arr := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		exp := expected(arr)
+		if got != exp {
+			fmt.Printf("test %d failed: expected=%s got=%s\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1920-1929/1926/verifierE.go
+++ b/1000-1999/1900-1999/1920-1929/1926/verifierE.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(n, k int64) string {
+	pow := int64(1)
+	for {
+		count := n/pow - n/(pow*2)
+		if k > count {
+			k -= count
+			pow <<= 1
+		} else {
+			ans := pow * (2*k - 1)
+			return fmt.Sprint(ans)
+		}
+	}
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	var tests [][2]int64
+	for i := 0; i < 100; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		k := rng.Int63n(n) + 1
+		tests = append(tests, [2]int64{n, k})
+	}
+	for idx, t := range tests {
+		in := fmt.Sprintf("1\n%d %d\n", t[0], t[1])
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		exp := expected(t[0], t[1])
+		if got != exp {
+			fmt.Printf("test %d failed: n=%d k=%d expected=%s got=%s\n", idx+1, t[0], t[1], exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1920-1929/1926/verifierF.go
+++ b/1000-1999/1900-1999/1920-1929/1926/verifierF.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const inf = int(1e9)
+
+var valid [128][128][128]bool
+
+func init() {
+	for p := 0; p < 128; p++ {
+		for c := 0; c < 128; c++ {
+			for n := 0; n < 128; n++ {
+				good := true
+				for j := 1; j <= 5; j++ {
+					if ((c>>j)&1) == 1 &&
+						((p>>(j-1))&1) == 1 &&
+						((p>>(j+1))&1) == 1 &&
+						((n>>(j-1))&1) == 1 &&
+						((n>>(j+1))&1) == 1 {
+						good = false
+						break
+					}
+				}
+				valid[p][c][n] = good
+			}
+		}
+	}
+}
+
+func expected(grid []string) string {
+	var orig [7]int
+	for i := 0; i < 7; i++ {
+		mask := 0
+		for j := 0; j < 7; j++ {
+			if grid[i][j] == 'B' {
+				mask |= 1 << j
+			}
+		}
+		orig[i] = mask
+	}
+	var cost [7][128]int
+	for i := 0; i < 7; i++ {
+		for m := 0; m < 128; m++ {
+			cost[i][m] = bits.OnesCount(uint(m ^ orig[i]))
+		}
+	}
+
+	var dp [128][128]int
+	for i := 0; i < 128; i++ {
+		for j := 0; j < 128; j++ {
+			dp[i][j] = inf
+		}
+	}
+	for m0 := 0; m0 < 128; m0++ {
+		for m1 := 0; m1 < 128; m1++ {
+			dp[m0][m1] = cost[0][m0] + cost[1][m1]
+		}
+	}
+	for row := 1; row <= 5; row++ {
+		var newdp [128][128]int
+		for i := 0; i < 128; i++ {
+			for j := 0; j < 128; j++ {
+				newdp[i][j] = inf
+			}
+		}
+		for prev := 0; prev < 128; prev++ {
+			for cur := 0; cur < 128; cur++ {
+				val := dp[prev][cur]
+				if val >= inf {
+					continue
+				}
+				for next := 0; next < 128; next++ {
+					if !valid[prev][cur][next] {
+						continue
+					}
+					v := val + cost[row+1][next]
+					if v < newdp[cur][next] {
+						newdp[cur][next] = v
+					}
+				}
+			}
+		}
+		dp = newdp
+	}
+	res := inf
+	for prev := 0; prev < 128; prev++ {
+		for cur := 0; cur < 128; cur++ {
+			if dp[prev][cur] < res {
+				res = dp[prev][cur]
+			}
+		}
+	}
+	return fmt.Sprint(res)
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func randGrid(rng *rand.Rand) []string {
+	grid := make([]string, 7)
+	for i := 0; i < 7; i++ {
+		row := make([]byte, 7)
+		for j := 0; j < 7; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = 'W'
+			} else {
+				row[j] = 'B'
+			}
+		}
+		grid[i] = string(row)
+	}
+	return grid
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	var tests [][]string
+	for i := 0; i < 100; i++ {
+		tests = append(tests, randGrid(rng))
+	}
+	for idx, grid := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		for _, row := range grid {
+			sb.WriteString(row)
+			sb.WriteByte('\n')
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		exp := expected(grid)
+		if got != exp {
+			fmt.Printf("test %d failed: expected=%s got=%s\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1920-1929/1926/verifierG.go
+++ b/1000-1999/1900-1999/1920-1929/1926/verifierG.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const inf = int(1e9)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expected(n int, parents []int, s string) string {
+	g := make([][]int, n)
+	parent := make([]int, n)
+	parent[0] = -1
+	for i := 1; i < n; i++ {
+		a := parents[i-1]
+		g[a] = append(g[a], i)
+		g[i] = append(g[i], a)
+	}
+	order := make([]int, 0, n)
+	stack := []int{0}
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, v)
+		for _, to := range g[v] {
+			if to == parent[v] {
+				continue
+			}
+			parent[to] = v
+			stack = append(stack, to)
+		}
+	}
+
+	dp0 := make([]int, n)
+	dp1 := make([]int, n)
+	for i := n - 1; i >= 0; i-- {
+		v := order[i]
+		var val0, val1 int
+		switch s[v] {
+		case 'S':
+			val0 = inf
+			val1 = 0
+		case 'P':
+			val0 = 0
+			val1 = inf
+		default:
+			val0 = 0
+			val1 = 0
+		}
+		for _, to := range g[v] {
+			if to == parent[v] {
+				continue
+			}
+			val0 += min(dp0[to], dp1[to]+1)
+			val1 += min(dp1[to], dp0[to]+1)
+		}
+		dp0[v] = val0
+		dp1[v] = val1
+	}
+	ans := min(dp0[0], dp1[0])
+	return fmt.Sprint(ans)
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func randTree(rng *rand.Rand, n int) []int {
+	par := make([]int, n-1)
+	for i := 2; i <= n; i++ {
+		par[i-2] = rng.Intn(i - 1)
+	}
+	return par
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := []byte{'P', 'S', 'C'}
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	type test struct {
+		n   int
+		par []int
+		s   string
+	}
+	var tests []test
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 2
+		par := randTree(rng, n)
+		s := randString(rng, n)
+		tests = append(tests, test{n: n, par: par, s: s})
+	}
+	for idx, t := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", t.n))
+		for i, v := range t.par {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v + 1))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(t.s)
+		sb.WriteByte('\n')
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		exp := expected(t.n, t.par, t.s)
+		if got != exp {
+			fmt.Printf("test %d failed: expected=%s got=%s\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1926 problems A–G
- each verifier runs 100 deterministic test cases
- verifiers support executing binaries or Go source files

## Testing
- `go version`
- `go run verifierA.go 1926A.go` *(fails: conflicting main packages)*
- `go run verifierA.go -- 1926A.go` *(shows usage due to Go run argument parsing)*


------
https://chatgpt.com/codex/tasks/task_e_6887894a55008324be7436418389901c