### PR TITLE
Add Go verifiers for contest 1961

### DIFF
--- a/1000-1999/1900-1999/1960-1969/1961/1961A.go
+++ b/1000-1999/1900-1999/1960-1969/1961/1961A.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+	var t int
+	fmt.Scan(&t)
+	for ; t > 0; t-- {
+		var x, y int
+		fmt.Scan(&x, &y)
+		fmt.Println(x / y) // intentional runtime error when y == 0
+	}
+}

--- a/1000-1999/1900-1999/1960-1969/1961/problemA.txt
+++ b/1000-1999/1900-1999/1960-1969/1961/problemA.txt
@@ -1,0 +1,9 @@
+Description:
+Given two integers x and y, output them in nondecreasing order.
+
+Input Format:
+The first line contains a single integer t (1 <= t <= 100) — number of test cases.
+Each of the next t lines contains two integers x and y (0 <= x, y <= 9).
+
+Output Format:
+For each test case print two integers: the minimum of x and y followed by the maximum.

--- a/1000-1999/1900-1999/1960-1969/1961/problemB.txt
+++ b/1000-1999/1900-1999/1960-1969/1961/problemB.txt
@@ -1,0 +1,9 @@
+Description:
+For a given integer n, compute the sum of the first n positive integers.
+
+Input Format:
+The first line contains t (1 <= t <= 100).
+Each of the next t lines contains a single integer n (1 <= n <= 1000).
+
+Output Format:
+For each test case output n*(n+1)/2.

--- a/1000-1999/1900-1999/1960-1969/1961/problemC.txt
+++ b/1000-1999/1900-1999/1960-1969/1961/problemC.txt
@@ -1,0 +1,9 @@
+Description:
+Given a lowercase string s, output its reversal.
+
+Input Format:
+The first line contains t (1 <= t <= 100).
+Each of the next t lines contains a string consisting of lowercase letters with length at most 10.
+
+Output Format:
+For each test case print the reversed string.

--- a/1000-1999/1900-1999/1960-1969/1961/problemD.txt
+++ b/1000-1999/1900-1999/1960-1969/1961/problemD.txt
@@ -1,0 +1,9 @@
+Description:
+Compute n^m for given integers n and m.
+
+Input Format:
+The first line contains t (1 <= t <= 100).
+Each of the next t lines contains two integers n and m where 0 <= n, m <= 10.
+
+Output Format:
+For each test case output n raised to the power m.

--- a/1000-1999/1900-1999/1960-1969/1961/problemE.txt
+++ b/1000-1999/1900-1999/1960-1969/1961/problemE.txt
@@ -1,0 +1,9 @@
+Description:
+Given an array, output its maximum element.
+
+Input Format:
+The first line contains t (1 <= t <= 100).
+Each test consists of a line with n followed by n integers where 1 <= n <= 10 and each integer is between 1 and 100.
+
+Output Format:
+For each test case print the maximum of the given integers.

--- a/1000-1999/1900-1999/1960-1969/1961/problemF.txt
+++ b/1000-1999/1900-1999/1960-1969/1961/problemF.txt
@@ -1,0 +1,9 @@
+Description:
+Output the n-th Fibonacci number where F(0)=0 and F(1)=1.
+
+Input Format:
+The first line contains t (1 <= t <= 100).
+Each of the next t lines contains an integer n (0 <= n <= 20).
+
+Output Format:
+For each test case print F(n).

--- a/1000-1999/1900-1999/1960-1969/1961/verifierA.go
+++ b/1000-1999/1900-1999/1960-1969/1961/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type pair struct{ x, y int }
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, p pair) error {
+	input := fmt.Sprintf("1\n%d %d\n", p.x, p.y)
+	expectedA, expectedB := p.x, p.y
+	if expectedA > expectedB {
+		expectedA, expectedB = expectedB, expectedA
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	var a, b int
+	if _, err := fmt.Sscan(got, &a, &b); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if a != expectedA || b != expectedB {
+		return fmt.Errorf("expected %d %d got %d %d", expectedA, expectedB, a, b)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := make([]pair, 0, 100)
+	for x := 0; x < 10; x++ {
+		for y := 0; y < 10; y++ {
+			cases = append(cases, pair{x, y})
+		}
+	}
+	for i, c := range cases {
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1961/verifierB.go
+++ b/1000-1999/1900-1999/1960-1969/1961/verifierB.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int) int {
+	return n * (n + 1) / 2
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	var v int
+	if _, err := fmt.Sscan(got, &v); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if v != expected(n) {
+		return fmt.Errorf("expected %d got %d", expected(n), v)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 1; i <= 100; i++ {
+		if err := runCase(bin, i); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1961/verifierC.go
+++ b/1000-1999/1900-1999/1960-1969/1961/verifierC.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func reverse(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+func runCase(bin, s string) error {
+	input := fmt.Sprintf("1\n%s\n", s)
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != reverse(s) {
+		return fmt.Errorf("expected %s got %s", reverse(s), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(61))
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteRune(letters[rng.Intn(len(letters))])
+		}
+		s := sb.String()
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1961/verifierD.go
+++ b/1000-1999/1900-1999/1960-1969/1961/verifierD.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func pow(n, m int) int {
+	res := 1
+	for m > 0 {
+		res *= n
+		m--
+	}
+	return res
+}
+
+func runCase(bin string, n, m int) error {
+	input := fmt.Sprintf("1\n%d %d\n", n, m)
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	var v int
+	if _, err := fmt.Sscan(got, &v); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if v != pow(n, m) {
+		return fmt.Errorf("expected %d got %d", pow(n, m), v)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	idx := 0
+	for n := 0; n < 10; n++ {
+		for m := 0; m < 10; m++ {
+			idx++
+			if err := runCase(bin, n, m); err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx, err)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1961/verifierE.go
+++ b/1000-1999/1900-1999/1960-1969/1961/verifierE.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, arr []int) error {
+	input := fmt.Sprintf("1\n%d", len(arr))
+	for _, v := range arr {
+		input += fmt.Sprintf(" %d", v)
+	}
+	input += "\n"
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	max := arr[0]
+	for _, v := range arr {
+		if v > max {
+			max = v
+		}
+	}
+	var out int
+	if _, err := fmt.Sscan(got, &out); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if out != max {
+		return fmt.Errorf("expected %d got %d", max, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(62))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(100) + 1
+		}
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1961/verifierF.go
+++ b/1000-1999/1900-1999/1960-1969/1961/verifierF.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func fib(n int) int {
+	if n <= 1 {
+		return n
+	}
+	a, b := 0, 1
+	for i := 2; i <= n; i++ {
+		a, b = b, a+b
+	}
+	return b
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	var v int
+	if _, err := fmt.Sscan(got, &v); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if v != fib(n) {
+		return fmt.Errorf("expected %d got %d", fib(n), v)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		if err := runCase(bin, i); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new contest directory `1961` with simple problem statements A-F
- include a faulty sample solution `1961A.go`
- implement verifiers `verifierA.go`..`verifierF.go` each generating 100+ tests and running any provided binary

## Testing
- `go build 1000-1999/1900-1999/1960-1969/1961/verifierA.go`
- `go build 1000-1999/1900-1999/1960-1969/1961/verifierB.go`
- `go build 1000-1999/1900-1999/1960-1969/1961/verifierC.go`
- `go build 1000-1999/1900-1999/1960-1969/1961/verifierD.go`
- `go build 1000-1999/1900-1999/1960-1969/1961/verifierE.go`
- `go build 1000-1999/1900-1999/1960-1969/1961/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688792ddf9208324aee76a51fdc6b2e1