### PR TITLE
Add large test suites for 1978 verifiers

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1978/verifierA.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierA.go
@@ -17,7 +17,7 @@ type testCaseA struct {
 
 func genTestsA() []testCaseA {
 	rand.Seed(42)
-	tests := make([]testCaseA, 20)
+	tests := make([]testCaseA, 100)
 	for i := range tests {
 		n := rand.Intn(9) + 2 // 2..10
 		arr := make([]int, n)

--- a/1000-1999/1900-1999/1970-1979/1978/verifierB.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierB.go
@@ -18,7 +18,7 @@ type testCaseB struct {
 
 func genTestsB() []testCaseB {
 	rand.Seed(43)
-	tests := make([]testCaseB, 20)
+	tests := make([]testCaseB, 100)
 	for i := range tests {
 		tests[i] = testCaseB{
 			n: int64(rand.Intn(50) + 1),

--- a/1000-1999/1900-1999/1970-1979/1978/verifierC.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierC.go
@@ -19,7 +19,7 @@ type testCaseC struct {
 
 func genTestsC() []testCaseC {
 	rand.Seed(44)
-	tests := make([]testCaseC, 20)
+	tests := make([]testCaseC, 100)
 	for i := range tests {
 		n := rand.Intn(7) + 2
 		var k int64 = int64(rand.Intn(n*n + 1))

--- a/1000-1999/1900-1999/1970-1979/1978/verifierD.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierD.go
@@ -23,7 +23,7 @@ type subset struct {
 
 func genTestsD() []testCaseD {
 	rand.Seed(45)
-	tests := make([]testCaseD, 20)
+	tests := make([]testCaseD, 100)
 	for i := range tests {
 		n := rand.Intn(5) + 2 // 2..6
 		a := make([]int, n)

--- a/1000-1999/1900-1999/1970-1979/1978/verifierE.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierE.go
@@ -21,7 +21,7 @@ type testCaseE struct {
 
 func genTestsE() []testCaseE {
 	rand.Seed(46)
-	tests := make([]testCaseE, 20)
+	tests := make([]testCaseE, 100)
 	for i := range tests {
 		n := rand.Intn(3) + 3 // 3..5
 		s := randomBinary(n)

--- a/1000-1999/1900-1999/1970-1979/1978/verifierF.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierF.go
@@ -18,7 +18,7 @@ type testCaseF struct {
 
 func genTestsF() []testCaseF {
 	rand.Seed(47)
-	tests := make([]testCaseF, 20)
+	tests := make([]testCaseF, 100)
 	for i := range tests {
 		n := rand.Intn(3) + 2 // 2..4
 		a := make([]int, n)


### PR DESCRIPTION
## Summary
- increase test case counts from 20 to 100 in the verifier programs for contest 1978

## Testing
- `go run verifierA.go ./1978A_bin` *(fails with runtime error as expected)*
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688797846850832496900896975d9ac1