### PR TITLE
Add verifiers for Codeforces Round 1923

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1923/verifierA.go
+++ b/1000-1999/1900-1999/1920-1929/1923/verifierA.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	n   int
+	arr []int
+}
+
+func solve(arr []int) int {
+	first := -1
+	last := -1
+	for i, v := range arr {
+		if v == 1 {
+			if first == -1 {
+				first = i
+			}
+			last = i
+		}
+	}
+	if first == -1 {
+		return 0
+	}
+	cnt := 0
+	for i := first; i <= last; i++ {
+		if arr[i] == 0 {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(49) + 2 // 2..50
+		arr := make([]int, n)
+		hasOne := false
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 1 {
+				arr[i] = 1
+				hasOne = true
+			}
+		}
+		if !hasOne {
+			arr[rng.Intn(n)] = 1
+		}
+		tests = append(tests, test{n, arr})
+	}
+	return tests
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(t.n))
+		sb.WriteString("\n")
+		for j, v := range t.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteString("\n")
+		expected := strconv.Itoa(solve(t.arr))
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1900-1999/1920-1929/1923/verifierB.go
+++ b/1000-1999/1900-1999/1920-1929/1923/verifierB.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	n int
+	k int64
+	a []int64
+	x []int64
+}
+
+func solve(n int, k int64, a, x []int64) string {
+	type pair struct {
+		t int64
+		a int64
+	}
+	p := make([]pair, n)
+	for i := 0; i < n; i++ {
+		t := x[i]
+		if t < 0 {
+			t = -t
+		}
+		p[i] = pair{t, a[i]}
+	}
+	sort.Slice(p, func(i, j int) bool { return p[i].t < p[j].t })
+	var sum int64
+	for _, pr := range p {
+		sum += pr.a
+		if sum > k*pr.t {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(43))
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 1
+		k := int64(rng.Intn(10) + 1)
+		a := make([]int64, n)
+		x := make([]int64, n)
+		for i := 0; i < n; i++ {
+			a[i] = int64(rng.Intn(5) + 1)
+			x[i] = int64(rng.Intn(10) - 5) // -5..4
+		}
+		tests = append(tests, test{n, k, a, x})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.k))
+		for j, v := range t.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(v, 10))
+		}
+		sb.WriteString("\n")
+		for j, v := range t.x {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(v, 10))
+		}
+		sb.WriteString("\n")
+		exp := solve(t.n, t.k, t.a, t.x)
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1900-1999/1920-1929/1923/verifierC.go
+++ b/1000-1999/1900-1999/1920-1929/1923/verifierC.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type query struct{ l, r int }
+
+type test struct {
+	n  int
+	q  int
+	c  []int64
+	qs []query
+}
+
+func solve(n int, c []int64, qs []query) []string {
+	prefSum := make([]int64, n+1)
+	prefOnes := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		prefSum[i] = prefSum[i-1] + c[i-1]
+		prefOnes[i] = prefOnes[i-1]
+		if c[i-1] == 1 {
+			prefOnes[i]++
+		}
+	}
+	ans := make([]string, len(qs))
+	for i, q := range qs {
+		length := q.r - q.l + 1
+		sum := prefSum[q.r] - prefSum[q.l-1]
+		ones := prefOnes[q.r] - prefOnes[q.l-1]
+		if length <= 1 || sum < int64(length+ones) {
+			ans[i] = "NO"
+		} else {
+			ans[i] = "YES"
+		}
+	}
+	return ans
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(44))
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 2
+		q := rng.Intn(5) + 1
+		c := make([]int64, n)
+		for i := 0; i < n; i++ {
+			c[i] = int64(rng.Intn(5) + 1)
+		}
+		qs := make([]query, q)
+		for i := 0; i < q; i++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			qs[i] = query{l, r}
+		}
+		tests = append(tests, test{n, q, c, qs})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.q))
+		for j, v := range t.c {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(v, 10))
+		}
+		sb.WriteString("\n")
+		for _, qq := range t.qs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", qq.l, qq.r))
+		}
+		expLines := solve(t.n, t.c, t.qs)
+		expected := strings.Join(expLines, "\n")
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1900-1999/1920-1929/1923/verifierD.go
+++ b/1000-1999/1900-1999/1920-1929/1923/verifierD.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	n int
+	a []int64
+}
+
+type state struct {
+	arr []int64
+	idx []int
+	t   int
+}
+
+func encode(arr []int64, idx []int) string {
+	var sb strings.Builder
+	for i := range arr {
+		sb.WriteString(strconv.FormatInt(arr[i], 10))
+		sb.WriteByte(':')
+		sb.WriteString(strconv.Itoa(idx[i]))
+		sb.WriteByte('|')
+	}
+	return sb.String()
+}
+
+func solve(a []int64) []int {
+	n := len(a)
+	best := make([]int, n)
+	for i := range best {
+		best[i] = -1
+	}
+	start := state{arr: append([]int64(nil), a...), idx: make([]int, n), t: 0}
+	for i := range start.idx {
+		start.idx[i] = i
+	}
+	visited := map[string]bool{encode(start.arr, start.idx): true}
+	q := list.New()
+	q.PushBack(start)
+	for q.Len() > 0 {
+		v := q.Remove(q.Front()).(state)
+		arr, idxs, t := v.arr, v.idx, v.t
+		for i := 0; i < len(arr)-1; i++ {
+			if arr[i] > arr[i+1] {
+				na := make([]int64, len(arr)-1)
+				ni := make([]int, len(idxs)-1)
+				copy(na[:i], arr[:i])
+				na[i] = arr[i] + arr[i+1]
+				copy(na[i+1:], arr[i+2:])
+				copy(ni[:i], idxs[:i])
+				ni[i] = idxs[i]
+				copy(ni[i+1:], idxs[i+2:])
+				if best[idxs[i+1]] == -1 || best[idxs[i+1]] > t+1 {
+					best[idxs[i+1]] = t + 1
+				}
+				key := encode(na, ni)
+				if !visited[key] {
+					visited[key] = true
+					q.PushBack(state{na, ni, t + 1})
+				}
+			}
+			if arr[i+1] > arr[i] {
+				na := make([]int64, len(arr)-1)
+				ni := make([]int, len(idxs)-1)
+				copy(na[:i], arr[:i])
+				na[i] = arr[i] + arr[i+1]
+				copy(na[i+1:], arr[i+2:])
+				copy(ni[:i], idxs[:i])
+				ni[i] = idxs[i+1]
+				copy(ni[i+1:], idxs[i+2:])
+				if best[idxs[i]] == -1 || best[idxs[i]] > t+1 {
+					best[idxs[i]] = t + 1
+				}
+				key := encode(na, ni)
+				if !visited[key] {
+					visited[key] = true
+					q.PushBack(state{na, ni, t + 1})
+				}
+			}
+		}
+	}
+	return best
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(45))
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 2
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			arr[i] = int64(rng.Intn(5) + 1)
+		}
+		tests = append(tests, test{n, arr})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(t.n))
+		sb.WriteString("\n")
+		for j, v := range t.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(v, 10))
+		}
+		sb.WriteString("\n")
+		expectedArr := solve(t.a)
+		expected := make([]string, len(expectedArr))
+		for j, v := range expectedArr {
+			expected[j] = strconv.Itoa(v)
+		}
+		exp := strings.Join(expected, " ")
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1900-1999/1920-1929/1923/verifierE.go
+++ b/1000-1999/1900-1999/1920-1929/1923/verifierE.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type edge struct{ u, v int }
+
+type test struct {
+	n      int
+	colors []int
+	edges  []edge
+}
+
+func countPaths(n int, colors []int, edges []edge) int64 {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	var ans int64
+	// BFS for each pair
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			if colors[i-1] != colors[j-1] {
+				continue
+			}
+			// BFS to find path
+			prev := make([]int, n+1)
+			for idx := range prev {
+				prev[idx] = -1
+			}
+			q := []int{i}
+			prev[i] = i
+			for len(q) > 0 && prev[j] == -1 {
+				cur := q[0]
+				q = q[1:]
+				for _, to := range adj[cur] {
+					if prev[to] == -1 {
+						prev[to] = cur
+						q = append(q, to)
+					}
+				}
+			}
+			if prev[j] == -1 {
+				continue
+			}
+			ok := true
+			cur := j
+			for prev[cur] != cur {
+				cur = prev[cur]
+				if cur != i && colors[cur-1] == colors[i-1] {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(46))
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(6) + 2
+		colors := make([]int, n)
+		for i := 0; i < n; i++ {
+			colors[i] = rng.Intn(3) + 1
+		}
+		edges := make([]edge, 0, n-1)
+		parent := make([]int, n+1)
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			edges = append(edges, edge{p, i})
+			parent[i] = p
+		}
+		tests = append(tests, test{n, colors, edges})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(t.n))
+		sb.WriteString("\n")
+		for j, v := range t.colors {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteString("\n")
+		for _, e := range t.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+		}
+		expected := strconv.FormatInt(countPaths(t.n, t.colors, t.edges), 10)
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1900-1999/1920-1929/1923/verifierF.go
+++ b/1000-1999/1900-1999/1920-1929/1923/verifierF.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	n int
+	k int
+	s string
+}
+
+func shrinkReverse(s string) string {
+	i := 0
+	for i < len(s) && s[i] == '0' {
+		i++
+	}
+	t := []byte(s[i:])
+	for l, r := 0, len(t)-1; l < r; l, r = l+1, r-1 {
+		t[l], t[r] = t[r], t[l]
+	}
+	return string(t)
+}
+
+func value(s string) int64 {
+	var val int64
+	for i := 0; i < len(s); i++ {
+		val = val*2 + int64(s[i]-'0')
+	}
+	return val
+}
+
+func minValue(n int, k int, s string) int64 {
+	type node struct {
+		str  string
+		step int
+	}
+	best := value(s)
+	seen := map[string]int{s: 0}
+	q := []node{{s, 0}}
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		if val := value(cur.str); val < best {
+			best = val
+		}
+		if cur.step == k {
+			continue
+		}
+		// swap operations
+		bytes := []byte(cur.str)
+		for i := 0; i < len(bytes); i++ {
+			for j := i + 1; j < len(bytes); j++ {
+				b := append([]byte(nil), bytes...)
+				b[i], b[j] = b[j], b[i]
+				ns := string(b)
+				if p, ok := seen[ns]; !ok || p > cur.step+1 {
+					seen[ns] = cur.step + 1
+					q = append(q, node{ns, cur.step + 1})
+				}
+			}
+		}
+		// shrink reverse
+		ns := shrinkReverse(cur.str)
+		if p, ok := seen[ns]; !ok || p > cur.step+1 {
+			seen[ns] = cur.step + 1
+			q = append(q, node{ns, cur.step + 1})
+		}
+	}
+	return best
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(47))
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(6) + 2
+		k := rng.Intn(n) + 1
+		b := make([]byte, n)
+		hasOne := false
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 1 {
+				b[i] = '1'
+				hasOne = true
+			} else {
+				b[i] = '0'
+			}
+		}
+		if !hasOne {
+			b[rng.Intn(n)] = '1'
+		}
+		tests = append(tests, test{n, k, string(b)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n%s\n", t.n, t.k, t.s)
+		expected := strconv.FormatInt(minValue(t.n, t.k, t.s), 10)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–F of contest 1923
- each verifier generates 100+ random tests and checks a given binary

## Testing
- `go run verifierA.go ./candA.bin`
- `go run verifierB.go ./candB.bin`
- `go run verifierC.go ./candC.bin`
- `go run verifierD.go ./candD.bin` *(fails as expected)*
- `go run verifierE.go ./candE.bin` *(fails as expected)*
- `go run verifierF.go ./candF.bin`

------
https://chatgpt.com/codex/tasks/task_e_688788781d948324a18812d995a92aa9