### PR TITLE
Add solution verifiers for contest 1967

### DIFF
--- a/1000-1999/1900-1999/1960-1969/1967/verifierA.go
+++ b/1000-1999/1900-1999/1960-1969/1967/verifierA.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type TestCaseA struct {
+	n int
+	k int64
+	a []int64
+}
+
+func genCaseA(rng *rand.Rand) TestCaseA {
+	n := rng.Intn(5) + 1
+	k := rng.Int63n(50)
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = rng.Int63n(50) + 1
+	}
+	return TestCaseA{n: n, k: k, a: a}
+}
+
+func canMake(t int64, a []int64, k int64) bool {
+	n := int64(len(a))
+	q := t / n
+	r := int(t % n)
+	need := int64(0)
+	for i, v := range a {
+		req := q
+		if i < r {
+			req++
+		}
+		if v < req {
+			need += req - v
+			if need > k {
+				return false
+			}
+		}
+	}
+	return need <= k
+}
+
+func expectedA(tc TestCaseA) int64 {
+	a := append([]int64(nil), tc.a...)
+	sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+	sum := int64(0)
+	for _, v := range a {
+		sum += v
+	}
+	low, high := int64(0), sum+tc.k
+	ans := int64(0)
+	for low <= high {
+		mid := (low + high) / 2
+		if canMake(mid, a, tc.k) {
+			ans = mid
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	if ans >= int64(tc.n) {
+		return ans - int64(tc.n) + 1
+	}
+	return 0
+}
+
+func runCaseA(bin string, tc TestCaseA, expect int64) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.k)
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseA(rng)
+		exp := expectedA(tc)
+		if err := runCaseA(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d k=%d a=%v\n", i+1, err, tc.n, tc.k, tc.a)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1967/verifierB1.go
+++ b/1000-1999/1900-1999/1960-1969/1967/verifierB1.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCaseB1 struct {
+	n int64
+	m int64
+}
+
+func genCaseB1(rng *rand.Rand) TestCaseB1 {
+	n := int64(rng.Intn(100) + 1)
+	m := int64(rng.Intn(100) + 1)
+	return TestCaseB1{n, m}
+}
+
+func expectedB1(n, m int64) int64 {
+	ans := int64(0)
+	for g := int64(1); g <= m; g++ {
+		kmax := (n + g) / (g * g)
+		kmin := int64(1)
+		if g == 1 {
+			kmin = 2
+		}
+		if kmax >= kmin {
+			ans += kmax - kmin + 1
+		}
+	}
+	return ans
+}
+
+func runCaseB1(bin string, tc TestCaseB1, expect int64) error {
+	input := fmt.Sprintf("1\n%d %d\n", tc.n, tc.m)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseB1(rng)
+		exp := expectedB1(tc.n, tc.m)
+		if err := runCaseB1(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d m=%d\n", i+1, err, tc.n, tc.m)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1967/verifierB2.go
+++ b/1000-1999/1900-1999/1960-1969/1967/verifierB2.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCaseB2 struct {
+	n int
+	m int
+}
+
+func genCaseB2(rng *rand.Rand) TestCaseB2 {
+	n := rng.Intn(40) + 1
+	m := rng.Intn(40) + 1
+	return TestCaseB2{n, m}
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expectedB2(n, m int) int64 {
+	count := int64(0)
+	for a := 1; a <= n; a++ {
+		for b := 1; b <= m; b++ {
+			g := gcd(a, b)
+			if (b*g)%(a+b) == 0 {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func runCaseB2(bin string, tc TestCaseB2, expect int64) error {
+	input := fmt.Sprintf("1\n%d %d\n", tc.n, tc.m)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseB2(rng)
+		exp := expectedB2(tc.n, tc.m)
+		if err := runCaseB2(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d m=%d\n", i+1, err, tc.n, tc.m)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1967/verifierC.go
+++ b/1000-1999/1900-1999/1960-1969/1967/verifierC.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 998244353
+
+type TestCaseC struct {
+	n int
+	k int64
+	b []int64
+}
+
+func genCaseC(rng *rand.Rand) TestCaseC {
+	n := rng.Intn(6) + 1
+	k := int64(rng.Intn(5) + 1)
+	b := make([]int64, n)
+	for i := range b {
+		b[i] = rng.Int63n(20)
+	}
+	return TestCaseC{n: n, k: k, b: b}
+}
+
+func applyN(v []int64) []int64 {
+	n := len(v)
+	res := make([]int64, n)
+	prefix := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		prefix[i] = (prefix[i-1] + v[i-1]) % MOD
+	}
+	for i := 1; i <= n; i++ {
+		lb := i & -i
+		res[i-1] = (prefix[i-1] - prefix[i-lb]) % MOD
+		if res[i-1] < 0 {
+			res[i-1] += MOD
+		}
+	}
+	return res
+}
+
+func powMod(a, e int64) int64 {
+	r := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			r = r * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return r
+}
+
+func modInv(a int64) int64 { return powMod(a, MOD-2) }
+
+func solveCaseC(n int, k int64, b []int64) []int64 {
+	r := bits.Len(uint(n))
+	powers := make([][]int64, r)
+	powers[0] = append([]int64(nil), b...)
+	for i := 1; i < r; i++ {
+		powers[i] = applyN(powers[i-1])
+	}
+	coeff := make([]int64, r)
+	coeff[0] = 1
+	comb := int64(1)
+	for i := 1; i < r; i++ {
+		comb = comb * (k + int64(i-1)) % MOD
+		comb = comb * modInv(int64(i)) % MOD
+		val := comb
+		if i%2 == 1 {
+			val = (MOD - val) % MOD
+		}
+		coeff[i] = val
+	}
+	ans := make([]int64, n)
+	for i := 0; i < r; i++ {
+		c := coeff[i]
+		if c == 0 {
+			continue
+		}
+		for j := 0; j < n; j++ {
+			ans[j] = (ans[j] + c*powers[i][j]) % MOD
+		}
+	}
+	return ans
+}
+
+func runCaseC(bin string, tc TestCaseC, expect []int64) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.k)
+	for i, v := range tc.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != tc.n {
+		return fmt.Errorf("expected %d numbers got %d", tc.n, len(fields))
+	}
+	for i, f := range fields {
+		var v int64
+		fmt.Sscan(f, &v)
+		if v%MOD != expect[i] {
+			return fmt.Errorf("index %d expected %d got %d", i, expect[i], v%MOD)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseC(rng)
+		exp := solveCaseC(tc.n, tc.k, tc.b)
+		if err := runCaseC(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d k=%d b=%v\n", i+1, err, tc.n, tc.k, tc.b)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1967/verifierD.go
+++ b/1000-1999/1900-1999/1960-1969/1967/verifierD.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCaseD struct {
+	n int
+	m int
+	a []int
+	b []int
+}
+
+func genCaseD(rng *rand.Rand) TestCaseD {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(m) + 1
+	}
+	b := make([]int, m)
+	for i := range b {
+		b[i] = rng.Intn(m) + 1
+	}
+	return TestCaseD{n: n, m: m, a: a, b: b}
+}
+
+func isNonDecreasing(arr []int) bool {
+	for i := 1; i < len(arr); i++ {
+		if arr[i] < arr[i-1] {
+			return false
+		}
+	}
+	return true
+}
+
+func stateKey(arr []int) string {
+	var sb strings.Builder
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	return sb.String()
+}
+
+func expectedD(tc TestCaseD) int {
+	start := append([]int(nil), tc.a...)
+	if isNonDecreasing(start) {
+		return 0
+	}
+	visited := map[string]bool{stateKey(start): true}
+	type item struct {
+		arr  []int
+		step int
+	}
+	q := list.New()
+	q.PushBack(item{start, 0})
+	for q.Len() > 0 {
+		front := q.Remove(q.Front()).(item)
+		if front.step > 8 {
+			continue
+		}
+		for mask := 1; mask < (1 << tc.n); mask++ {
+			next := append([]int(nil), front.arr...)
+			for i := 0; i < tc.n; i++ {
+				if mask>>i&1 == 1 {
+					next[i] = tc.b[next[i]-1]
+				}
+			}
+			key := stateKey(next)
+			if visited[key] {
+				continue
+			}
+			if isNonDecreasing(next) {
+				return front.step + 1
+			}
+			visited[key] = true
+			q.PushBack(item{next, front.step + 1})
+		}
+	}
+	return -1
+}
+
+func runCaseD(bin string, tc TestCaseD, expect int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseD(rng)
+		exp := expectedD(tc)
+		if err := runCaseD(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d m=%d a=%v b=%v\n", i+1, err, tc.n, tc.m, tc.a, tc.b)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1967/verifierE1.go
+++ b/1000-1999/1900-1999/1960-1969/1967/verifierE1.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+type TestCaseE struct {
+	n  int
+	m  int
+	b0 int
+}
+
+func genCaseE(rng *rand.Rand) TestCaseE {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	b0 := rng.Intn(3)
+	return TestCaseE{n: n, m: m, b0: b0}
+}
+
+func possible(a []int, b0 int) bool {
+	cur := map[int]struct{}{b0: {}}
+	for _, x := range a {
+		nxt := map[int]struct{}{}
+		for v := range cur {
+			if v+1 != x {
+				nxt[v+1] = struct{}{}
+			}
+			if v-1 >= 0 && v-1 != x {
+				nxt[v-1] = struct{}{}
+			}
+		}
+		if len(nxt) == 0 {
+			return false
+		}
+		cur = nxt
+	}
+	return true
+}
+
+func expectedE(tc TestCaseE) int64 {
+	arr := make([]int, tc.n)
+	var ans int64
+	var dfs func(pos int)
+	dfs = func(pos int) {
+		if pos == tc.n {
+			if possible(arr, tc.b0) {
+				ans++
+			}
+			return
+		}
+		for v := 1; v <= tc.m; v++ {
+			arr[pos] = v
+			dfs(pos + 1)
+		}
+	}
+	dfs(0)
+	return ans % mod
+}
+
+func runCaseE(bin string, tc TestCaseE, expect int64) error {
+	input := fmt.Sprintf("1\n%d %d %d\n", tc.n, tc.m, tc.b0)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got%mod != expect {
+		return fmt.Errorf("expected %d got %d", expect, got%mod)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseE(rng)
+		exp := expectedE(tc)
+		if err := runCaseE(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d m=%d b0=%d\n", i+1, err, tc.n, tc.m, tc.b0)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1967/verifierE2.go
+++ b/1000-1999/1900-1999/1960-1969/1967/verifierE2.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+type TestCaseE struct {
+	n  int
+	m  int
+	b0 int
+}
+
+func genCaseE(rng *rand.Rand) TestCaseE {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	b0 := rng.Intn(3)
+	return TestCaseE{n: n, m: m, b0: b0}
+}
+
+func possible(a []int, b0 int) bool {
+	cur := map[int]struct{}{b0: {}}
+	for _, x := range a {
+		nxt := map[int]struct{}{}
+		for v := range cur {
+			if v+1 != x {
+				nxt[v+1] = struct{}{}
+			}
+			if v-1 >= 0 && v-1 != x {
+				nxt[v-1] = struct{}{}
+			}
+		}
+		if len(nxt) == 0 {
+			return false
+		}
+		cur = nxt
+	}
+	return true
+}
+
+func expectedE(tc TestCaseE) int64 {
+	arr := make([]int, tc.n)
+	var ans int64
+	var dfs func(pos int)
+	dfs = func(pos int) {
+		if pos == tc.n {
+			if possible(arr, tc.b0) {
+				ans++
+			}
+			return
+		}
+		for v := 1; v <= tc.m; v++ {
+			arr[pos] = v
+			dfs(pos + 1)
+		}
+	}
+	dfs(0)
+	return ans % mod
+}
+
+func runCaseE(bin string, tc TestCaseE, expect int64) error {
+	input := fmt.Sprintf("1\n%d %d %d\n", tc.n, tc.m, tc.b0)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got%mod != expect {
+		return fmt.Errorf("expected %d got %d", expect, got%mod)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseE(rng)
+		exp := expectedE(tc)
+		if err := runCaseE(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d m=%d b0=%d\n", i+1, err, tc.n, tc.m, tc.b0)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1960-1969/1967/verifierF.go
+++ b/1000-1999/1900-1999/1960-1969/1967/verifierF.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const infVal = int(1e9)
+
+type QuerySet struct {
+	q  int
+	xs []int
+}
+
+type TestCaseF struct {
+	n       int
+	p       []int
+	queries []QuerySet
+}
+
+func genCaseF(rng *rand.Rand) TestCaseF {
+	n := rng.Intn(5) + 1
+	p := rng.Perm(n)
+	for i := range p {
+		p[i]++
+	}
+	qs := make([]QuerySet, n)
+	for q := 1; q <= n; q++ {
+		k := rng.Intn(3)
+		xs := make([]int, k)
+		for i := range xs {
+			xs[i] = rng.Intn(q) + 1
+		}
+		qs[q-1] = QuerySet{q: q, xs: xs}
+	}
+	return TestCaseF{n: n, p: p, queries: qs}
+}
+
+func expectedF(tc TestCaseF) []int {
+	ans := []int{}
+	seq := make([]int, 0, tc.n)
+	for _, qs := range tc.queries {
+		q := qs.q
+		xs := qs.xs
+		seq = seq[:0]
+		for _, v := range tc.p {
+			if v <= q {
+				seq = append(seq, v)
+			}
+		}
+		m := len(seq)
+		pre := make([]int, m)
+		stack := make([]int, 0, m)
+		for i := 0; i < m; i++ {
+			for len(stack) > 0 && seq[stack[len(stack)-1]] <= seq[i] {
+				stack = stack[:len(stack)-1]
+			}
+			if len(stack) == 0 {
+				pre[i] = -infVal
+			} else {
+				pre[i] = stack[len(stack)-1]
+			}
+			stack = append(stack, i)
+		}
+		nxt := make([]int, m)
+		stack = stack[:0]
+		for i := m - 1; i >= 0; i-- {
+			for len(stack) > 0 && seq[stack[len(stack)-1]] <= seq[i] {
+				stack = stack[:len(stack)-1]
+			}
+			if len(stack) == 0 {
+				nxt[i] = infVal
+			} else {
+				nxt[i] = stack[len(stack)-1]
+			}
+			stack = append(stack, i)
+		}
+		diff := make([]int, m)
+		for i := 0; i < m; i++ {
+			if pre[i] <= -infVal/2 || nxt[i] >= infVal/2 {
+				diff[i] = infVal
+			} else {
+				diff[i] = nxt[i] - pre[i]
+			}
+		}
+		for _, x := range xs {
+			sum := 0
+			for i := 0; i < m; i++ {
+				d := diff[i]
+				if d > x {
+					sum += x
+				} else {
+					sum += d
+				}
+			}
+			ans = append(ans, sum)
+		}
+	}
+	return ans
+}
+
+func runCaseF(bin string, tc TestCaseF, expect []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", tc.n)
+	for i, v := range tc.p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, qs := range tc.queries {
+		fmt.Fprintf(&sb, "%d\n", len(qs.xs))
+		for i, x := range qs.xs {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", x)
+		}
+		sb.WriteByte('\n')
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outs := strings.Fields(strings.TrimSpace(out.String()))
+	if len(outs) != len(expect) {
+		return fmt.Errorf("expected %d numbers got %d", len(expect), len(outs))
+	}
+	for i, s := range outs {
+		var v int
+		fmt.Sscan(s, &v)
+		if v != expect[i] {
+			return fmt.Errorf("index %d expected %d got %d", i, expect[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseF(rng)
+		exp := expectedF(tc)
+		if err := runCaseF(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d p=%v queries=%v\n", i+1, err, tc.n, tc.p, tc.queries)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1967
- each verifier generates 100 random tests and checks a provided binary
- includes simple reference implementations or naive logic for expected answers

## Testing
- `gofmt -w verifierA.go verifierB1.go verifierB2.go verifierC.go verifierD.go verifierE1.go verifierE2.go verifierF.go`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68879481fc68832498eb0040cfd765bd