### PR TITLE
Add Go solution verifiers for CF contest 1935

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1935/verifierA.go
+++ b/1000-1999/1900-1999/1930-1939/1935/verifierA.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	n int
+	s string
+}
+
+func reverseString(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+func expected(tc TestCase) string {
+	rev := reverseString(tc.s)
+	ans := tc.s
+	if tmp := tc.s + rev; tmp < ans {
+		ans = tmp
+	}
+	if tmp := rev + tc.s; tmp < ans {
+		ans = tmp
+	}
+	return ans
+}
+
+func genTests() []TestCase {
+	rand.Seed(time.Now().UnixNano())
+	const T = 100
+	tests := make([]TestCase, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(10) + 2
+		if n%2 == 1 {
+			n++
+		}
+		l := rand.Intn(10) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rand.Intn(26))
+		}
+		tests[i] = TestCase{n: n, s: string(b)}
+	}
+	return tests
+}
+
+func buildInput(tests []TestCase) []byte {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&buf, tc.n)
+		fmt.Fprintln(&buf, tc.s)
+	}
+	return buf.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	tests := genTests()
+	input := buildInput(tests)
+
+	expectedOutputs := make([]string, len(tests))
+	for i, tc := range tests {
+		expectedOutputs[i] = expected(tc)
+	}
+
+	out, err := runBinary(binary, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error executing binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	got := strings.Fields(strings.TrimSpace(string(out)))
+	if len(got) != len(expectedOutputs) {
+		fmt.Fprintf(os.Stderr, "expected %d outputs, got %d\n", len(expectedOutputs), len(got))
+		os.Exit(1)
+	}
+	for i := range expectedOutputs {
+		if got[i] != expectedOutputs[i] {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d\ninput:\n%d\n%s\nexpected: %s\nactual: %s\n", i+1, tests[i].n, tests[i].s, expectedOutputs[i], got[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1935/verifierB.go
+++ b/1000-1999/1900-1999/1930-1939/1935/verifierB.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	n   int
+	arr []int
+}
+
+func genTests() []TestCase {
+	rand.Seed(time.Now().UnixNano())
+	const T = 100
+	tests := make([]TestCase, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(8) + 2
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(n + 2)
+		}
+		tests[i] = TestCase{n: n, arr: arr}
+	}
+	return tests
+}
+
+func buildInput(tests []TestCase) []byte {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, len(tests))
+	for _, tc := range tests {
+		fmt.Fprint(&buf, tc.n)
+		for _, v := range tc.arr {
+			fmt.Fprint(&buf, " ", v)
+		}
+		fmt.Fprintln(&buf)
+	}
+	return buf.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func mexCount(db map[int]int) int {
+	m := 0
+	for db[m] > 0 {
+		m++
+	}
+	return m
+}
+
+func expected(tc TestCase) string {
+	n := tc.n
+	t := tc.arr
+	pref := make([]int, n)
+	suf := make([]int, n)
+	db := make(map[int]int)
+	mex := 0
+	for i := 0; i < n; i++ {
+		db[t[i]]++
+		for db[mex] > 0 {
+			mex++
+		}
+		pref[i] = mex
+	}
+	for i := range db {
+		delete(db, i)
+	}
+	mex = 0
+	for i := n - 1; i >= 0; i-- {
+		db[t[i]]++
+		for db[mex] > 0 {
+			mex++
+		}
+		suf[i] = mex
+	}
+	pos := -1
+	for i := 0; i+1 < n; i++ {
+		if pref[i] == suf[i+1] {
+			pos = i
+		}
+	}
+	if pos < 0 {
+		return "-1"
+	}
+	return fmt.Sprintf("2\n1 %d\n%d %d", pos+1, pos+2, n)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	tests := genTests()
+	input := buildInput(tests)
+
+	expectedOutputs := make([]string, len(tests))
+	for i, tc := range tests {
+		expectedOutputs[i] = expected(tc)
+	}
+
+	out, err := runBinary(binary, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error executing binary: %v\n", err)
+		os.Exit(1)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	idx := 0
+	for i, exp := range expectedOutputs {
+		if idx >= len(lines) {
+			fmt.Fprintf(os.Stderr, "output too short on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if exp == "-1" {
+			if strings.TrimSpace(lines[idx]) != "-1" {
+				fmt.Fprintf(os.Stderr, "mismatch on test %d\nexpected -1 got %s\n", i+1, lines[idx])
+				os.Exit(1)
+			}
+			idx++
+		} else {
+			parts := strings.Split(exp, "\n")
+			for _, p := range parts {
+				if idx >= len(lines) || strings.TrimSpace(lines[idx]) != strings.TrimSpace(p) {
+					fmt.Fprintf(os.Stderr, "mismatch on test %d\nexpected %s got %s\n", i+1, p, lines[idx])
+					os.Exit(1)
+				}
+				idx++
+			}
+		}
+	}
+	if idx != len(lines) {
+		fmt.Fprintf(os.Stderr, "extra output lines detected")
+		os.Exit(1)
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1935/verifierC.go
+++ b/1000-1999/1900-1999/1930-1939/1935/verifierC.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Message struct {
+	a int64
+	b int64
+}
+
+type TestCase struct {
+	n    int
+	L    int64
+	msgs []Message
+}
+
+func genTests() []TestCase {
+	rand.Seed(time.Now().UnixNano())
+	const T = 100
+	tests := make([]TestCase, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(6) + 1
+		L := int64(rand.Intn(50) + 1)
+		msgs := make([]Message, n)
+		for j := 0; j < n; j++ {
+			a := int64(rand.Intn(10) + 1)
+			b := int64(rand.Intn(10) + 1)
+			msgs[j] = Message{a: a, b: b}
+		}
+		tests[i] = TestCase{n: n, L: L, msgs: msgs}
+	}
+	return tests
+}
+
+func buildInput(tests []TestCase) []byte {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&buf, "%d %d\n", tc.n, tc.L)
+		for _, m := range tc.msgs {
+			fmt.Fprintf(&buf, "%d %d\n", m.a, m.b)
+		}
+	}
+	return buf.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func expected(tc TestCase) string {
+	n := tc.n
+	L := tc.L
+	msgs := tc.msgs
+	maxSize := 0
+	for mask := 1; mask < (1 << n); mask++ {
+		sumA := int64(0)
+		minB := int64(1 << 60)
+		maxB := int64(0)
+		sz := 0
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				sumA += msgs[i].a
+				if msgs[i].b < minB {
+					minB = msgs[i].b
+				}
+				if msgs[i].b > maxB {
+					maxB = msgs[i].b
+				}
+				sz++
+			}
+		}
+		cost := sumA
+		if sz > 1 {
+			cost += maxB - minB
+		}
+		if cost <= L && sz > maxSize {
+			maxSize = sz
+		}
+	}
+	if 0 <= int(L) && maxSize == 0 {
+		return "0"
+	}
+	return fmt.Sprintf("%d", maxSize)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	tests := genTests()
+	input := buildInput(tests)
+
+	expectedOutputs := make([]string, len(tests))
+	for i, tc := range tests {
+		expectedOutputs[i] = expected(tc)
+	}
+
+	out, err := runBinary(binary, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error executing binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	got := strings.Fields(strings.TrimSpace(string(out)))
+	if len(got) != len(expectedOutputs) {
+		fmt.Fprintf(os.Stderr, "expected %d outputs, got %d\n", len(expectedOutputs), len(got))
+		os.Exit(1)
+	}
+	for i := range expectedOutputs {
+		if got[i] != expectedOutputs[i] {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d\nexpected %s got %s\n", i+1, expectedOutputs[i], got[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1935/verifierD.go
+++ b/1000-1999/1900-1999/1930-1939/1935/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	n   int
+	c   int
+	arr []int
+}
+
+func genTests() []TestCase {
+	rand.Seed(time.Now().UnixNano())
+	const T = 100
+	tests := make([]TestCase, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(5) + 1
+		c := n + rand.Intn(20)
+		vals := rand.Perm(c + 1)[:n]
+		sortInts(vals)
+		tests[i] = TestCase{n: n, c: c, arr: vals}
+	}
+	return tests
+}
+
+func sortInts(a []int) {
+	for i := 1; i < len(a); i++ {
+		for j := i; j > 0 && a[j-1] > a[j]; j-- {
+			a[j], a[j-1] = a[j-1], a[j]
+		}
+	}
+}
+
+func buildInput(tests []TestCase) []byte {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&buf, "%d %d\n", tc.n, tc.c)
+		for i, v := range tc.arr {
+			if i > 0 {
+				fmt.Fprint(&buf, " ")
+			}
+			fmt.Fprint(&buf, v)
+		}
+		fmt.Fprintln(&buf)
+	}
+	return buf.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func expected(tc TestCase) string {
+	s := make(map[int]bool)
+	for _, v := range tc.arr {
+		s[v] = true
+	}
+	var count int64
+	for x := 0; x <= tc.c; x++ {
+		for y := x; y <= tc.c; y++ {
+			if s[x+y] || s[y-x] {
+				continue
+			}
+			count++
+		}
+	}
+	return fmt.Sprintf("%d", count)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	tests := genTests()
+	input := buildInput(tests)
+
+	expectedOutputs := make([]string, len(tests))
+	for i, tc := range tests {
+		expectedOutputs[i] = expected(tc)
+	}
+
+	out, err := runBinary(binary, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error executing binary: %v\n", err)
+		os.Exit(1)
+	}
+	got := strings.Fields(strings.TrimSpace(string(out)))
+	if len(got) != len(expectedOutputs) {
+		fmt.Fprintf(os.Stderr, "expected %d outputs, got %d\n", len(expectedOutputs), len(got))
+		os.Exit(1)
+	}
+	for i := range expectedOutputs {
+		if got[i] != expectedOutputs[i] {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d expected %s got %s\n", i+1, expectedOutputs[i], got[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1935/verifierE.go
+++ b/1000-1999/1900-1999/1930-1939/1935/verifierE.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Course struct {
+	x int64
+	y int64
+}
+
+type Query struct {
+	l int
+	r int
+}
+
+type TestCase struct {
+	n       int
+	courses []Course
+	q       int
+	queries []Query
+}
+
+func genTests() []TestCase {
+	rand.Seed(time.Now().UnixNano())
+	const T = 100
+	tests := make([]TestCase, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(6) + 1
+		courses := make([]Course, n)
+		for j := range courses {
+			x := rand.Intn(16)
+			y := x + rand.Intn(16-x)
+			courses[j] = Course{int64(x), int64(y)}
+		}
+		q := rand.Intn(6) + 1
+		queries := make([]Query, q)
+		for j := range queries {
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			queries[j] = Query{l, r}
+		}
+		tests[i] = TestCase{n: n, courses: courses, q: q, queries: queries}
+	}
+	return tests
+}
+
+func buildInput(tests []TestCase) []byte {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&buf, tc.n)
+		for _, c := range tc.courses {
+			fmt.Fprintf(&buf, "%d %d\n", c.x, c.y)
+		}
+		fmt.Fprintln(&buf, tc.q)
+		for _, qu := range tc.queries {
+			fmt.Fprintf(&buf, "%d %d\n", qu.l, qu.r)
+		}
+	}
+	return buf.Bytes()
+}
+
+func runBinary(path string, input []byte) ([]byte, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	return cmd.CombinedOutput()
+}
+
+func canSet(x, y int64, b uint) bool {
+	start := x
+	if ((start >> b) & 1) == 0 {
+		start = (start>>(b+1))<<(b+1) + (1 << b)
+	}
+	return start <= y
+}
+
+func expected(tc TestCase) string {
+	res := make([]int, tc.q)
+	for idx, q := range tc.queries {
+		val := 0
+		for b := 0; b < 30; b++ {
+			ok := false
+			for i := q.l - 1; i <= q.r-1; i++ {
+				if canSet(tc.courses[i].x, tc.courses[i].y, uint(b)) {
+					ok = true
+					break
+				}
+			}
+			if ok {
+				val |= 1 << b
+			}
+		}
+		res[idx] = val
+	}
+	parts := make([]string, len(res))
+	for i, v := range res {
+		parts[i] = fmt.Sprintf("%d", v)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	tests := genTests()
+	input := buildInput(tests)
+
+	expectedOutputs := make([]string, len(tests))
+	for i, tc := range tests {
+		expectedOutputs[i] = expected(tc)
+	}
+
+	out, err := runBinary(binary, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error executing binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	gotLines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	// Flatten expected outputs lines
+	var expLines []string
+	for _, exp := range expectedOutputs {
+		expLines = append(expLines, strings.Split(exp, "\n")...)
+	}
+	if len(gotLines) != len(expLines) {
+		fmt.Fprintf(os.Stderr, "expected %d lines, got %d\n", len(expLines), len(gotLines))
+		os.Exit(1)
+	}
+	for i := range expLines {
+		if strings.TrimSpace(gotLines[i]) != strings.TrimSpace(expLines[i]) {
+			fmt.Fprintf(os.Stderr, "mismatch on output line %d expected %s got %s\n", i+1, expLines[i], gotLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1900-1999/1930-1939/1935/verifierF.go
+++ b/1000-1999/1900-1999/1930-1939/1935/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	u int
+	v int
+}
+
+type TestCase struct {
+	n     int
+	edges []Edge
+}
+
+func genTree(n int) []Edge {
+	edges := make([]Edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, Edge{p, i})
+	}
+	return edges
+}
+
+func genTests() []TestCase {
+	rand.Seed(time.Now().UnixNano())
+	const T = 100
+	tests := make([]TestCase, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(4) + 5 // 5..8
+		edges := genTree(n)
+		tests[i] = TestCase{n: n, edges: edges}
+	}
+	return tests
+}
+
+func buildInput(tests []TestCase) []byte {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&buf, tc.n)
+		for _, e := range tc.edges {
+			fmt.Fprintf(&buf, "%d %d\n", e.u, e.v)
+		}
+	}
+	return buf.Bytes()
+}
+
+func run(binary string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(binary, ".go") {
+		cmd = exec.Command("go", "run", binary)
+	} else {
+		cmd = exec.Command(binary)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	tests := genTests()
+	input := buildInput(tests)
+
+	// compile reference solution
+	refBin := "ref_solF"
+	cmd := exec.Command("g++", "solF.cpp", "-O2", "-std=c++17", "-o", refBin)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to compile reference: %v\n%s\n", err, string(out))
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	expected, err := run("./"+refBin, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reference execution error: %v\n", err)
+		os.Exit(1)
+	}
+
+	actual, err := run(binary, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error executing binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	if strings.TrimSpace(actual) != strings.TrimSpace(expected) {
+		fmt.Fprintln(os.Stderr, "output mismatch between reference and binary")
+		os.Exit(1)
+	}
+
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go with simple oracle algorithm and random tests
- add verifierB.go through verifierE.go to check candidate binaries for problems B-E
- add verifierF.go which compares output with compiled `solF.cpp`

## Testing
- `go run verifierA.go ./1935A_bin`
- `go run verifierB.go ./1935B_bin`
- `go run verifierC.go ./1935C_bin`
- `go run verifierD.go ./1935D_bin`
- `go run verifierE.go ./1935E_bin`
- `go run verifierF.go ./solF_bin`

------
https://chatgpt.com/codex/tasks/task_e_68878bc0b48883249a36cc457d36b1ce