### PR TITLE
Add README mention for contest 1989 verifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ go run verifierA.go ./mySolutionA
 go run verifierB.go ./mySolutionB
 ```
 
+Contest 1989 includes verifiers for all six problems with at least 100 test
+cases each. Run them by passing the path to your executable. For example:
+
+```bash
+cd 1000-1999/1900-1999/1980-1989/1989
+go run verifierA.go ./1989A
+```
+
 ## Running the local webserver
 
 The `webserver.go` program lets you browse contests and test solutions


### PR DESCRIPTION
## Summary
- document the existence of contest 1989 verifiers

## Testing
- `go build 1000-1999/1900-1999/1980-1989/1989/verifierA.go`
- `go build 1000-1999/1900-1999/1980-1989/1989/verifierB.go`
- `go build 1000-1999/1900-1999/1980-1989/1989/verifierC.go`
- `go build 1000-1999/1900-1999/1980-1989/1989/verifierD.go`
- `go build 1000-1999/1900-1999/1980-1989/1989/verifierE.go`
- `go build 1000-1999/1900-1999/1980-1989/1989/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68879a86f66883248fee6abb29e42e65