### PR TITLE
Change 1811 verifier message

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1811/verifierA.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierA.go
@@ -94,5 +94,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, "extra output")
 		os.Exit(1)
 	}
-	fmt.Println("Accepted")
+	fmt.Println("All tests passed")
 }

--- a/1000-1999/1800-1899/1810-1819/1811/verifierB.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierB.go
@@ -108,5 +108,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, "extra output")
 		os.Exit(1)
 	}
-	fmt.Println("Accepted")
+	fmt.Println("All tests passed")
 }

--- a/1000-1999/1800-1899/1810-1819/1811/verifierC.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierC.go
@@ -110,5 +110,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, "extra output")
 		os.Exit(1)
 	}
-	fmt.Println("Accepted")
+	fmt.Println("All tests passed")
 }

--- a/1000-1999/1800-1899/1810-1819/1811/verifierD.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierD.go
@@ -105,5 +105,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, "extra output")
 		os.Exit(1)
 	}
-	fmt.Println("Accepted")
+	fmt.Println("All tests passed")
 }

--- a/1000-1999/1800-1899/1810-1819/1811/verifierE.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierE.go
@@ -90,5 +90,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, "extra output")
 		os.Exit(1)
 	}
-	fmt.Println("Accepted")
+	fmt.Println("All tests passed")
 }

--- a/1000-1999/1800-1899/1810-1819/1811/verifierF.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierF.go
@@ -211,5 +211,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, "extra output")
 		os.Exit(1)
 	}
-	fmt.Println("Accepted")
+	fmt.Println("All tests passed")
 }

--- a/1000-1999/1800-1899/1810-1819/1811/verifierG1.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierG1.go
@@ -175,5 +175,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, "extra output")
 		os.Exit(1)
 	}
-	fmt.Println("Accepted")
+	fmt.Println("All tests passed")
 }

--- a/1000-1999/1800-1899/1810-1819/1811/verifierG2.go
+++ b/1000-1999/1800-1899/1810-1819/1811/verifierG2.go
@@ -165,5 +165,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, "extra output")
 		os.Exit(1)
 	}
-	fmt.Println("Accepted")
+	fmt.Println("All tests passed")
 }


### PR DESCRIPTION
## Summary
- tweak contest 1811 verifiers

## Testing
- `go vet 1000-1999/1800-1899/1810-1819/1811/verifier*.go`

------
https://chatgpt.com/codex/tasks/task_e_6889fa9fc0408324bdcb436b3d797c6f