### PR TITLE
Add Go verifiers for contest 1972

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1972/verifierA.go
+++ b/1000-1999/1900-1999/1970-1979/1972/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "io"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+// expectedOps computes the answer for problem A
+func expectedOps(a, b []int) int {
+    j := 0
+    ops := 0
+    n := len(a)
+    for i := 0; i < n; i++ {
+        if j < n && a[j] <= b[i] {
+            j++
+        } else {
+            ops++
+        }
+    }
+    return ops
+}
+
+func runTest(binary string, n int, a, b []int) error {
+    var input strings.Builder
+    input.WriteString("1\n")
+    input.WriteString(fmt.Sprintf("%d\n", n))
+    for i, v := range a {
+        if i > 0 {
+            input.WriteByte(' ')
+        }
+        input.WriteString(fmt.Sprintf("%d", v))
+    }
+    input.WriteByte('\n')
+    for i, v := range b {
+        if i > 0 {
+            input.WriteByte(' ')
+        }
+        input.WriteString(fmt.Sprintf("%d", v))
+    }
+    input.WriteByte('\n')
+
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(input.String())
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = io.Discard
+
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("execution error: %v", err)
+    }
+    result := strings.TrimSpace(out.String())
+    expected := fmt.Sprintf("%d", expectedOps(a, b))
+    if result != expected {
+        return fmt.Errorf("expected %s, got %s", expected, result)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("Usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    binary := os.Args[1]
+    rand.Seed(time.Now().UnixNano())
+    const tests = 100
+    for t := 0; t < tests; t++ {
+        n := rand.Intn(100) + 1
+        a := make([]int, n)
+        b := make([]int, n)
+        cur := rand.Intn(1000) + 1
+        for i := 0; i < n; i++ {
+            cur += rand.Intn(50) + 1
+            if cur > 1_000_000_000 {
+                cur = 1_000_000_000
+            }
+            a[i] = cur
+        }
+        cur = a[0] + rand.Intn(50)
+        if cur > 1_000_000_000 {
+            cur = 1_000_000_000
+        }
+        for i := 0; i < n; i++ {
+            if cur < a[i] {
+                cur = a[i]
+            }
+            cur += rand.Intn(50)
+            if cur > 1_000_000_000 {
+                cur = 1_000_000_000
+            }
+            b[i] = cur
+        }
+        if err := runTest(binary, n, a, b); err != nil {
+            fmt.Printf("Test %d failed: %v\n", t+1, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed\n", tests)
+}
+

--- a/1000-1999/1900-1999/1970-1979/1972/verifierB.go
+++ b/1000-1999/1900-1999/1970-1979/1972/verifierB.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "io"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+// expectedResult returns the expected answer for problem B
+func expectedResult(s string) string {
+    cnt := 0
+    for _, ch := range s {
+        if ch == 'U' {
+            cnt++
+        }
+    }
+    if cnt%2 == 1 {
+        return "YES"
+    }
+    return "NO"
+}
+
+func runTest(binary string, n int, s string) error {
+    var input strings.Builder
+    input.WriteString("1\n")
+    input.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+
+    cmd := exec.Command(binary)
+    cmd.Stdin = strings.NewReader(input.String())
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = io.Discard
+
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("execution error: %v", err)
+    }
+    result := strings.TrimSpace(out.String())
+    expected := expectedResult(s)
+    if !strings.EqualFold(result, expected) {
+        return fmt.Errorf("expected %s, got %s", expected, result)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("Usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    binary := os.Args[1]
+    rand.Seed(time.Now().UnixNano())
+    const tests = 100
+    for t := 0; t < tests; t++ {
+        n := rand.Intn(100) + 1
+        var sb strings.Builder
+        for i := 0; i < n; i++ {
+            if rand.Intn(2) == 0 {
+                sb.WriteByte('U')
+            } else {
+                sb.WriteByte('D')
+            }
+        }
+        s := sb.String()
+        if err := runTest(binary, n, s); err != nil {
+            fmt.Printf("Test %d failed: %v\n", t+1, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed\n", tests)
+}
+


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 1972
- verifiers run a binary on 100 random tests and check outputs

## Testing
- `go run verifierA.go ./1972A_bin`
- `go run verifierB.go ./1972B_bin`


------
https://chatgpt.com/codex/tasks/task_e_688795e0233083248eee0527eab56ad6