### PR TITLE
Add contest 1934 verifiers

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1934/verifierA.go
+++ b/1000-1999/1900-1999/1930-1939/1934/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	if errBuf.Len() > 0 {
+		return "", fmt.Errorf(errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(arr []int) int {
+	sort.Ints(arr)
+	n := len(arr)
+	return 2*(arr[n-1]-arr[0]) + 2*(arr[n-2]-arr[1])
+}
+
+func genTests() [][]int {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([][]int, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(97) + 4 // 4..100
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rng.Intn(2000001) - 1000000
+		}
+		tests = append(tests, a)
+	}
+	// edge cases
+	tests = append(tests, []int{0, 0, 0, 0})
+	tests = append(tests, []int{1, -1, 1, -1})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for idx, arr := range tests {
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		expect := fmt.Sprintf("%d", expected(append([]int(nil), arr...)))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed: expected %s got %s\n", idx+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1900-1999/1930-1939/1934/verifierB.go
+++ b/1000-1999/1900-1999/1930-1939/1934/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	if errBuf.Len() > 0 {
+		return "", fmt.Errorf(errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int) int {
+	coins := []int{1, 3, 6, 10, 15}
+	const maxBase = 29
+	const inf = int(1e9)
+	dp := make([]int, maxBase+1)
+	for i := 1; i <= maxBase; i++ {
+		dp[i] = inf
+		for _, c := range coins {
+			if i >= c && dp[i-c]+1 < dp[i] {
+				dp[i] = dp[i-c] + 1
+			}
+		}
+	}
+	if n < 15 {
+		return dp[n]
+	}
+	r := (n-15)%15 + 15
+	ans := (n - r) / 15
+	return ans + dp[r]
+}
+
+func genTests() []int {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]int, 102)
+	for i := 0; i < 102; i++ {
+		tests[i] = rng.Intn(1_000_000_000) + 1
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTests()
+	for idx, n := range cases {
+		input := fmt.Sprintf("1\n%d\n", n)
+		expect := fmt.Sprintf("%d", expected(n))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed: n=%d expected %s got %s\n", idx+1, n, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1900-1999/1930-1939/1934/verifierC.go
+++ b/1000-1999/1900-1999/1930-1939/1934/verifierC.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m   int
+	x1, y1 int
+	x2, y2 int
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rng.Intn(8) + 2
+		m := rng.Intn(8) + 2
+		x1 := rng.Intn(n) + 1
+		y1 := rng.Intn(m) + 1
+		x2 := rng.Intn(n) + 1
+		y2 := rng.Intn(m) + 1
+		for x1 == x2 && y1 == y2 {
+			x2 = rng.Intn(n) + 1
+			y2 = rng.Intn(m) + 1
+		}
+		cases[i] = testCase{n: n, m: m, x1: x1, y1: y1, x2: x2, y2: y2}
+	}
+	return cases
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func interact(bin string, cases []testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	w := bufio.NewWriter(stdin)
+	r := bufio.NewReader(stdout)
+
+	fmt.Fprintf(w, "%d\n", len(cases))
+	w.Flush()
+	for idx, tc := range cases {
+		fmt.Fprintf(w, "%d %d\n", tc.n, tc.m)
+		w.Flush()
+		queries := 0
+		for {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("case %d: failed to read: %v", idx+1, err)
+			}
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "?") {
+				queries++
+				if queries > 4 {
+					return fmt.Errorf("case %d: too many queries", idx+1)
+				}
+				var x, y int
+				if _, err := fmt.Sscanf(line, "? %d %d", &x, &y); err != nil {
+					return fmt.Errorf("case %d: invalid query %q", idx+1, line)
+				}
+				d1 := abs(x-tc.x1) + abs(y-tc.y1)
+				d2 := abs(x-tc.x2) + abs(y-tc.y2)
+				d := d1
+				if d2 < d {
+					d = d2
+				}
+				fmt.Fprintf(w, "%d\n", d)
+				w.Flush()
+			} else if strings.HasPrefix(line, "!") {
+				var x, y int
+				if _, err := fmt.Sscanf(line, "! %d %d", &x, &y); err != nil {
+					return fmt.Errorf("case %d: invalid answer %q", idx+1, line)
+				}
+				if (x != tc.x1 || y != tc.y1) && (x != tc.x2 || y != tc.y2) {
+					return fmt.Errorf("case %d: wrong cell", idx+1)
+				}
+				fmt.Fprintln(w, "Ok")
+				w.Flush()
+				break
+			} else if line != "" {
+				return fmt.Errorf("case %d: unexpected output %q", idx+1, line)
+			}
+		}
+	}
+	stdin.Close()
+	outLeft, _ := io.ReadAll(stdout)
+	errLeft, _ := io.ReadAll(&errBuf)
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, string(errLeft)+string(errBuf.Bytes()))
+	}
+	if strings.TrimSpace(string(outLeft)) != "" {
+		return fmt.Errorf("extra output: %s", string(outLeft))
+	}
+	if errBuf.Len() > 0 {
+		return fmt.Errorf(errBuf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	if err := interact(bin, cases); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1900-1999/1930-1939/1934/verifierD1.go
+++ b/1000-1999/1900-1999/1930-1939/1934/verifierD1.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	if errBuf.Len() > 0 {
+		return "", fmt.Errorf(errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, m uint64) ([]uint64, bool) {
+	if m >= n || m == 0 {
+		return nil, false
+	}
+	if n&(n-1) == 0 {
+		return nil, false
+	}
+	pow := uint64(1) << (bits.Len64(n) - 1)
+	r := n - pow
+	if m >= pow {
+		if n^m >= n {
+			return nil, false
+		}
+		return []uint64{n, m}, true
+	}
+	h := uint64(1) << (bits.Len64(m) - 1)
+	if r&h != 0 {
+		return []uint64{n, m}, true
+	}
+	if r > h {
+		return []uint64{n, pow + h, m}, true
+	}
+	return nil, false
+}
+
+func genTests() [][2]uint64 {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([][2]uint64, 100)
+	for i := range tests {
+		n := rng.Uint64()%1_000_000 + 2
+		// ensure not power of two, else expectation may be false
+		for n&(n-1) == 0 {
+			n = rng.Uint64()%1_000_000 + 2
+		}
+		m := rng.Uint64()%uint64(n-1) + 1
+		tests[i] = [2]uint64{n, m}
+	}
+	// edge case impossible
+	tests = append(tests, [2]uint64{7, 3})
+	tests = append(tests, [2]uint64{4, 2})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTests()
+	for idx, c := range cases {
+		input := fmt.Sprintf("1\n%d %d\n", c[0], c[1])
+		seq, ok := solveCase(c[0], c[1])
+		var expect string
+		if !ok {
+			expect = "-1"
+		} else {
+			var sb strings.Builder
+			sb.WriteString(fmt.Sprintf("%d\n", len(seq)-1))
+			for i, v := range seq {
+				if i > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", v))
+			}
+			expect = strings.TrimSpace(sb.String())
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed: n=%d m=%d expected %q got %q\n", idx+1, c[0], c[1], expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1900-1999/1930-1939/1934/verifierD2.go
+++ b/1000-1999/1900-1999/1930-1939/1934/verifierD2.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	if errBuf.Len() > 0 {
+		return "", fmt.Errorf(errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n uint64) string {
+	if bits.OnesCount64(n)%2 == 0 {
+		p1 := n & -n
+		p2 := n - p1
+		if p2 == 0 {
+			p1, p2 = 1, n-1
+		}
+		return fmt.Sprintf("first\n%d %d", p1, p2)
+	}
+	return "second"
+}
+
+func genTests() []uint64 {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]uint64, 100)
+	for i := range cases {
+		cases[i] = rng.Uint64()%1_000_000 + 1
+	}
+	cases = append(cases, 1, 2, 3, 4)
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTests()
+	for idx, n := range cases {
+		input := fmt.Sprintf("1\n%d\n", n)
+		expect := expected(n)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed: n=%d expected %q got %q\n", idx+1, n, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1900-1999/1930-1939/1934/verifierE.go
+++ b/1000-1999/1900-1999/1930-1939/1934/verifierE.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	if errBuf.Len() > 0 {
+		return "", fmt.Errorf(errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solve(n int) string {
+	l, r, t := n/2+1, n, 1
+	type tri [3]int
+	var ans []tri
+	var lastv, lastt, lastl int
+	for {
+		if r <= 11 {
+			switch r {
+			case 3:
+				ans = append(ans, tri{t, 2 * t, 3 * t})
+			case 4:
+				ans = append(ans, tri{t, 3 * t, 4 * t})
+			case 5:
+				ans = append(ans, tri{3 * t, 4 * t, 5 * t})
+			case 6:
+				ans = append(ans, tri{3 * t, 4 * t, 5 * t})
+			case 7:
+				ans = append(ans, tri{t, 3 * t, 4 * t})
+				ans = append(ans, tri{5 * t, 6 * t, 7 * t})
+			case 8:
+				ans = append(ans, tri{t, 5 * t, 7 * t})
+				ans = append(ans, tri{2 * t, 6 * t, 8 * t})
+			case 9:
+				ans = append(ans, tri{t, 5 * t, 6 * t})
+				ans = append(ans, tri{7 * t, 8 * t, 9 * t})
+			case 10:
+				ans = append(ans, tri{2 * t, 6 * t, 10 * t})
+				ans = append(ans, tri{7 * t, 8 * t, 9 * t})
+			case 11:
+				ans = append(ans, tri{t, 10 * t, 11 * t})
+				ans = append(ans, tri{7 * t, 8 * t, 9 * t})
+			}
+			break
+		}
+		skip := false
+		if l%4 == 3 && r%4 == 1 {
+			ans = append(ans, tri{l * t, r * t, 2 * t})
+			l++
+			skip = true
+		}
+		for l%4 > 1 {
+			l--
+		}
+		i := (l/4)*4 + 1
+		for i+2 <= r {
+			ans = append(ans, tri{i * t, (i + 1) * t, (i + 2) * t})
+			i += 4
+		}
+		if i <= r {
+			if i+1 <= r {
+				ans = append(ans, tri{t, i * t, (i + 1) * t})
+			} else {
+				if !skip {
+					if lastv != 0 {
+						if gcd(i*t, lastv) < lastl*lastt {
+							d := gcd(i*t, lastv)
+							ans = append(ans, tri{d, i * t, lastv})
+							lastv = 0
+							lastt = 0
+						} else {
+							ans = append(ans, tri{lastt, 2 * lastt, lastv})
+							lastv = i * t
+							lastt = t
+							lastl = l
+						}
+					} else {
+						lastv = i * t
+						lastt = t
+						lastl = l
+					}
+				}
+			}
+		}
+		l = (l-1)/4 + 1
+		r = r / 4
+		t *= 4
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(ans)))
+	for _, v := range ans {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", v[0], v[1], v[2]))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genTests() []int {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]int, 100)
+	for i := range cases {
+		cases[i] = rng.Intn(2000) + 3
+	}
+	cases = append(cases, 3, 4, 5, 6, 7)
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genTests()
+	for idx, n := range cases {
+		input := fmt.Sprintf("1\n%d\n", n)
+		expect := solve(n)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed: n=%d expected\n%s\ngot\n%s\n", idx+1, n, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 1934
- verifiers generate over 100 randomized tests each
- interactive verifier for problem C simulates the judge

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1934/verifierA.go`
- `go build 1000-1999/1900-1999/1930-1939/1934/verifierB.go`
- `go build 1000-1999/1900-1999/1930-1939/1934/verifierC.go`
- `go build 1000-1999/1900-1999/1930-1939/1934/verifierD1.go`
- `go build 1000-1999/1900-1999/1930-1939/1934/verifierD2.go`
- `go build 1000-1999/1900-1999/1930-1939/1934/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68878b7aade8832484f1dccaefa8e889