### PR TITLE
Add Go solution verifiers for contest 1931

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1931/verifierA.go
+++ b/1000-1999/1900-1999/1930-1939/1931/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1931A.go")
+	tmpDir, err := os.MkdirTemp("", "ref1931A")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := r.Intn(76) + 3 // 3..78
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1931/verifierB.go
+++ b/1000-1999/1900-1999/1930-1939/1931/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1931B.go")
+	tmpDir, err := os.MkdirTemp("", "ref1931B")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := r.Intn(20) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		arr := make([]int, n)
+		sum := 0
+		for i := 0; i < n; i++ {
+			arr[i] = r.Intn(1000)
+			sum += arr[i]
+		}
+		arr[0] += (n - sum%n) % n
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1931/verifierC.go
+++ b/1000-1999/1900-1999/1930-1939/1931/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1931C.go")
+	tmpDir, err := os.MkdirTemp("", "ref1931C")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := r.Intn(20) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", r.Intn(n)+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1931/verifierD.go
+++ b/1000-1999/1900-1999/1930-1939/1931/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1931D.go")
+	tmpDir, err := os.MkdirTemp("", "ref1931D")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := r.Intn(20) + 2
+		x := r.Int63n(1000) + 1
+		y := r.Int63n(1000) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x, y))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", r.Int63n(1000)+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1931/verifierE.go
+++ b/1000-1999/1900-1999/1930-1939/1931/verifierE.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1931E.go")
+	tmpDir, err := os.MkdirTemp("", "ref1931E")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := r.Intn(20) + 1
+		m := r.Intn(1000)
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", r.Intn(1000)+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1931/verifierF.go
+++ b/1000-1999/1900-1999/1930-1939/1931/verifierF.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1931F.go")
+	tmpDir, err := os.MkdirTemp("", "ref1931F")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randPerm(r *rand.Rand, n int) []int {
+	arr := r.Perm(n)
+	for i := range arr {
+		arr[i]++
+	}
+	return arr
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		n := r.Intn(5) + 1
+		k := r.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		base := randPerm(r, n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", base[i]))
+		}
+		sb.WriteByte('\n')
+		for s := 1; s < k; s++ {
+			arr := randPerm(r, n)
+			for i := 0; i < n; i++ {
+				if i > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", arr[i]))
+			}
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1931/verifierG.go
+++ b/1000-1999/1900-1999/1930-1939/1931/verifierG.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1931G.go")
+	tmpDir, err := os.MkdirTemp("", "ref1931G")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for ; t > 0; t-- {
+		c1 := r.Intn(50)
+		c2 := r.Intn(50)
+		c3 := r.Intn(50)
+		c4 := r.Intn(50)
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", c1, c2, c3, c4))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go based verifiers for all problems of Codeforces contest 1931 (A–G)
- each verifier builds the reference solution, generates 100 random test cases and checks any candidate binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `./verifierA 1931A.go`

------
https://chatgpt.com/codex/tasks/task_e_68878aa8e330832499ac694572de683d