### PR TITLE
Add solution verifiers for CF 1941

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1941/verifierA.go
+++ b/1000-1999/1900-1999/1940-1949/1941/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseA struct {
+	n, m, k int
+	b, c    []int
+	exp     string
+}
+
+func solveA(n, m, k int, b, c []int) string {
+	cnt := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if b[i]+c[j] <= k {
+				cnt++
+			}
+		}
+	}
+	return fmt.Sprint(cnt)
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCaseA {
+	rng := rand.New(rand.NewSource(1))
+	cases := make([]testCaseA, 100)
+	for i := range cases {
+		n := rng.Intn(8) + 1
+		m := rng.Intn(8) + 1
+		k := rng.Intn(50) + 1
+		b := make([]int, n)
+		c := make([]int, m)
+		for j := 0; j < n; j++ {
+			b[j] = rng.Intn(40) + 1
+		}
+		for j := 0; j < m; j++ {
+			c[j] = rng.Intn(40) + 1
+		}
+		cases[i] = testCaseA{n: n, m: m, k: k, b: b, c: c, exp: solveA(n, m, k, b, c)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		var sb strings.Builder
+		fmt.Fprintln(&sb, 1)
+		fmt.Fprintf(&sb, "%d %d %d\n", tc.n, tc.m, tc.k)
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(tc.b[j]))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < tc.m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(tc.c[j]))
+		}
+		sb.WriteByte('\n')
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, tc.exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1941/verifierB.go
+++ b/1000-1999/1900-1999/1940-1949/1941/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseB struct {
+	n   int
+	a   []int64
+	exp string
+}
+
+func canZero(a []int64) bool {
+	n := len(a)
+	for i := 0; i <= n-3; i++ {
+		x := a[i]
+		if a[i+1] < 2*x || a[i+2] < x {
+			return false
+		}
+		a[i+1] -= 2 * x
+		a[i+2] -= x
+	}
+	return a[n-2] == 0 && a[n-1] == 0
+}
+
+func solveB(arr []int64) string {
+	b := make([]int64, len(arr))
+	copy(b, arr)
+	if canZero(b) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCaseB {
+	rng := rand.New(rand.NewSource(2))
+	cases := make([]testCaseB, 100)
+	for i := range cases {
+		n := rng.Intn(6) + 3
+		arr := make([]int64, n)
+		for j := 0; j < n; j++ {
+			arr[j] = int64(rng.Intn(20))
+		}
+		cases[i] = testCaseB{n: n, a: arr, exp: solveB(arr)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		var sb strings.Builder
+		fmt.Fprintln(&sb, 1)
+		fmt.Fprintf(&sb, "%d\n", tc.n)
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(tc.a[j]))
+		}
+		sb.WriteByte('\n')
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(strings.ToUpper(got)) != tc.exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, tc.exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1941/verifierC.go
+++ b/1000-1999/1900-1999/1940-1949/1941/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseC struct {
+	s   string
+	exp string
+}
+
+func solveC(s string) string {
+	n := len(s)
+	ans := 0
+	for i := 0; i < n; {
+		if i+4 < n && s[i:i+5] == "mapie" {
+			ans++
+			i += 5
+		} else if i+2 < n && (s[i:i+3] == "pie" || s[i:i+3] == "map") {
+			ans++
+			i += 3
+		} else {
+			i++
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCaseC {
+	rng := rand.New(rand.NewSource(3))
+	cases := make([]testCaseC, 100)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := range cases {
+		n := rng.Intn(20) + 1
+		sb := strings.Builder{}
+		for j := 0; j < n; j++ {
+			sb.WriteRune(letters[rng.Intn(len(letters))])
+		}
+		s := sb.String()
+		cases[i] = testCaseC{s: s, exp: solveC(s)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		input := fmt.Sprintf("1\n%d\n%s\n", len(tc.s), tc.s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, tc.exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1941/verifierD.go
+++ b/1000-1999/1900-1999/1940-1949/1941/verifierD.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseD struct {
+	n, m, x int
+	r       []int
+	c       []byte
+	exp     string
+}
+
+func solveD(n, m, x int, r []int, c []byte) string {
+	x--
+	cur := make([]bool, n)
+	cur[x] = true
+	for i := 0; i < m; i++ {
+		rr := r[i]
+		dir := c[i]
+		next := make([]bool, n)
+		for pos := 0; pos < n; pos++ {
+			if !cur[pos] {
+				continue
+			}
+			if dir == '0' || dir == '?' {
+				to := (pos + rr) % n
+				next[to] = true
+			}
+			if dir == '1' || dir == '?' {
+				to := pos - rr
+				to %= n
+				if to < 0 {
+					to += n
+				}
+				next[to] = true
+			}
+		}
+		cur = next
+	}
+	var res []int
+	for i := 0; i < n; i++ {
+		if cur[i] {
+			res = append(res, i+1)
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintln(&sb, len(res))
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCaseD {
+	rng := rand.New(rand.NewSource(4))
+	cases := make([]testCaseD, 100)
+	for i := range cases {
+		n := rng.Intn(6) + 2
+		m := rng.Intn(6) + 1
+		x := rng.Intn(n) + 1
+		r := make([]int, m)
+		c := make([]byte, m)
+		for j := 0; j < m; j++ {
+			r[j] = rng.Intn(n-1) + 1
+			d := rng.Intn(3)
+			if d == 0 {
+				c[j] = '0'
+			} else if d == 1 {
+				c[j] = '1'
+			} else {
+				c[j] = '?'
+			}
+		}
+		cases[i] = testCaseD{n: n, m: m, x: x, r: r, c: c, exp: solveD(n, m, x, r, c)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		var sb strings.Builder
+		fmt.Fprintln(&sb, 1)
+		fmt.Fprintf(&sb, "%d %d %d\n", tc.n, tc.m, tc.x)
+		for j := 0; j < tc.m; j++ {
+			fmt.Fprintf(&sb, "%d %c\n", tc.r[j], tc.c[j])
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\n", i+1, tc.exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1941/verifierE.go
+++ b/1000-1999/1900-1999/1940-1949/1941/verifierE.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseE struct {
+	n, m, k, d int
+	grid       [][]int
+	exp        string
+}
+
+func rowCost(row []int, d int) int64 {
+	m := len(row)
+	const INF int64 = 1 << 60
+	cost := make([]int64, m)
+	for i, v := range row {
+		cost[i] = int64(v) + 1
+	}
+	dp := make([]int64, m)
+	for i := range dp {
+		dp[i] = INF
+	}
+	dp[0] = cost[0]
+	type pair struct {
+		idx int
+		val int64
+	}
+	deque := make([]pair, 0)
+	for j := 1; j < m; j++ {
+		val := dp[j-1]
+		for len(deque) > 0 && deque[len(deque)-1].val >= val {
+			deque = deque[:len(deque)-1]
+		}
+		deque = append(deque, pair{j - 1, val})
+		limit := j - (d + 1)
+		for len(deque) > 0 && deque[0].idx < limit {
+			deque = deque[1:]
+		}
+		if len(deque) > 0 {
+			dp[j] = cost[j] + deque[0].val
+		}
+	}
+	return dp[m-1]
+}
+
+func solveE(n, m, k, d int, grid [][]int) string {
+	costs := make([]int64, n)
+	for i := 0; i < n; i++ {
+		costs[i] = rowCost(grid[i], d)
+	}
+	var sum int64
+	for i := 0; i < k; i++ {
+		sum += costs[i]
+	}
+	ans := sum
+	for i := k; i < n; i++ {
+		sum += costs[i] - costs[i-k]
+		if sum < ans {
+			ans = sum
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCaseE {
+	rng := rand.New(rand.NewSource(5))
+	cases := make([]testCaseE, 100)
+	for i := range cases {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(6) + 3
+		k := rng.Intn(n) + 1
+		d := rng.Intn(m) + 1
+		grid := make([][]int, n)
+		for r := 0; r < n; r++ {
+			grid[r] = make([]int, m)
+			for c := 0; c < m; c++ {
+				if c == 0 || c == m-1 {
+					grid[r][c] = 0
+				} else {
+					grid[r][c] = rng.Intn(10)
+				}
+			}
+		}
+		cases[i] = testCaseE{n: n, m: m, k: k, d: d, grid: grid, exp: solveE(n, m, k, d, grid)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		var sb strings.Builder
+		fmt.Fprintln(&sb, 1)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", tc.n, tc.m, tc.k, tc.d)
+		for r := 0; r < tc.n; r++ {
+			for c := 0; c < tc.m; c++ {
+				if c > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprint(tc.grid[r][c]))
+			}
+			sb.WriteByte('\n')
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, tc.exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1941/verifierF.go
+++ b/1000-1999/1900-1999/1940-1949/1941/verifierF.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCaseF struct {
+	n, m, k int
+	a       []int64
+	d       []int64
+	f       []int64
+	exp     string
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func existsSumInRange(D, F []int64, L, R int64) bool {
+	i, j := 0, len(F)-1
+	for i < len(D) && j >= 0 {
+		s := D[i] + F[j]
+		if s < L {
+			i++
+		} else if s > R {
+			j--
+		} else {
+			return true
+		}
+	}
+	return false
+}
+
+func can(a, D, F []int64, limit int64) bool {
+	pos := -1
+	for i := 1; i < len(a); i++ {
+		gap := a[i] - a[i-1]
+		if gap > limit {
+			if pos != -1 {
+				return false
+			}
+			pos = i
+		}
+	}
+	if pos == -1 {
+		return true
+	}
+	gap := a[pos] - a[pos-1]
+	if gap > 2*limit {
+		return false
+	}
+	left := maxInt64(a[pos-1], a[pos]-limit)
+	right := minInt64(a[pos], a[pos-1]+limit)
+	return existsSumInRange(D, F, left, right)
+}
+
+func solveF(n, m, k int, a, d, f []int64) string {
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	sort.Slice(d, func(i, j int) bool { return d[i] < d[j] })
+	sort.Slice(f, func(i, j int) bool { return f[i] < f[j] })
+	low, high := int64(0), int64(4_000_000_000)
+	for low < high {
+		mid := (low + high) / 2
+		if can(a, d, f, mid) {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	return fmt.Sprint(low)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCaseF {
+	rng := rand.New(rand.NewSource(6))
+	cases := make([]testCaseF, 100)
+	for i := range cases {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(4) + 1
+		k := rng.Intn(4) + 1
+		a := make([]int64, n)
+		cur := int64(0)
+		for j := 0; j < n; j++ {
+			cur += int64(rng.Intn(5) + 1)
+			a[j] = cur
+		}
+		d := make([]int64, m)
+		for j := 0; j < m; j++ {
+			d[j] = int64(rng.Intn(10) + 1)
+		}
+		f := make([]int64, k)
+		for j := 0; j < k; j++ {
+			f[j] = int64(rng.Intn(10) + 1)
+		}
+		cases[i] = testCaseF{n: n, m: m, k: k, a: a, d: d, f: f, exp: solveF(n, m, k, a, d, f)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		var sb strings.Builder
+		fmt.Fprintln(&sb, 1)
+		fmt.Fprintf(&sb, "%d %d %d\n", tc.n, tc.m, tc.k)
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(tc.a[j]))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < tc.m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(tc.d[j]))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < tc.k; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(tc.f[j]))
+		}
+		sb.WriteByte('\n')
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, tc.exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1940-1949/1941/verifierG.go
+++ b/1000-1999/1900-1999/1940-1949/1941/verifierG.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseG struct {
+	n, m  int
+	edges [][3]int
+	b, e  int
+	exp   string
+}
+
+type deque struct {
+	data       []int
+	head, tail int
+}
+
+func newDeque(n int) *deque {
+	size := 2*n + 10
+	d := &deque{data: make([]int, size)}
+	d.head = size / 2
+	d.tail = d.head
+	return d
+}
+
+func (d *deque) empty() bool     { return d.head == d.tail }
+func (d *deque) pushFront(x int) { d.head--; d.data[d.head] = x }
+func (d *deque) pushBack(x int)  { d.data[d.tail] = x; d.tail++ }
+func (d *deque) popFront() int   { x := d.data[d.head]; d.head++; return x }
+
+func solveG(n, m int, edges [][3]int, b, e int) string {
+	colorID := make(map[int]int)
+	vertexColors := make([][]int, n+1)
+	colorVerts := [][]int{{}}
+	for _, ed := range edges {
+		u, v, c := ed[0], ed[1], ed[2]
+		id, ok := colorID[c]
+		if !ok {
+			id = len(colorVerts)
+			colorID[c] = id
+			colorVerts = append(colorVerts, []int{})
+		}
+		vertexColors[u] = append(vertexColors[u], id)
+		vertexColors[v] = append(vertexColors[v], id)
+		colorVerts[id] = append(colorVerts[id], u)
+		colorVerts[id] = append(colorVerts[id], v)
+	}
+	if b == e {
+		return "0"
+	}
+	numColors := len(colorVerts) - 1
+	total := n + numColors
+	const INF = int(1e9)
+	dist := make([]int, total+1)
+	for i := 1; i <= total; i++ {
+		dist[i] = INF
+	}
+	dq := newDeque(total)
+	dist[b] = 0
+	dq.pushFront(b)
+	for !dq.empty() {
+		v := dq.popFront()
+		d := dist[v]
+		if v == e {
+			break
+		}
+		if v <= n {
+			for _, cid := range vertexColors[v] {
+				node := n + cid
+				if dist[node] > d+1 {
+					dist[node] = d + 1
+					dq.pushBack(node)
+				}
+			}
+		} else {
+			cid := v - n
+			if colorVerts[cid] != nil {
+				for _, u := range colorVerts[cid] {
+					if dist[u] > d {
+						dist[u] = d
+						dq.pushFront(u)
+					}
+				}
+				colorVerts[cid] = nil
+			}
+		}
+	}
+	return fmt.Sprint(dist[e])
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCaseG {
+	rng := rand.New(rand.NewSource(7))
+	cases := make([]testCaseG, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 2
+		m := rng.Intn(6) + 1
+		edges := make([][3]int, m)
+		for j := 0; j < m; j++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			for v == u {
+				v = rng.Intn(n) + 1
+			}
+			c := rng.Intn(5) + 1
+			edges[j] = [3]int{u, v, c}
+		}
+		b := rng.Intn(n) + 1
+		e := rng.Intn(n) + 1
+		cases[i] = testCaseG{n: n, m: m, edges: edges, b: b, e: e, exp: solveG(n, m, edges, b, e)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		var sb strings.Builder
+		fmt.Fprintln(&sb, 1)
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+		for _, ed := range tc.edges {
+			fmt.Fprintf(&sb, "%d %d %d\n", ed[0], ed[1], ed[2])
+		}
+		fmt.Fprintf(&sb, "%d %d\n", tc.b, tc.e)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, tc.exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 1941 problems A–G
- each verifier generates 100 random tests and checks any submitted binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68878d64f7988324b23d37faf8658265