### PR TITLE
Add Go verifiers for contest 1955

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1955/verifierA.go
+++ b/1000-1999/1900-1999/1950-1959/1955/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1955A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return "./" + ref, nil
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	a := rng.Intn(30) + 1
+	b := rng.Intn(30) + 1
+	return fmt.Sprintf("1\n%d %d %d\n", n, a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	// Some edge cases
+	cases = append(cases, "1\n1 1 1\n", "1\n2 5 3\n", "1\n100 30 30\n")
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runProgram(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProgram(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp = strings.TrimSpace(exp)
+		got = strings.TrimSpace(got)
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1950-1959/1955/verifierB.go
+++ b/1000-1999/1900-1999/1950-1959/1955/verifierB.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1955B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return "./" + ref, nil
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genValid(rng *rand.Rand) (string, []int64, int, int64, int64) {
+	n := rng.Intn(4) + 2
+	c := rng.Int63n(10) + 1
+	d := rng.Int63n(10) + 1
+	base := rng.Int63n(50) + 1
+	arr := make([]int64, n*n)
+	idx := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			arr[idx] = base + int64(i)*c + int64(j)*d
+			idx++
+		}
+	}
+	// shuffle arr
+	for i := len(arr) - 1; i > 0; i-- {
+		j := rng.Intn(i + 1)
+		arr[i], arr[j] = arr[j], arr[i]
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d\n", n, c, d)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String(), arr, n, c, d
+}
+
+func genInvalid(rng *rand.Rand) string {
+	_, arr, n, c, d := genValid(rng)
+	// modify one value
+	arr[0]++
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d\n", n, c, d)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 50 {
+		tc, _, _, _, _ := genValid(rng)
+		cases = append(cases, tc)
+	}
+	for len(cases) < 100 {
+		cases = append(cases, genInvalid(rng))
+	}
+
+	for i, tc := range cases {
+		exp, err := runProgram(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProgram(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1950-1959/1955/verifierC.go
+++ b/1000-1999/1900-1999/1950-1959/1955/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1955C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return "./" + ref, nil
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	a := make([]int64, n)
+	sum := int64(0)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Int63n(20) + 1
+		sum += a[i]
+	}
+	k := rng.Int63n(sum*2 + 1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, k)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runProgram(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProgram(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1950-1959/1955/verifierD.go
+++ b/1000-1999/1900-1999/1950-1959/1955/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1955D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return "./" + ref, nil
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(n) + 1
+	k := rng.Intn(m) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(5) + 1
+	}
+	b := make([]int, m)
+	for i := range b {
+		b[i] = rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d\n", n, m, k)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runProgram(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProgram(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1950-1959/1955/verifierE.go
+++ b/1000-1999/1900-1999/1950-1959/1955/verifierE.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1955E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return "./" + ref, nil
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(30) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runProgram(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProgram(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1950-1959/1955/verifierF.go
+++ b/1000-1999/1900-1999/1950-1959/1955/verifierF.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1955F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return "./" + ref, nil
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	c1 := rng.Intn(10)
+	c2 := rng.Intn(10)
+	c3 := rng.Intn(10)
+	c4 := rng.Intn(10)
+	return fmt.Sprintf("1\n%d %d %d %d\n", c1, c2, c3, c4)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runProgram(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProgram(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1950-1959/1955/verifierG.go
+++ b/1000-1999/1900-1999/1950-1959/1955/verifierG.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1955G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return "./" + ref, nil
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	grid := make([][]int, n)
+	for i := range grid {
+		grid[i] = make([]int, m)
+		for j := range grid[i] {
+			grid[i][j] = rng.Intn(10) + 1
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", grid[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runProgram(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProgram(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1950-1959/1955/verifierH.go
+++ b/1000-1999/1900-1999/1950-1959/1955/verifierH.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refH.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1955H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v: %s", err, string(out))
+	}
+	return "./" + ref, nil
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	k := rng.Intn(3) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '#'
+			} else {
+				row[j] = '.'
+			}
+		}
+		grid[i] = string(row)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d %d\n", n, m, k)
+	for i := 0; i < n; i++ {
+		sb.WriteString(grid[i])
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < k; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(m) + 1
+		p := rng.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", x, y, p)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		exp, err := runProgram(ref, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProgram(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifiers A–H for contest 1955
- each verifier builds the reference solution and runs at least 100 random tests against a candidate binary

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1955/verifierA.go`
- `go build 1000-1999/1900-1999/1950-1959/1955/verifierH.go`

------
https://chatgpt.com/codex/tasks/task_e_688791399748832481bc17a6b875fecc