### PR TITLE
Add solution verifiers for Codeforces contest 1965

### DIFF
--- a/1000-1999/1900-1999/1960-1969/1965/verifierA.go
+++ b/1000-1999/1900-1999/1960-1969/1965/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(nums []int) string {
+	seen := make(map[int]struct{})
+	for _, v := range nums {
+		seen[v] = struct{}{}
+	}
+	if len(seen)%2 == 1 {
+		return "Alice"
+	}
+	return "Bob"
+}
+
+func buildCase(nums []int) testCase {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(nums)))
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: solve(nums)}
+}
+
+func genRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	nums := make([]int, n)
+	for i := range nums {
+		nums[i] = rng.Intn(10)
+	}
+	return buildCase(nums)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase([]int{1}))
+	cases = append(cases, buildCase([]int{1, 1}))
+	cases = append(cases, buildCase([]int{1, 2}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genRandomCase(rng))
+	}
+	for idx, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1965/verifierB.go
+++ b/1000-1999/1900-1999/1960-1969/1965/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseOutput(out string) (int, []int, error) {
+	rdr := strings.NewReader(out)
+	var m int
+	if _, err := fmt.Fscan(rdr, &m); err != nil {
+		return 0, nil, fmt.Errorf("failed to read m: %v", err)
+	}
+	if m < 1 || m > 25 {
+		return 0, nil, fmt.Errorf("invalid m %d", m)
+	}
+	arr := make([]int, m)
+	for i := 0; i < m; i++ {
+		if _, err := fmt.Fscan(rdr, &arr[i]); err != nil {
+			return 0, nil, fmt.Errorf("failed to read value %d: %v", i+1, err)
+		}
+		if arr[i] < 0 || arr[i] > 1_000_000_000 {
+			return 0, nil, fmt.Errorf("value out of range")
+		}
+	}
+	return m, arr, nil
+}
+
+func check(n, k int, arr []int) error {
+	reachable := make([]bool, n+1)
+	reachable[0] = true
+	for _, x := range arr {
+		if x > n {
+			continue
+		}
+		for s := n; s >= 0; s-- {
+			if reachable[s] && s+x <= n {
+				reachable[s+x] = true
+			}
+		}
+	}
+	if k <= n && reachable[k] {
+		return fmt.Errorf("found subsequence sum %d", k)
+	}
+	for v := 1; v <= n; v++ {
+		if v == k {
+			continue
+		}
+		if !reachable[v] {
+			return fmt.Errorf("no subsequence for %d", v)
+		}
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (string, int, int) {
+	n := rng.Intn(20) + 2
+	k := rng.Intn(n) + 1
+	input := fmt.Sprintf("1\n%d %d\n", n, k)
+	return input, n, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n, k := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		_, arr, err := parseOutput(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\noutput:\n%s\ninput:\n%s", i+1, err, out, in)
+			os.Exit(1)
+		}
+		if err := check(n, k, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\noutput:\n%s\ninput:\n%s", i+1, err, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1965/verifierC.go
+++ b/1000-1999/1900-1999/1960-1969/1965/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func reverse(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+func solve(n int, s string) int {
+	for L := 1; L <= n; L++ {
+		t := s[:L]
+		tRev := reverse(t)
+		ok := true
+		for start := 0; start < n; start += L {
+			end := start + L
+			if end > n {
+				seg := s[start:n]
+				prefix := t[:n-start]
+				prefRev := tRev[len(tRev)-(n-start):]
+				if seg != prefix && seg != prefRev {
+					ok = false
+					break
+				}
+			} else {
+				seg := s[start:end]
+				if seg != t && seg != tRev {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok {
+			return L
+		}
+	}
+	return n
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(15) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	var s strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			s.WriteByte('0')
+		} else {
+			s.WriteByte('1')
+		}
+	}
+	str := s.String()
+	sb.WriteString(str)
+	sb.WriteByte('\n')
+	return sb.String(), solve(n, str)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out)
+		if got != fmt.Sprintf("%d", exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1965/verifierD.go
+++ b/1000-1999/1900-1999/1960-1969/1965/verifierD.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, int, []int64) {
+	n := rng.Intn(3) + 3 // 3..5
+	arr := make([]int64, n)
+	for i := 0; i < (n+1)/2; i++ {
+		v := int64(rng.Intn(5) + 1)
+		arr[i] = v
+		arr[n-1-i] = v
+	}
+	var sums []int64
+	for i := 0; i < n; i++ {
+		s := int64(0)
+		for j := i; j < n; j++ {
+			s += arr[j]
+			sums = append(sums, s)
+		}
+	}
+	idx := rng.Intn(len(sums))
+	given := append([]int64(nil), sums[:idx]...)
+	given = append(given, sums[idx+1:]...)
+
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range given {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), n, given
+}
+
+func parseOutput(out string, n int) ([]int64, error) {
+	rdr := strings.NewReader(out)
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		if _, err := fmt.Fscan(rdr, &arr[i]); err != nil {
+			return nil, fmt.Errorf("failed to read value %d: %v", i+1, err)
+		}
+		if arr[i] <= 0 {
+			return nil, fmt.Errorf("values must be positive")
+		}
+	}
+	return arr, nil
+}
+
+func verify(n int, given []int64, arr []int64) error {
+	for i := 0; i < n; i++ {
+		if arr[i] != arr[n-1-i] {
+			return fmt.Errorf("array not palindrome")
+		}
+	}
+	var sums []int64
+	for i := 0; i < n; i++ {
+		s := int64(0)
+		for j := i; j < n; j++ {
+			s += arr[j]
+			sums = append(sums, s)
+		}
+	}
+	sort.Slice(sums, func(i, j int) bool { return sums[i] < sums[j] })
+	sort.Slice(given, func(i, j int) bool { return given[i] < given[j] })
+	i, j := 0, 0
+	diff := 0
+	for i < len(sums) && j < len(given) {
+		if sums[i] == given[j] {
+			i++
+			j++
+		} else {
+			diff++
+			i++
+		}
+	}
+	diff += len(sums) - i
+	diff += len(given) - j
+	if diff != 1 {
+		return fmt.Errorf("subarray sums mismatch")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n, given := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		arr, err := parseOutput(out, n)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\noutput:\n%s\ninput:\n%s", i+1, err, out, in)
+			os.Exit(1)
+		}
+		if err := verify(n, given, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\noutput:\n%s\ninput:\n%s", i+1, err, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1965/verifierE.go
+++ b/1000-1999/1900-1999/1960-1969/1965/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Move struct {
+	x, y, z, c int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n, m, k int, a [][]int) string {
+	var ans []Move
+	for i := n; i >= 1; i-- {
+		for j := 1; j <= m; j++ {
+			for l := 2; l <= n-i+1; l++ {
+				ans = append(ans, Move{i, j, l, a[i-1][j-1]})
+			}
+			for l := i + 1; l <= 2*i-1; l++ {
+				ans = append(ans, Move{l, j, n - i + 1, a[i-1][j-1]})
+			}
+			for l := n - i + 2; l <= n+a[i-1][j-1]; l++ {
+				ans = append(ans, Move{2*i - 1, j, l, a[i-1][j-1]})
+			}
+		}
+	}
+	for t := 1; t <= k; t++ {
+		for i := 1; i < n; i++ {
+			if i%2 == 1 || i+1 == n {
+				for j := 1; j <= m; j++ {
+					ans = append(ans, Move{2 * i, j, t + n - 1, t})
+				}
+			}
+		}
+		for i := 1; i < n; i++ {
+			ans = append(ans, Move{2 * i, m + 1, t + n - 1, t})
+			if i+1 < n {
+				ans = append(ans, Move{2*i + 1, m + 1, t + n - 1, t})
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(ans)))
+	for _, mv := range ans {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", mv.x, mv.y, mv.z, mv.c))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(2) + 2
+	m := rng.Intn(2) + 2
+	k := rng.Intn(2) + 1
+	a := make([][]int, n)
+	for i := range a {
+		a[i] = make([]int, m)
+		for j := range a[i] {
+			a[i][j] = rng.Intn(k) + 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	expected := solve(n, m, k, a)
+	return sb.String(), expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1965/verifierF.go
+++ b/1000-1999/1900-1999/1960-1969/1965/verifierF.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type interval struct{ l, r int }
+
+func possible(start, end int, intervals []interval, used []bool) bool {
+	if start > end {
+		return true
+	}
+	for i := 0; i < len(intervals); i++ {
+		if !used[i] && intervals[i].l <= start && start <= intervals[i].r {
+			used[i] = true
+			if possible(start+1, end, intervals, used) {
+				return true
+			}
+			used[i] = false
+		}
+	}
+	return false
+}
+
+func countWays(intervals []interval) []int {
+	n := len(intervals)
+	maxR := 0
+	for _, in := range intervals {
+		if in.r > maxR {
+			maxR = in.r
+		}
+	}
+	res := make([]int, n)
+	for k := 1; k <= n; k++ {
+		cnt := 0
+		for s := 1; s+k-1 <= maxR; s++ {
+			if possible(s, s+k-1, intervals, make([]bool, n)) {
+				cnt++
+			}
+		}
+		res[k-1] = cnt
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(5) + 1
+	intervals := make([]interval, n)
+	maxDay := n + 3
+	for i := 0; i < n; i++ {
+		l := rng.Intn(maxDay) + 1
+		r := l + rng.Intn(maxDay-l+1)
+		intervals[i] = interval{l, r}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", intervals[i].l, intervals[i].r))
+	}
+	expected := countWays(intervals)
+	// convert expected to ints
+	return sb.String(), expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		gotFields := strings.Fields(out)
+		if len(gotFields) != len(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\noutput:\n%s\ninput:\n%s", i+1, len(exp), len(gotFields), out, in)
+			os.Exit(1)
+		}
+		for j, gstr := range gotFields {
+			var g int
+			if _, err := fmt.Sscan(gstr, &g); err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid number %q\noutput:\n%s\ninput:\n%s", i+1, gstr, out, in)
+				os.Exit(1)
+			}
+			if g != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %v\noutput:\n%s\ninput:\n%s", i+1, exp, gotFields, out, in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–F of contest 1965
- each verifier runs a target binary and checks at least 100 test cases
- verifiers include random test generation and result checking specific to each task

## Testing
- `go build 1000-1999/1900-1999/1960-1969/1965/verifierA.go`
- `go build 1000-1999/1900-1999/1960-1969/1965/verifierB.go`
- `go build 1000-1999/1900-1999/1960-1969/1965/verifierC.go`
- `go build 1000-1999/1900-1999/1960-1969/1965/verifierD.go`
- `go build 1000-1999/1900-1999/1960-1969/1965/verifierE.go`
- `go build 1000-1999/1900-1999/1960-1969/1965/verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_688793f5e8ec83249be09f67daa47dd5