### PR TITLE
Add verifiers for contest 1945

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1945/verifierA.go
+++ b/1000-1999/1900-1999/1940-1949/1945/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1945A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	a := rng.Int63n(1_000_000_000)
+	b := rng.Int63n(1_000_000_000)
+	c := rng.Int63n(1_000_000_000)
+	return fmt.Sprintf("1\n%d %d %d\n", a, b, c)
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1945/verifierB.go
+++ b/1000-1999/1900-1999/1940-1949/1945/verifierB.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1945B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	a := rng.Int63n(1_000_000_000) + 1
+	b := rng.Int63n(1_000_000_000) + 1
+	m := rng.Int63n(1_000_000_000) + 1
+	return fmt.Sprintf("1\n%d %d %d\n", a, b, m)
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1945/verifierC.go
+++ b/1000-1999/1900-1999/1940-1949/1945/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1945C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 3
+	s := genString(rng, n)
+	return fmt.Sprintf("1\n%d\n%s\n", n, s)
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1945/verifierD.go
+++ b/1000-1999/1900-1999/1940-1949/1945/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1945D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(100)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(100)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1945/verifierE.go
+++ b/1000-1999/1900-1999/1940-1949/1945/verifierE.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1945E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generatePerm(rng *rand.Rand, n int) []int {
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	return perm
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	x := rng.Intn(n) + 1
+	p := generatePerm(rng, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, x)
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1945/verifierF.go
+++ b/1000-1999/1900-1999/1940-1949/1945/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1945F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generatePerm(rng *rand.Rand, n int) []int {
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	return perm
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	v := make([]int, n)
+	for i := range v {
+		v[i] = rng.Intn(100) + 1
+	}
+	p := generatePerm(rng, n)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, val := range v {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", val)
+	}
+	sb.WriteByte('\n')
+	for i, val := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", val)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1945/verifierG.go
+++ b/1000-1999/1900-1999/1940-1949/1945/verifierG.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1945G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(7) + 1
+	D := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, D)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		k := rng.Int63n(100) + 1
+		s := rng.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d %d", k, s)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1945/verifierH.go
+++ b/1000-1999/1900-1999/1940-1949/1945/verifierH.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refH.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1945H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(7) + 4
+	x := rng.Intn(20)
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(50) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, x)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for all problems in contest 1945
- each verifier compiles the reference solution, runs 100 random tests and checks the given binary

## Testing
- `go run verifierA.go ./1945A_bin`

------
https://chatgpt.com/codex/tasks/task_e_68878e7d20008324ae83adb9f9245e07