### PR TITLE
Add verifiers for contest 1942

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1942/verifierA.go
+++ b/1000-1999/1900-1999/1940-1949/1942/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refA1942")
+	cmd := exec.Command("go", "build", "-o", tmp, "1942A.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(n) + 1
+	return fmt.Sprintf("1\n%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1942/verifierB.go
+++ b/1000-1999/1900-1999/1940-1949/1942/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refB1942")
+	cmd := exec.Command("go", "build", "-o", tmp, "1942B.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	perm := rng.Perm(n)
+	a := make([]int, n)
+	present := make([]bool, n+1)
+	mex := 0
+	for i := 0; i < n; i++ {
+		// compute mex of prefix before p[i]
+		for present[mex] {
+			mex++
+		}
+		a[i] = mex - perm[i]
+		present[perm[i]] = true
+	}
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprint(&buf, v)
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(43))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1942/verifierC1.go
+++ b/1000-1999/1900-1999/1940-1949/1942/verifierC1.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refC1_1942")
+	cmd := exec.Command("go", "build", "-o", tmp, "1942C1.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(10-4+1) + 4
+	x := rng.Intn(n-1) + 2
+	if x > n {
+		x = n
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d %d 0\n", n, x)
+	used := make(map[int]bool)
+	for i := 0; i < x; i++ {
+		v := rng.Intn(n) + 1
+		for used[v] {
+			v = rng.Intn(n) + 1
+		}
+		used[v] = true
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprint(&buf, v)
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC1.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(44))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1942/verifierC2.go
+++ b/1000-1999/1900-1999/1940-1949/1942/verifierC2.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refC2_1942")
+	cmd := exec.Command("go", "build", "-o", tmp, "1942C2.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(10-4+1) + 4
+	x := rng.Intn(n-1) + 2
+	if x > n {
+		x = n
+	}
+	y := rng.Intn(n - x + 1)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d %d %d\n", n, x, y)
+	used := make(map[int]bool)
+	for i := 0; i < x; i++ {
+		v := rng.Intn(n) + 1
+		for used[v] {
+			v = rng.Intn(n) + 1
+		}
+		used[v] = true
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprint(&buf, v)
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC2.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(45))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1942/verifierD.go
+++ b/1000-1999/1900-1999/1940-1949/1942/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refD_1942")
+	cmd := exec.Command("go", "build", "-o", tmp, "1942D.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(3) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d %d\n", n, k)
+	for i := 1; i <= n; i++ {
+		for j := i; j <= n; j++ {
+			if j > i {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprint(&buf, rng.Intn(11)-5)
+		}
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(46))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1942/verifierE.go
+++ b/1000-1999/1900-1999/1940-1949/1942/verifierE.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refE_1942")
+	cmd := exec.Command("go", "build", "-o", tmp, "1942E.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	l := rng.Intn(20) + 2
+	n := rng.Intn(l/2) + 1
+	return fmt.Sprintf("1\n%d %d\n", l, n)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(47))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1942/verifierF.go
+++ b/1000-1999/1900-1999/1940-1949/1942/verifierF.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refF_1942")
+	cmd := exec.Command("go", "build", "-o", tmp, "1942F.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	q := rng.Intn(4) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d\n", n, q)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&buf, "%f", rng.Float64()*3)
+		if i+1 < n {
+			buf.WriteByte(' ')
+		}
+	}
+	buf.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		k := rng.Intn(n) + 1
+		x := rng.Float64() * 3
+		fmt.Fprintf(&buf, "%d %f\n", k, x)
+	}
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(48))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1942/verifierG.go
+++ b/1000-1999/1900-1999/1940-1949/1942/verifierG.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refG_1942")
+	cmd := exec.Command("go", "build", "-o", tmp, "1942G.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	a := rng.Intn(3)
+	b := rng.Intn(3)
+	c := rng.Intn(3)
+	return fmt.Sprintf("1\n%d %d %d\n", a, b, c)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(49))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1942/verifierH.go
+++ b/1000-1999/1900-1999/1940-1949/1942/verifierH.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	tmp := filepath.Join(os.TempDir(), "refH_1942")
+	cmd := exec.Command("go", "build", "-o", tmp, "1942H.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+func runProg(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	q := rng.Intn(4) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "1\n%d %d\n", n, q)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		if i > 2 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprint(&buf, p)
+	}
+	if n > 1 {
+		buf.WriteByte('\n')
+	} else {
+		buf.WriteByte('\n')
+	}
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprint(&buf, rng.Intn(5))
+	}
+	buf.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		t := rng.Intn(2) + 1
+		x := rng.Intn(n) + 1
+		v := rng.Intn(5) + 1
+		fmt.Fprintf(&buf, "%d %d %d\n", t, x, v)
+	}
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(50))
+	for i := 0; i < 100; i++ {
+		test := genTest(rng)
+		expected, err := runProg(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference error:", err)
+			os.Exit(1)
+		}
+		got, err := runProg(target, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d execution error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, test, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems in contest 1942
- each verifier compiles the reference solution and runs 100 random tests

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC1.go verifierC2.go verifierD.go verifierE.go verifierF.go verifierG.go verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_68878daafef48324b1e8363c7e738b99