### PR TITLE
Add verifiers for contest 1928

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1928/verifierA.go
+++ b/1000-1999/1900-1999/1920-1929/1928/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genTests() []byte {
+	rand.Seed(42)
+	var sb strings.Builder
+	t := 120
+	fmt.Fprintf(&sb, "%d\n", t)
+	// few fixed edge cases
+	edge := [][2]int64{{1, 1}, {1, 2}, {1, 3}, {2, 2}, {2, 3}, {2, 4}}
+	for _, e := range edge {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	for i := len(edge); i < t; i++ {
+		a := rand.Int63n(1e9) + 1
+		b := rand.Int63n(1e9) + 1
+		fmt.Fprintf(&sb, "%d %d\n", a, b)
+	}
+	return []byte(sb.String())
+}
+
+func runCmd(cmd *exec.Cmd, input []byte) (string, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	input := genTests()
+	candCmd := exec.Command(os.Args[1])
+	candOut, err := runCmd(candCmd, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "candidate error: %v\n", err)
+		os.Exit(1)
+	}
+	refCmd := exec.Command("go", "run", "1928A.go")
+	refOut, err := runCmd(refCmd, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reference error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+		fmt.Println("WA")
+		fmt.Println("input:\n" + string(input))
+		fmt.Println("expected:\n" + refOut)
+		fmt.Println("got:\n" + candOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+	_ = time.Now() // avoid import warning
+}

--- a/1000-1999/1900-1999/1920-1929/1928/verifierB.go
+++ b/1000-1999/1900-1999/1920-1929/1928/verifierB.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func genTests() []byte {
+	rand.Seed(43)
+	var sb strings.Builder
+	t := 120
+	fmt.Fprintf(&sb, "%d\n", t)
+	total := 0
+	for i := 0; i < t; i++ {
+		n := rand.Intn(50) + 1
+		total += n
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			v := rand.Intn(1000) + 1
+			fmt.Fprintf(&sb, "%d", v)
+			if j+1 < n {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	_ = total
+	return []byte(sb.String())
+}
+
+func runCmd(cmd *exec.Cmd, input []byte) (string, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	input := genTests()
+	candCmd := exec.Command(os.Args[1])
+	candOut, err := runCmd(candCmd, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "candidate error: %v\n", err)
+		os.Exit(1)
+	}
+	refCmd := exec.Command("go", "run", "1928B.go")
+	refOut, err := runCmd(refCmd, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reference error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+		fmt.Println("WA")
+		fmt.Println("input:\n" + string(input))
+		fmt.Println("expected:\n" + refOut)
+		fmt.Println("got:\n" + candOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1900-1999/1920-1929/1928/verifierC.go
+++ b/1000-1999/1900-1999/1920-1929/1928/verifierC.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func genTests() []byte {
+	rand.Seed(44)
+	var sb strings.Builder
+	t := 120
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Int63n(1e6) + 2
+		x := rand.Int63n(n-1) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, x)
+	}
+	return []byte(sb.String())
+}
+
+func runCmd(cmd *exec.Cmd, input []byte) (string, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	input := genTests()
+	candCmd := exec.Command(os.Args[1])
+	candOut, err := runCmd(candCmd, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "candidate error: %v\n", err)
+		os.Exit(1)
+	}
+	refCmd := exec.Command("go", "run", "1928C.go")
+	refOut, err := runCmd(refCmd, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reference error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+		fmt.Println("WA")
+		fmt.Println("input:\n" + string(input))
+		fmt.Println("expected:\n" + refOut)
+		fmt.Println("got:\n" + candOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1900-1999/1920-1929/1928/verifierD.go
+++ b/1000-1999/1900-1999/1920-1929/1928/verifierD.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func genTests() []byte {
+	rand.Seed(45)
+	t := 100
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(40) + 1
+		b := rand.Intn(20) + 1
+		x := rand.Int63n(50)
+		fmt.Fprintf(&sb, "%d %d %d\n", n, b, x)
+		for j := 0; j < n; j++ {
+			v := rand.Intn(50) + 1
+			fmt.Fprintf(&sb, "%d", v)
+			if j+1 < n {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func runCmd(cmd *exec.Cmd, input []byte) (string, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	input := genTests()
+	candCmd := exec.Command(os.Args[1])
+	candOut, err := runCmd(candCmd, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "candidate error: %v\n", err)
+		os.Exit(1)
+	}
+	refCmd := exec.Command("go", "run", "1928D.go")
+	refOut, err := runCmd(refCmd, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reference error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+		fmt.Println("WA")
+		fmt.Println("input:\n" + string(input))
+		fmt.Println("expected:\n" + refOut)
+		fmt.Println("got:\n" + candOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1900-1999/1920-1929/1928/verifierE.go
+++ b/1000-1999/1900-1999/1920-1929/1928/verifierE.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func genTests() []byte {
+	rand.Seed(46)
+	t := 110
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(30) + 1
+		x := rand.Intn(60)
+		y := rand.Intn(60) + 1
+		s := rand.Intn(100)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", n, x, y, s)
+	}
+	return []byte(sb.String())
+}
+
+func runCmd(cmd *exec.Cmd, input []byte) (string, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	input := genTests()
+	candCmd := exec.Command(os.Args[1])
+	candOut, err := runCmd(candCmd, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "candidate error: %v\n", err)
+		os.Exit(1)
+	}
+	refCmd := exec.Command("go", "run", "1928E.go")
+	refOut, err := runCmd(refCmd, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reference error: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+		fmt.Println("WA")
+		fmt.Println("input:\n" + string(input))
+		fmt.Println("expected:\n" + refOut)
+		fmt.Println("got:\n" + candOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1900-1999/1920-1929/1928/verifierF.go
+++ b/1000-1999/1900-1999/1920-1929/1928/verifierF.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func genTest() string {
+	n := rand.Intn(8) + 1
+	m := rand.Intn(8) + 1
+	q := rand.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, q)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d", rand.Intn(11)-5)
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&sb, "%d", rand.Intn(11)-5)
+		if i+1 < m {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		t := rand.Intn(2) + 1
+		if t == 1 {
+			l := rand.Intn(n) + 1
+			r := l + rand.Intn(n-l+1)
+			x := rand.Intn(11) - 5
+			fmt.Fprintf(&sb, "1 %d %d %d\n", l, r, x)
+		} else {
+			l := rand.Intn(m) + 1
+			r := l + rand.Intn(m-l+1)
+			x := rand.Intn(11) - 5
+			fmt.Fprintf(&sb, "2 %d %d %d\n", l, r, x)
+		}
+	}
+	return sb.String()
+}
+
+func runCmd(cmd *exec.Cmd, input []byte) (string, error) {
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	rand.Seed(47)
+	for i := 0; i < 100; i++ {
+		input := []byte(genTest())
+		candCmd := exec.Command(os.Args[1])
+		candOut, err := runCmd(candCmd, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error: %v\n", err)
+			os.Exit(1)
+		}
+		refCmd := exec.Command("go", "run", "1928F.go")
+		refOut, err := runCmd(refCmd, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error: %v\n", err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Println("WA on test", i+1)
+			fmt.Println("input:\n" + string(input))
+			fmt.Println("expected:\n" + refOut)
+			fmt.Println("got:\n" + candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for CF contest 1928 problems A-F
- verifiers run candidate binaries on 100+ generated tests and check output against reference solutions

## Testing
- `go run verifierA.go ./solA`

------
https://chatgpt.com/codex/tasks/task_e_688789d69c40832496891abb82f5425d