### PR TITLE
Add solution verifiers for CF Round 1946

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1946/verifierA.go
+++ b/1000-1999/1900-1999/1940-1949/1946/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var t int
+	fmt.Fscan(reader, &t)
+	var out strings.Builder
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+		m := (n - 1) / 2
+		target := a[m] + 1
+		var ops int64
+		for i := m; i < n; i++ {
+			if a[i] < target {
+				ops += target - a[i]
+			}
+		}
+		out.WriteString(fmt.Sprintf("%d\n", ops))
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(46))
+	var tests []test
+	fixed := []string{
+		"1\n3\n2 2 8\n",
+		"1\n1\n5\n",
+		"1\n2\n1 1\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(10)+1)
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1900-1999/1940-1949/1946/verifierB.go
+++ b/1000-1999/1900-1999/1940-1949/1946/verifierB.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod int64 = 1_000_000_007
+
+type test struct {
+	input    string
+	expected string
+}
+
+func modPow(base, exp, m int64) int64 {
+	res := int64(1)
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res * base % m
+		}
+		base = base * base % m
+		exp >>= 1
+	}
+	return res
+}
+
+func maxSub(arr []int64) int64 {
+	best := arr[0]
+	cur := arr[0]
+	for i := 1; i < len(arr); i++ {
+		if cur+arr[i] > arr[i] {
+			cur += arr[i]
+		} else {
+			cur = arr[i]
+		}
+		if cur > best {
+			best = cur
+		}
+	}
+	return best
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var t int
+	fmt.Fscan(reader, &t)
+	var out strings.Builder
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		arr := make([]int64, n)
+		var sum int64
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+			sum += arr[i]
+		}
+		mx := maxSub(arr)
+		if mx <= 0 {
+			out.WriteString(fmt.Sprintf("%d\n", (sum%mod+mod)%mod))
+			continue
+		}
+		pow2 := modPow(2, int64(k), mod)
+		if sum >= mx {
+			ans := ((sum%mod + mod) % mod) * pow2 % mod
+			out.WriteString(fmt.Sprintf("%d\n", ans))
+		} else {
+			inc := (mx%mod + mod) % mod
+			inc = inc * ((pow2 - 1 + mod) % mod) % mod
+			ans := ((sum%mod+mod)%mod + inc) % mod
+			out.WriteString(fmt.Sprintf("%d\n", ans))
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(47))
+	var tests []test
+	fixed := []string{
+		"1\n1 0\n5\n",
+		"1\n3 1\n1 2 3\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		k := rng.Intn(4)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(11)-5)
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1900-1999/1940-1949/1946/verifierC.go
+++ b/1000-1999/1900-1999/1940-1949/1946/verifierC.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func can(g [][]int, n, k, x int) bool {
+	sizes := make([]int, 0)
+	var dfs func(v, p int) int
+	dfs = func(v, p int) int {
+		sum := 1
+		for _, to := range g[v] {
+			if to == p {
+				continue
+			}
+			sum += dfs(to, v)
+		}
+		if sum >= x {
+			sizes = append(sizes, sum)
+			return 0
+		}
+		return sum
+	}
+	dfs(0, -1)
+	if len(sizes) < k {
+		return false
+	}
+	sort.Ints(sizes)
+	total := 0
+	for i := 0; i < k; i++ {
+		total += sizes[i]
+	}
+	return n-total >= x
+}
+
+func solveOne(n, k int, edges [][2]int) int {
+	g := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	low, high, ans := 1, n, 1
+	for low <= high {
+		mid := (low + high) / 2
+		if can(g, n, k, mid) {
+			ans = mid
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	return ans
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var t int
+	fmt.Fscan(reader, &t)
+	var out strings.Builder
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		edges := make([][2]int, n-1)
+		for i := 0; i < n-1; i++ {
+			var u, v int
+			fmt.Fscan(reader, &u, &v)
+			u--
+			v--
+			edges[i] = [2]int{u, v}
+		}
+		ans := solveOne(n, k, edges)
+		out.WriteString(fmt.Sprintf("%d\n", ans))
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges = append(edges, [2]int{i, p})
+	}
+	return edges
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(48))
+	var tests []test
+	fixed := []string{
+		"1\n1 0\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		k := rng.Intn(n)
+		edges := generateTree(rng, n)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1900-1999/1940-1949/1946/verifierD.go
+++ b/1000-1999/1900-1999/1940-1949/1946/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var t int
+	fmt.Fscan(reader, &t)
+	var out strings.Builder
+	const mask30 int64 = (1 << 30) - 1
+	for ; t > 0; t-- {
+		var n int
+		var x int64
+		fmt.Fscan(reader, &n, &x)
+		mask := (^x) & mask30
+		px := int64(0)
+		base := int64(0)
+		segments := 0
+		for i := 0; i < n; i++ {
+			var v int64
+			fmt.Fscan(reader, &v)
+			px ^= v & mask
+			if px == base {
+				segments++
+				base = px
+			}
+		}
+		if px == base {
+			out.WriteString(fmt.Sprintf("%d\n", segments))
+		} else {
+			out.WriteString("-1\n")
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(49))
+	var tests []test
+	fixed := []string{
+		"1\n1 0\n0\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		x := rng.Int63n(8)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Int63n(8))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1900-1999/1940-1949/1946/verifierE.go
+++ b/1000-1999/1900-1999/1940-1949/1946/verifierE.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD int64 = 1000000007
+const MAXN = 200005
+
+type test struct {
+	input    string
+	expected string
+}
+
+var fac [MAXN]int64
+var ifac [MAXN]int64
+var invNum [MAXN]int64
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		b >>= 1
+	}
+	return res
+}
+
+func initComb() {
+	fac[0] = 1
+	for i := 1; i < MAXN; i++ {
+		fac[i] = fac[i-1] * int64(i) % MOD
+	}
+	ifac[MAXN-1] = modPow(fac[MAXN-1], MOD-2)
+	for i := MAXN - 1; i > 0; i-- {
+		ifac[i-1] = ifac[i] * int64(i) % MOD
+	}
+	for i := 1; i < MAXN; i++ {
+		invNum[i] = modPow(int64(i), MOD-2)
+	}
+}
+
+func comb(n, k int) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	return fac[n] * ifac[k] % MOD * ifac[n-k] % MOD
+}
+
+func prefixCount(L int, P []int) int64 {
+	if L == 0 {
+		if len(P) == 0 {
+			return 1
+		}
+		return 0
+	}
+	if len(P) == 0 || P[0] != 1 || P[len(P)-1] > L {
+		return 0
+	}
+	for i := 1; i < len(P); i++ {
+		if P[i] <= P[i-1] {
+			return 0
+		}
+	}
+	ans := fac[L-1]
+	for i := 1; i < len(P); i++ {
+		ans = ans * invNum[P[i]-1] % MOD
+	}
+	return ans
+}
+
+func suffixCount(L int, S []int) int64 {
+	if L == 0 {
+		if len(S) == 0 {
+			return 1
+		}
+		return 0
+	}
+	if len(S) == 0 || S[len(S)-1] != L {
+		return 0
+	}
+	for i := 1; i < len(S); i++ {
+		if S[i] <= S[i-1] {
+			return 0
+		}
+	}
+	ans := fac[L-1]
+	for i := 0; i < len(S)-1; i++ {
+		ans = ans * invNum[L-S[i]] % MOD
+	}
+	return ans
+}
+
+func solveCase(n int, P, S []int) int64 {
+	if len(P) == 0 || len(S) == 0 {
+		return 0
+	}
+	if P[0] != 1 || S[len(S)-1] != n {
+		return 0
+	}
+	mp := make(map[int]struct{}, len(P))
+	for _, v := range P {
+		mp[v] = struct{}{}
+	}
+	inter := 0
+	for _, v := range S {
+		if _, ok := mp[v]; ok {
+			inter++
+		}
+	}
+	if inter != 1 {
+		return 0
+	}
+	x := P[len(P)-1]
+	if S[0] != x {
+		return 0
+	}
+	for _, v := range P {
+		if v > x {
+			return 0
+		}
+	}
+	for _, v := range S {
+		if v < x {
+			return 0
+		}
+	}
+	L := x - 1
+	R := n - x
+	var Pleft []int
+	for _, v := range P {
+		if v < x {
+			Pleft = append(Pleft, v)
+		}
+	}
+	var Sright []int
+	for _, v := range S {
+		if v > x {
+			Sright = append(Sright, v-x)
+		}
+	}
+	A := prefixCount(L, Pleft)
+	B := suffixCount(R, Sright)
+	if A == 0 || B == 0 {
+		return 0
+	}
+	ans := comb(n-1, L) * A % MOD
+	ans = ans * B % MOD
+	return ans
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var t int
+	fmt.Fscan(reader, &t)
+	var out strings.Builder
+	for ; t > 0; t-- {
+		var n, m1, m2 int
+		fmt.Fscan(reader, &n, &m1, &m2)
+		P := make([]int, m1)
+		for i := 0; i < m1; i++ {
+			fmt.Fscan(reader, &P[i])
+		}
+		S := make([]int, m2)
+		for i := 0; i < m2; i++ {
+			fmt.Fscan(reader, &S[i])
+		}
+		ans := solveCase(n, P, S)
+		out.WriteString(fmt.Sprintf("%d\n", ans))
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(50))
+	var tests []test
+	fixed := []string{
+		"1\n1 0 0\n\n\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		m1 := rng.Intn(n + 1)
+		m2 := rng.Intn(n + 1)
+		var P []int
+		for i := 0; i < m1; i++ {
+			v := rng.Intn(n) + 1
+			P = append(P, v)
+		}
+		var S []int
+		for i := 0; i < m2; i++ {
+			v := rng.Intn(n) + 1
+			S = append(S, v)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m1, m2))
+		for i, v := range P {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		for i, v := range S {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	initComb()
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1900-1999/1940-1949/1946/verifierF.go
+++ b/1000-1999/1900-1999/1940-1949/1946/verifierF.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solveOne(a []int, l, r int) int64 {
+	n := r - l + 1
+	dp := make([]int64, n)
+	var ans int64
+	for i := l; i <= r; i++ {
+		dp[i-l] = 1
+		for j := l; j < i; j++ {
+			if a[i]%a[j] == 0 {
+				dp[i-l] += dp[j-l]
+			}
+		}
+		ans += dp[i-l]
+	}
+	return ans
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var t int
+	fmt.Fscan(reader, &t)
+	var out strings.Builder
+	for ; t > 0; t-- {
+		var n, q int
+		fmt.Fscan(reader, &n, &q)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		for ; q > 0; q-- {
+			var l, r int
+			fmt.Fscan(reader, &l, &r)
+			l--
+			r--
+			ans := solveOne(a, l, r)
+			out.WriteString(fmt.Sprintf("%d\n", ans))
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(51))
+	var tests []test
+	fixed := []string{
+		"1\n1 1\n1\n1 1\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		q := rng.Intn(3) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(6) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", a[i])
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < q; j++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			fmt.Fprintf(&sb, "%d %d\n", l, r)
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A-F of Codeforces Round 1946
- each verifier generates at least 100 deterministic tests and checks any provided binary

## Testing
- `go build` on each verifier
- `go run verifierA.go ./1946A_bin`

------
https://chatgpt.com/codex/tasks/task_e_68878ec32b30832489a60d8a5037619f