### PR TITLE
Add verifiers for Codeforces contest 1933

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1933/verifierA.go
+++ b/1000-1999/1900-1999/1930-1939/1933/verifierA.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsA = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binA")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleA")
+	cmd := exec.Command("go", "build", "-o", tmp, "1933A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(50) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Intn(201) - 100
+		fmt.Fprintf(&sb, "%d", val)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < numTestsA; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1933/verifierB.go
+++ b/1000-1999/1900-1999/1930-1939/1933/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsB = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binB")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleB")
+	cmd := exec.Command("go", "build", "-o", tmp, "1933B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Intn(100) + 1
+		fmt.Fprintf(&sb, "%d", val)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < numTestsB; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1933/verifierC.go
+++ b/1000-1999/1900-1999/1930-1939/1933/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsC = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binC")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleC")
+	cmd := exec.Command("go", "build", "-o", tmp, "1933C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	a := rng.Intn(8) + 2
+	b := rng.Intn(8) + 2
+	l := rng.Intn(100000) + 1
+	return fmt.Sprintf("1\n%d %d %d\n", a, b, l)
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < numTestsC; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1933/verifierD.go
+++ b/1000-1999/1900-1999/1930-1939/1933/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsD = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binD")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleD")
+	cmd := exec.Command("go", "build", "-o", tmp, "1933D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Intn(100) + 1
+		fmt.Fprintf(&sb, "%d", val)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < numTestsD; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1933/verifierE.go
+++ b/1000-1999/1900-1999/1930-1939/1933/verifierE.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsE = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binE")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleE")
+	cmd := exec.Command("go", "build", "-o", tmp, "1933E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d", val)
+	}
+	sb.WriteByte('\n')
+	q := rng.Intn(5) + 1
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		u := rng.Intn(20) + 1
+		fmt.Fprintf(&sb, "%d %d\n", l, u)
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(5))
+	for i := 0; i < numTestsE; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1933/verifierF.go
+++ b/1000-1999/1900-1999/1930-1939/1933/verifierF.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsF = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binF")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleF")
+	cmd := exec.Command("go", "build", "-o", tmp, "1933F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rng.Intn(2)
+			fmt.Fprintf(&sb, "%d", val)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(6))
+	for i := 0; i < numTestsF; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1933/verifierG.go
+++ b/1000-1999/1900-1999/1930-1939/1933/verifierG.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsG = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binG")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleG")
+	cmd := exec.Command("go", "build", "-o", tmp, "1933G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func randShape(rng *rand.Rand) string {
+	if rng.Intn(2) == 0 {
+		return "circle"
+	}
+	return "square"
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 5
+	m := rng.Intn(3) + 5
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d\n", n, m, q)
+	for i := 0; i < q; i++ {
+		r := rng.Intn(n) + 1
+		c := rng.Intn(m) + 1
+		fmt.Fprintf(&sb, "%d %d %s\n", r, c, randShape(rng))
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(7))
+	for i := 0; i < numTestsG; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for all problems of contest 1933
- each verifier builds candidate binaries and runs 100 randomized tests using the official solution

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_68878b3494208324965724c33b63b84c