### PR TITLE
Add Go verifiers for Codeforces contest 1930

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1930/verifierA.go
+++ b/1000-1999/1900-1999/1930-1939/1930/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n   int
+	arr []int
+}
+
+func solveCaseA(tc testCaseA) int {
+	arr := append([]int(nil), tc.arr...)
+	sort.Ints(arr)
+	sum := 0
+	for i := 0; i < 2*tc.n; i += 2 {
+		sum += arr[i]
+	}
+	return sum
+}
+
+func generateCaseA(rng *rand.Rand) (string, string) {
+	tc := testCaseA{n: rng.Intn(5) + 1, arr: nil}
+	tc.arr = make([]int, 2*tc.n)
+	for i := range tc.arr {
+		tc.arr[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	exp := fmt.Sprintf("%d\n", solveCaseA(tc))
+	return input, exp
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseA(rng)
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1930/verifierB.go
+++ b/1000-1999/1900-1999/1930-1939/1930/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveB(n int) []int {
+	res := make([]int, 0, n)
+	l, r := 1, n
+	for l < r {
+		res = append(res, l)
+		res = append(res, r)
+		l++
+		r--
+	}
+	if l == r {
+		res = append(res, l)
+	}
+	return res
+}
+
+func generateCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 3
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	input := sb.String()
+	perm := solveB(n)
+	var exp strings.Builder
+	for i, v := range perm {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(strconv.Itoa(v))
+	}
+	exp.WriteByte('\n')
+	return input, exp.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1930/verifierC.go
+++ b/1000-1999/1900-1999/1930-1939/1930/verifierC.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type interval struct {
+	high int64
+	low  int64
+}
+
+func find(parent map[int64]int64, x int64) int64 {
+	if x <= 0 {
+		return 0
+	}
+	root := x
+	for {
+		p, ok := parent[root]
+		if !ok {
+			parent[root] = root
+			break
+		}
+		if p == root {
+			break
+		}
+		root = p
+	}
+	for x != root {
+		p := parent[x]
+		parent[x] = root
+		x = p
+	}
+	return root
+}
+
+func solveC(n int, a []int64) []int64 {
+	intervals := make([]interval, n)
+	for i := 0; i < n; i++ {
+		intervals[i] = interval{high: a[i] + int64(i+1), low: a[i] + 1}
+	}
+	sort.Slice(intervals, func(i, j int) bool {
+		if intervals[i].low == intervals[j].low {
+			return intervals[i].high > intervals[j].high
+		}
+		return intervals[i].low > intervals[j].low
+	})
+	parent := make(map[int64]int64, n*2)
+	res := make([]int64, 0, n)
+	for _, it := range intervals {
+		x := find(parent, it.high)
+		if x >= it.low {
+			parent[x] = find(parent, x-1)
+			res = append(res, x)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i] > res[j] })
+	return res
+}
+
+func generateCaseC(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = int64(rng.Intn(20))
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	ans := solveC(n, a)
+	var exp strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(strconv.FormatInt(v, 10))
+	}
+	exp.WriteByte('\n')
+	return input, exp.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1930/verifierD1.go
+++ b/1000-1999/1900-1999/1930-1939/1930/verifierD1.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func minOnes(p string) int {
+	n := len(p)
+	covered := make([]bool, n)
+	ans := 0
+	for i := 0; i < n; i++ {
+		if p[i] == '1' && !covered[i] {
+			pos := i + 1
+			if pos >= n {
+				pos = i
+			}
+			ans++
+			for j := pos - 1; j <= pos+1; j++ {
+				if j >= 0 && j < n {
+					covered[j] = true
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func solveD1(n int, s string) int {
+	total := 0
+	for i := 0; i < n; i++ {
+		for j := i + 1; j <= n; j++ {
+			total += minOnes(s[i:j])
+		}
+	}
+	return total
+}
+
+func generateCaseD1(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	bytes := make([]byte, n)
+	for i := range bytes {
+		if rng.Intn(2) == 0 {
+			bytes[i] = '0'
+		} else {
+			bytes[i] = '1'
+		}
+	}
+	s := string(bytes)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+	input := sb.String()
+	exp := fmt.Sprintf("%d\n", solveD1(n, s))
+	return input, exp
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD1(rng)
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1930/verifierD2.go
+++ b/1000-1999/1900-1999/1930-1939/1930/verifierD2.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func computeSum(s string) int64 {
+	var cnt [5]int64
+	var sum [5]int64
+	var total int64
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		var newCnt [5]int64
+		var newSum [5]int64
+		if ch == '0' {
+			newCnt[0] = 1
+		} else {
+			newCnt[1] = 1
+			newSum[1] = 1
+		}
+		for st := 0; st < 5; st++ {
+			c := cnt[st]
+			if c == 0 {
+				continue
+			}
+			if ch == '0' {
+				switch st {
+				case 0:
+					newCnt[0] += c
+					newSum[0] += sum[st]
+				case 1:
+					newCnt[2] += c
+					newSum[2] += sum[st]
+				case 2:
+					newCnt[3] += c
+					newSum[3] += sum[st]
+				default:
+					newCnt[4] += c
+					newSum[4] += sum[st]
+				}
+			} else {
+				switch st {
+				case 0:
+					newCnt[1] += c
+					newSum[1] += sum[st] + c
+				case 1:
+					newCnt[2] += c
+					newSum[2] += sum[st]
+				case 2:
+					newCnt[3] += c
+					newSum[3] += sum[st]
+				case 3, 4:
+					newCnt[1] += c
+					newSum[1] += sum[st] + c
+				}
+			}
+		}
+		cnt = newCnt
+		sum = newSum
+		for j := 0; j < 5; j++ {
+			total += sum[j]
+		}
+	}
+	return total
+}
+
+func generateCaseD2(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	bytes := make([]byte, n)
+	for i := range bytes {
+		if rng.Intn(2) == 0 {
+			bytes[i] = '0'
+		} else {
+			bytes[i] = '1'
+		}
+	}
+	s := string(bytes)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+	input := sb.String()
+	exp := fmt.Sprintf("%d\n", computeSum(s))
+	return input, exp
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD2(rng)
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1930/verifierE.go
+++ b/1000-1999/1900-1999/1930-1939/1930/verifierE.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func reachableMasks(n, k int) map[int]struct{} {
+	start := (1 << n) - 1
+	visited := make(map[int]struct{})
+	var dfs func(mask int)
+	dfs = func(mask int) {
+		if _, ok := visited[mask]; ok {
+			return
+		}
+		visited[mask] = struct{}{}
+		// collect positions
+		pos := make([]int, 0, n)
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				pos = append(pos, i)
+			}
+		}
+		m := len(pos)
+		if m < 2*k+1 {
+			return
+		}
+		// choose center index among existing positions
+		for centerIdx := k; centerIdx < m-k; centerIdx++ {
+			leftIdx := pos[:centerIdx]
+			rightIdx := pos[centerIdx+1:]
+			leftComb := make([]int, 0, k)
+			var chooseLeft func(start int)
+			chooseLeft = func(start int) {
+				if len(leftComb) == k {
+					rightComb := make([]int, 0, k)
+					var chooseRight func(idx int)
+					chooseRight = func(idx int) {
+						if len(rightComb) == k {
+							newMask := mask
+							for _, li := range leftComb {
+								newMask &^= 1 << li
+							}
+							for _, ri := range rightComb {
+								newMask &^= 1 << ri
+							}
+							dfs(newMask)
+							return
+						}
+						for j := idx; j < len(rightIdx); j++ {
+							rightComb = append(rightComb, rightIdx[j])
+							chooseRight(j + 1)
+							rightComb = rightComb[:len(rightComb)-1]
+						}
+					}
+					chooseRight(0)
+					return
+				}
+				for i := start; i < len(leftIdx); i++ {
+					leftComb = append(leftComb, leftIdx[i])
+					chooseLeft(i + 1)
+					leftComb = leftComb[:len(leftComb)-1]
+				}
+			}
+			chooseLeft(0)
+		}
+	}
+	dfs(start)
+	return visited
+}
+
+func bruteE(n int) []int {
+	limit := (n - 1) / 2
+	res := make([]int, limit)
+	for k := 1; k <= limit; k++ {
+		masks := reachableMasks(n, k)
+		res[k-1] = len(masks) % mod
+	}
+	return res
+}
+
+func generateCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 3
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	input := sb.String()
+	ans := bruteE(n)
+	var exp strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprintf("%d", v))
+	}
+	exp.WriteByte('\n')
+	return input, exp.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1930/verifierF.go
+++ b/1000-1999/1900-1999/1930-1939/1930/verifierF.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maxBits = 22
+const maxNodes = 1 << (maxBits + 1)
+
+type trie struct {
+	ch   [][2]int32
+	mx   []int32
+	size int32
+}
+
+func newTrie() *trie {
+	t := &trie{
+		ch:   make([][2]int32, maxNodes),
+		mx:   make([]int32, maxNodes),
+		size: 1,
+	}
+	for i := range t.mx {
+		t.mx[i] = -1
+	}
+	return t
+}
+
+func (t *trie) reset() {
+	t.size = 1
+	t.ch[0][0], t.ch[0][1] = 0, 0
+	t.mx[0] = -1
+}
+
+func (t *trie) add(v int) {
+	node := int32(0)
+	if int32(v) > t.mx[node] {
+		t.mx[node] = int32(v)
+	}
+	for i := maxBits - 1; i >= 0; i-- {
+		b := (v >> i) & 1
+		if t.ch[node][b] == 0 {
+			t.ch[node][b] = t.size
+			t.ch[t.size][0], t.ch[t.size][1] = 0, 0
+			t.mx[t.size] = -1
+			t.size++
+		}
+		node = t.ch[node][b]
+		if int32(v) > t.mx[node] {
+			t.mx[node] = int32(v)
+		}
+	}
+}
+
+func (t *trie) query(mask int) int {
+	if t.size == 1 {
+		return 0
+	}
+	node := int32(0)
+	res := 0
+	for i := maxBits - 1; i >= 0; i-- {
+		bit := (mask >> i) & 1
+		c0 := t.ch[node][0]
+		c1 := t.ch[node][1]
+		if bit == 1 {
+			if c1 != 0 {
+				node = c1
+				res |= 1 << i
+			} else if c0 != 0 {
+				node = c0
+			} else {
+				break
+			}
+		} else {
+			if c0 == 0 && c1 == 0 {
+				break
+			} else if c0 == 0 {
+				node = c1
+			} else if c1 == 0 {
+				node = c0
+			} else {
+				rem := mask & ((1 << i) - 1)
+				v0 := int(t.mx[c0]) & rem
+				v1 := int(t.mx[c1]) & rem
+				if v0 >= v1 {
+					node = c0
+				} else {
+					node = c1
+				}
+			}
+		}
+	}
+	return res
+}
+
+func solveF(n, q int, e []int) []int {
+	mask := (1 << bits.Len(uint(n-1))) - 1
+	trieA := newTrie()
+	trieB := newTrie()
+	ans := 0
+	last := 0
+	res := make([]int, q)
+	for i := 0; i < q; i++ {
+		v := (e[i] + last) % n
+		diff1 := trieA.query(mask ^ v)
+		if diff1 > ans {
+			ans = diff1
+		}
+		diff2 := trieB.query(v)
+		if diff2 > ans {
+			ans = diff2
+		}
+		trieA.add(v)
+		trieB.add(mask ^ v)
+		last = ans
+		res[i] = ans
+	}
+	return res
+}
+
+func generateCaseF(rng *rand.Rand) (string, string) {
+	n := rng.Intn(32) + 1
+	q := rng.Intn(6) + 1
+	e := make([]int, q)
+	for i := range e {
+		e[i] = rng.Intn(n)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i, v := range e {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	ans := solveF(n, q, e)
+	var exp strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(strconv.Itoa(v))
+	}
+	exp.WriteByte('\n')
+	return input, exp.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseF(rng)
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1930/verifierG.go
+++ b/1000-1999/1900-1999/1930-1939/1930/verifierG.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int = 998244353
+
+func solveG(n int, edges [][2]int) int {
+	g := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	parent := make([]int, n+1)
+	order := make([]int, 0, n)
+	stack := []int{1}
+	parent[1] = 0
+	for len(stack) > 0 {
+		u := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, u)
+		for _, v := range g[u] {
+			if v == parent[u] {
+				continue
+			}
+			parent[v] = u
+			stack = append(stack, v)
+		}
+	}
+	maxVal := make([]int, n+1)
+	dp := make([]int, n+1)
+	for i := len(order) - 1; i >= 0; i-- {
+		u := order[i]
+		maxVal[u] = u
+		heavy := 0
+		for _, v := range g[u] {
+			if v == parent[u] {
+				continue
+			}
+			if maxVal[v] > maxVal[u] {
+				maxVal[u] = maxVal[v]
+			}
+			if heavy == 0 || maxVal[v] > maxVal[heavy] {
+				heavy = v
+			}
+		}
+		if heavy == 0 {
+			dp[u] = 1
+			continue
+		}
+		res := dp[heavy]
+		for _, v := range g[u] {
+			if v == parent[u] || v == heavy {
+				continue
+			}
+			res = res * (dp[v] + 1) % MOD
+		}
+		dp[u] = res % MOD
+	}
+	return dp[1] % MOD
+}
+
+func generateCaseG(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	input := sb.String()
+	ans := solveG(n, edges)
+	exp := fmt.Sprintf("%d\n", ans)
+	return input, exp
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseG(rng)
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1930/verifierH.go
+++ b/1000-1999/1900-1999/1930-1939/1930/verifierH.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func lcaInit(n int, edges [][2]int) ([][]int, []int, int) {
+	g := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	log := 0
+	for (1 << log) <= n {
+		log++
+	}
+	parent := make([][]int, log)
+	for i := range parent {
+		parent[i] = make([]int, n+1)
+	}
+	depth := make([]int, n+1)
+	stack := []int{1}
+	parent[0][1] = 0
+	depth[1] = 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, to := range g[v] {
+			if to == parent[0][v] {
+				continue
+			}
+			parent[0][to] = v
+			depth[to] = depth[v] + 1
+			stack = append(stack, to)
+		}
+	}
+	for k := 1; k < log; k++ {
+		for i := 1; i <= n; i++ {
+			parent[k][i] = parent[k-1][parent[k-1][i]]
+		}
+	}
+	return parent, depth, log
+}
+
+func lcaQuery(a, b int, parent [][]int, depth []int, log int) int {
+	if depth[a] < depth[b] {
+		a, b = b, a
+	}
+	diff := depth[a] - depth[b]
+	for k := 0; diff > 0; k++ {
+		if diff&1 == 1 {
+			a = parent[k][a]
+		}
+		diff >>= 1
+	}
+	if a == b {
+		return a
+	}
+	for k := log - 1; k >= 0; k-- {
+		if parent[k][a] != parent[k][b] {
+			a = parent[k][a]
+			b = parent[k][b]
+		}
+	}
+	return parent[0][a]
+}
+
+func solveH(n int, edges [][2]int, queries []struct {
+	arr  []int
+	u, v int
+}) []int {
+	parent, depth, log := lcaInit(n, edges)
+	res := make([]int, len(queries))
+	visited := make([]bool, n+1)
+	used := make([]int, 0, n)
+	for idx, q := range queries {
+		l := lcaQuery(q.u, q.v, parent, depth, log)
+		addVal := func(x int) {
+			val := q.arr[x]
+			if !visited[val] {
+				visited[val] = true
+				used = append(used, val)
+			}
+		}
+		for x := q.u; x != l; x = parent[0][x] {
+			addVal(x)
+		}
+		for x := q.v; x != l; x = parent[0][x] {
+			addVal(x)
+		}
+		addVal(l)
+		mex := 0
+		for mex <= n && visited[mex] {
+			mex++
+		}
+		res[idx] = mex
+		for _, val := range used {
+			visited[val] = false
+		}
+		used = used[:0]
+	}
+	return res
+}
+
+func generateCaseH(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	q := rng.Intn(3) + 1
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	queries := make([]struct {
+		arr  []int
+		u, v int
+	}, q)
+	for i := 0; i < q; i++ {
+		arr := make([]int, n+1)
+		for j := 1; j <= n; j++ {
+			arr[j] = rng.Intn(n + 1)
+		}
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		queries[i] = struct {
+			arr  []int
+			u, v int
+		}{arr: arr, u: u, v: v}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for _, qu := range queries {
+		for j := 1; j <= n; j++ {
+			if j > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", qu.arr[j]))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d %d\n", qu.u, qu.v))
+	}
+	input := sb.String()
+	ans := solveH(n, edges, queries)
+	var exp strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprintf("%d", v))
+	}
+	exp.WriteByte('\n')
+	return input, exp.String()
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseH(rng)
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1930/verifierI.go
+++ b/1000-1999/1900-1999/1930-1939/1930/verifierI.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int = 998244353
+
+func checkGood(p, q string) bool {
+	n := len(p)
+	for i := 0; i < n; i++ {
+		ch := p[i]
+		found := false
+		for l := 0; l <= i && !found; l++ {
+			for r := i; r < n && !found; r++ {
+				if l <= i && i <= r {
+					sub := q[l : r+1]
+					m := r - l + 1
+					count := 0
+					for j := 0; j < m; j++ {
+						if sub[j] == ch {
+							count++
+						}
+					}
+					need := m / 2
+					if m%2 != 0 {
+						need = (m + 1) / 2
+					}
+					if count >= need {
+						found = true
+					}
+				}
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func countGoodStrings(p string) int {
+	n := len(p)
+	total := 0
+	cur := make([]byte, n)
+	var dfs func(idx int)
+	dfs = func(idx int) {
+		if idx == n {
+			if checkGood(p, string(cur)) {
+				total++
+				if total >= MOD {
+					total -= MOD
+				}
+			}
+			return
+		}
+		cur[idx] = '0'
+		dfs(idx + 1)
+		cur[idx] = '1'
+		dfs(idx + 1)
+	}
+	dfs(0)
+	return total % MOD
+}
+
+func generateCaseI(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	bytes := make([]byte, n)
+	for i := range bytes {
+		if rng.Intn(2) == 0 {
+			bytes[i] = '0'
+		} else {
+			bytes[i] = '1'
+		}
+	}
+	p := string(bytes)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n%s\n", n, p))
+	input := sb.String()
+	ans := countGoodStrings(p)
+	exp := fmt.Sprintf("%d\n", ans)
+	return input, exp
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseI(rng)
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` through `verifierI.go` for contest 1930
- each verifier generates 100 random tests and checks a binary
- includes brute-force logic for problem E and uses solutions for others

## Testing
- `go build verifierA.go`
- `go build verifierB.go verifierC.go verifierD1.go verifierD2.go verifierE.go verifierF.go verifierG.go verifierH.go verifierI.go` *(each individually)*

------
https://chatgpt.com/codex/tasks/task_e_68878a6287a48324b97d90880abac745