### PR TITLE
Add verifiers for contest 1985

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1985/verifierA.go
+++ b/1000-1999/1900-1999/1980-1989/1985/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1985A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(a, b string) []byte {
+	return []byte(fmt.Sprintf("1\n%s %s\n", a, b))
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	b1 := make([]byte, 3)
+	b2 := make([]byte, 3)
+	for i := 0; i < 3; i++ {
+		b1[i] = letters[rng.Intn(26)]
+		b2[i] = letters[rng.Intn(26)]
+	}
+	return buildCase(string(b1), string(b2))
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(1))
+	tests := [][]byte{
+		buildCase("abc", "def"),
+		buildCase("aaa", "bbb"),
+		buildCase("zzz", "aaa"),
+	}
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1985/verifierB.go
+++ b/1000-1999/1900-1999/1980-1989/1985/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1985B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(n int) []byte {
+	return []byte(fmt.Sprintf("1\n%d\n", n))
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(99) + 2 // 2..100
+	return buildCase(n)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(2))
+	tests := [][]byte{buildCase(2), buildCase(3), buildCase(10)}
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1985/verifierC.go
+++ b/1000-1999/1900-1999/1980-1989/1985/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1985C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(arr []int64) []byte {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(10) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = rng.Int63n(20)
+	}
+	return buildCase(arr)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(3))
+	tests := [][]byte{
+		buildCase([]int64{0}),
+		buildCase([]int64{1, 1}),
+		buildCase([]int64{1, 2, 3, 6}),
+	}
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1985/verifierD.go
+++ b/1000-1999/1900-1999/1980-1989/1985/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1985D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(grid []string) []byte {
+	n := len(grid)
+	m := len(grid[0])
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, row := range grid {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = '.'
+			} else {
+				b[j] = '#'
+			}
+		}
+		grid[i] = string(b)
+	}
+	return buildCase(grid)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(4))
+	tests := [][]byte{
+		buildCase([]string{"#"}),
+		buildCase([]string{".", "#"}),
+		buildCase([]string{"..", "##"}),
+	}
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1985/verifierE.go
+++ b/1000-1999/1900-1999/1980-1989/1985/verifierE.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1985E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(x, y, z, k int64) []byte {
+	return []byte(fmt.Sprintf("1\n%d %d %d %d\n", x, y, z, k))
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	x := int64(rng.Intn(5) + 1)
+	y := int64(rng.Intn(5) + 1)
+	z := int64(rng.Intn(5) + 1)
+	k := int64(rng.Intn(int(x*y*z)) + 1)
+	return buildCase(x, y, z, k)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(5))
+	tests := [][]byte{
+		buildCase(1, 1, 1, 1),
+		buildCase(2, 2, 2, 4),
+		buildCase(3, 3, 3, 27),
+	}
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1985/verifierF.go
+++ b/1000-1999/1900-1999/1980-1989/1985/verifierF.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1985F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(h int64, a, c []int64) []byte {
+	n := len(a)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", h, n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range c {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(4) + 1
+	h := int64(rng.Intn(50) + 1)
+	a := make([]int64, n)
+	c := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(10) + 1)
+		c[i] = int64(rng.Intn(5) + 1)
+	}
+	return buildCase(h, a, c)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(6))
+	tests := [][]byte{
+		buildCase(1, []int64{1}, []int64{1}),
+		buildCase(10, []int64{5}, []int64{2}),
+		buildCase(20, []int64{3, 4}, []int64{1, 2}),
+	}
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1985/verifierG.go
+++ b/1000-1999/1900-1999/1980-1989/1985/verifierG.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1985G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(l, r, k int64) []byte {
+	return []byte(fmt.Sprintf("1\n%d %d %d\n", l, r, k))
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	l := int64(rng.Intn(5))
+	r := l + int64(rng.Intn(5)+1)
+	k := int64(rng.Intn(10) + 1)
+	return buildCase(l, r, k)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(7))
+	tests := [][]byte{
+		buildCase(0, 1, 1),
+		buildCase(1, 2, 2),
+		buildCase(1, 3, 3),
+	}
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1985/verifierH1.go
+++ b/1000-1999/1900-1999/1980-1989/1985/verifierH1.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refH1.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1985H1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(grid []string) []byte {
+	n := len(grid)
+	m := len(grid[0])
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, row := range grid {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = '.'
+			} else {
+				b[j] = '#'
+			}
+		}
+		grid[i] = string(b)
+	}
+	return buildCase(grid)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(8))
+	tests := [][]byte{
+		buildCase([]string{"#"}),
+		buildCase([]string{".", "#"}),
+		buildCase([]string{"..", "##"}),
+	}
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierH1.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1985/verifierH2.go
+++ b/1000-1999/1900-1999/1980-1989/1985/verifierH2.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runExe(path string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refH2.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1985H2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func buildCase(grid []string) []byte {
+	n := len(grid)
+	m := len(grid[0])
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, row := range grid {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func genRandomCase(rng *rand.Rand) []byte {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = '.'
+			} else {
+				b[j] = '#'
+			}
+		}
+		grid[i] = string(b)
+	}
+	return buildCase(grid)
+}
+
+func genTests() [][]byte {
+	rng := rand.New(rand.NewSource(9))
+	tests := [][]byte{
+		buildCase([]string{"#"}),
+		buildCase([]string{".", "#"}),
+		buildCase([]string{"..", "##"}),
+	}
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierH2.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n%s", i+1, err, exp)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(tc), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest 1985
- each verifier compiles a reference solution and runs ~100 randomized tests against a candidate binary

## Testing
- `go build 1000-1999/1900-1999/1980-1989/1985/verifierA.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/verifierB.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/verifierC.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/verifierD.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/verifierE.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/verifierF.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/verifierG.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/verifierH1.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/verifierH2.go`


------
https://chatgpt.com/codex/tasks/task_e_6887996ea6d883249fc4b0a3fa4876fc