### PR TITLE
Add verifiers for Codeforces contest 1944

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1944/verifierA.go
+++ b/1000-1999/1900-1999/1940-1949/1944/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveCase(n, k int) string {
+	ans := n
+	for m := 1; m <= n; m++ {
+		if m*(n-m) <= k {
+			ans = m
+			break
+		}
+	}
+	return strconv.Itoa(ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	maxK := n * (n - 1) / 2
+	k := rng.Intn(maxK + 1)
+	input := fmt.Sprintf("1\n%d %d\n", n, k)
+	expect := solveCase(n, k)
+	return input, expect
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// deterministic edge cases
+	cases := []struct {
+		in  string
+		exp string
+	}{
+		{"1\n1 0\n", "1"},
+		{"1\n2 1\n", "1"},
+		{"1\n3 0\n", "3"},
+	}
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, struct{ in, exp string }{in, exp})
+	}
+	for i, tc := range cases {
+		out, err := runCandidate(bin, tc.in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(tc.exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.exp, out, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1944/verifierB.go
+++ b/1000-1999/1900-1999/1940-1949/1944/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1944B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 2
+	k := rng.Intn(n/2) + 1
+	arr := make([]int, 2*n)
+	idx := 0
+	for i := 1; i <= n; i++ {
+		arr[idx] = i
+		arr[idx+1] = i
+		idx += 2
+	}
+	rng.Shuffle(2*n, func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[len(os.Args)-1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out, err := run(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` to generate random tests for problem A
- add `verifierB.go` that builds an oracle from `1944B.go` and runs random tests

## Testing
- `go run verifierA.go -- 1944A.go`
- `go run verifierB.go -- 1944B.go`


------
https://chatgpt.com/codex/tasks/task_e_68878e3712e083248ce04be2cbce6190