### PR TITLE
Add verifiers for contest 1937 problems A and B

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1937/verifierA.go
+++ b/1000-1999/1900-1999/1930-1939/1937/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+}
+
+func generateCase(rng *rand.Rand) (string, testCase) {
+	n := rng.Intn(1_000_000_000) + 1
+	input := fmt.Sprintf("1\n%d\n", n)
+	return input, testCase{n: n}
+}
+
+func expected(tc testCase) int {
+	ans := 1
+	for ans<<1 <= tc.n {
+		ans <<= 1
+	}
+	return ans
+}
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		want := fmt.Sprintf("%d", expected(tc))
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1937/verifierB.go
+++ b/1000-1999/1900-1999/1930-1939/1937/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1937B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n     int
+	s1    string
+	s2    string
+	input string
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 2
+	b1 := make([]byte, n)
+	b2 := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b1[i] = byte('0' + rng.Intn(2))
+		b2[i] = byte('0' + rng.Intn(2))
+	}
+	input := fmt.Sprintf("1\n%d\n%s\n%s\n", n, string(b1), string(b2))
+	return testCase{n: n, s1: string(b1), s2: string(b2), input: input}
+}
+
+func runCase(candidate, ref string, tc testCase) error {
+	want, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(candidate, tc.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(want) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(candidate, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- each verifier generates at least 100 random test cases
- verifierB builds the official solution for comparison

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1937/verifierA.go`
- `go build 1000-1999/1900-1999/1930-1939/1937/verifierB.go`

------
https://chatgpt.com/codex/tasks/task_e_68878c4d24bc83249511fe608e397e5e