### PR TITLE
Add verifiers for contest 1929

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1929/verifierA.go
+++ b/1000-1999/1900-1999/1920-1929/1929/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1929A.go")
+	refBin := filepath.Join(os.TempDir(), "1929A_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(99) + 2 // 2..100
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rand.Int63n(1_000_000_000) + 1
+		sb.WriteString(fmt.Sprintf("%d", val))
+	}
+	sb.WriteString("\n")
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1929/verifierB.go
+++ b/1000-1999/1900-1999/1920-1929/1929/verifierB.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1929B.go")
+	refBin := filepath.Join(os.TempDir(), "1929B_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Int63n(100_000_000-1) + 2 // 2..1e8
+	k := rand.Int63n(4*n-2) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1929/verifierC.go
+++ b/1000-1999/1900-1999/1920-1929/1929/verifierC.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1929C.go")
+	refBin := filepath.Join(os.TempDir(), "1929C_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	k := rand.Int63n(29) + 2  // 2..30
+	x := rand.Int63n(100) + 1 // 1..100
+	a := rand.Int63n(1_000_000_000) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", k, x, a))
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1929/verifierD.go
+++ b/1000-1999/1900-1999/1920-1929/1929/verifierD.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1929D.go")
+	refBin := filepath.Join(os.TempDir(), "1929D_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(15) + 2 // small tree
+	edges := make([][2]int, 0, n-1)
+	for v := 2; v <= n; v++ {
+		p := rand.Intn(v-1) + 1
+		edges = append(edges, [2]int{p, v})
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1929/verifierE.go
+++ b/1000-1999/1900-1999/1920-1929/1929/verifierE.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1929E.go")
+	refBin := filepath.Join(os.TempDir(), "1929E_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(8) + 2
+	edges := make([][2]int, 0, n-1)
+	for v := 2; v <= n; v++ {
+		p := rand.Intn(v-1) + 1
+		edges = append(edges, [2]int{p, v})
+	}
+	k := rand.Intn(4) + 1
+	if k > n-1 {
+		k = n - 1
+		if k == 0 {
+			k = 1
+		}
+	}
+	pairs := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		a := rand.Intn(n) + 1
+		b := rand.Intn(n-1) + 1
+		if b >= a {
+			b++
+		}
+		pairs[i] = [2]int{a, b}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	for _, p := range pairs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1920-1929/1929/verifierF.go
+++ b/1000-1999/1900-1999/1920-1929/1929/verifierF.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1929F.go")
+	refBin := filepath.Join(os.TempDir(), "1929F_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTree(n int) ([]int, []int) {
+	left := make([]int, n+1)
+	right := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		left[i] = -1
+		right[i] = -1
+	}
+	avail := []int{1}
+	for v := 2; v <= n; v++ {
+		pIdx := rand.Intn(len(avail))
+		p := avail[pIdx]
+		if left[p] == -1 && (rand.Intn(2) == 0 || right[p] != -1) {
+			left[p] = v
+		} else {
+			right[p] = v
+		}
+		if left[p] != -1 && right[p] != -1 {
+			avail[pIdx] = avail[len(avail)-1]
+			avail = avail[:len(avail)-1]
+		}
+		avail = append(avail, v)
+	}
+	return left, right
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 2
+	C := rand.Int63n(20) + 1
+	left, right := genTree(n)
+	vals := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		if rand.Intn(2) == 0 {
+			vals[i] = -1
+		} else {
+			vals[i] = rand.Int63n(C) + 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, C))
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", left[i], right[i], vals[i]))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verification programs for problems A-F of contest 1929
- verifiers build the reference solution and check any binary on 100 random tests

## Testing
- `go test ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68878a1c6ef08324b024e6bb543e929a