### PR TITLE
Add verifiers for contest 1932

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1932/verifierA.go
+++ b/1000-1999/1900-1999/1930-1939/1932/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1932A.go")
+	out := filepath.Join(os.TempDir(), "refA.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	n := rand.Intn(50) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", n))
+	cells := make([]byte, n)
+	cells[0] = '.'
+	options := []byte{'.', '@', '*'}
+	for i := 1; i < n; i++ {
+		cells[i] = options[rand.Intn(len(options))]
+	}
+	b.WriteString(string(cells))
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func genTest() string {
+	t := rand.Intn(5) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		b.WriteString(genCase())
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1932/verifierB.go
+++ b/1000-1999/1900-1999/1930-1939/1932/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1932B.go")
+	out := filepath.Join(os.TempDir(), "refB.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	n := rand.Intn(10) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprintf("%d", rand.Intn(20)+1))
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func genTest() string {
+	t := rand.Intn(5) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		b.WriteString(genCase())
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1932/verifierC.go
+++ b/1000-1999/1900-1999/1930-1939/1932/verifierC.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1932C.go")
+	out := filepath.Join(os.TempDir(), "refC.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(1000) + 2
+	arr := make([]int, n)
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		arr[i] = rand.Intn(m-1) + 1
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	b.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if rand.Intn(2) == 0 {
+			b.WriteByte('L')
+		} else {
+			b.WriteByte('R')
+		}
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func genTest() string {
+	t := rand.Intn(5) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		b.WriteString(genCase())
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1932/verifierD.go
+++ b/1000-1999/1900-1999/1930-1939/1932/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1932D.go")
+	out := filepath.Join(os.TempDir(), "refD.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+var ranks = []byte("23456789TJQKA")
+var suits = []byte{'C', 'D', 'H', 'S'}
+
+func randomCard() string {
+	r := ranks[rand.Intn(len(ranks))]
+	s := suits[rand.Intn(len(suits))]
+	return fmt.Sprintf("%c%c", r, s)
+}
+
+func genCase() string {
+	n := rand.Intn(5) + 1
+	trump := suits[rand.Intn(len(suits))]
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", n))
+	b.WriteString(fmt.Sprintf("%c\n", trump))
+	for i := 0; i < 2*n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(randomCard())
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func genTest() string {
+	t := rand.Intn(5) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		b.WriteString(genCase())
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:\n" + expect)
+			fmt.Println("Got:\n" + got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1932/verifierE.go
+++ b/1000-1999/1900-1999/1930-1939/1932/verifierE.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1932E.go")
+	out := filepath.Join(os.TempDir(), "refE.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	n := rand.Intn(20) + 1
+	var digits strings.Builder
+	for i := 0; i < n; i++ {
+		digits.WriteByte(byte('0' + rand.Intn(10)))
+	}
+	return fmt.Sprintf("%d\n%s\n", n, digits.String())
+}
+
+func genTest() string {
+	t := rand.Intn(5) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		b.WriteString(genCase())
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1932/verifierF.go
+++ b/1000-1999/1900-1999/1930-1939/1932/verifierF.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1932F.go")
+	out := filepath.Join(os.TempDir(), "refF.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(10) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		l := rand.Intn(n) + 1
+		r := rand.Intn(n-l+1) + l
+		b.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return b.String()
+}
+
+func genTest() string {
+	t := rand.Intn(5) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		b.WriteString(genCase())
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1932/verifierG.go
+++ b/1000-1999/1900-1999/1930-1939/1932/verifierG.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1932G.go")
+	out := filepath.Join(os.TempDir(), "refG.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase() string {
+	n := rand.Intn(5) + 2
+	maxEdges := n * (n - 1)
+	m := rand.Intn(maxEdges) + 1
+	H := rand.Intn(20) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d %d %d\n", n, m, H))
+	for i := 0; i < n; i++ {
+		b.WriteString(fmt.Sprintf("%d ", rand.Intn(20)))
+	}
+	b.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		b.WriteString(fmt.Sprintf("%d ", rand.Intn(20)))
+	}
+	b.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		for v == u {
+			v = rand.Intn(n) + 1
+		}
+		b.WriteString(fmt.Sprintf("%d %d\n", u, v))
+	}
+	return b.String()
+}
+
+func genTest() string {
+	t := rand.Intn(5) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		b.WriteString(genCase())
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:\n" + expect)
+			fmt.Println("Got:\n" + got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G of contest 1932
- each verifier compiles the reference solution and runs 100 randomized tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68878aeea4688324b2d4a3778055df97