### PR TITLE
Fix verifier for CF 1362B

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1362/verifierB.go
+++ b/1000-1999/1300-1399/1360-1369/1362/verifierB.go
@@ -75,9 +75,12 @@ func main() {
 	var input strings.Builder
 	fmt.Fprintln(&input, len(tests))
 	for _, tc := range tests {
-		fmt.Fprint(&input, len(tc.arr))
-		for _, v := range tc.arr {
-			fmt.Fprintf(&input, " %d", v)
+		fmt.Fprintln(&input, len(tc.arr))
+		for i, v := range tc.arr {
+			if i > 0 {
+				fmt.Fprint(&input, " ")
+			}
+			fmt.Fprint(&input, v)
 		}
 		fmt.Fprintln(&input)
 	}


### PR DESCRIPTION
## Summary
- correct verifierB to print each array on a new line as in the problem statement

## Testing
- `go build -o sol2 1362B.go`
- `go run verifierB.go ./sol2`

------
https://chatgpt.com/codex/tasks/task_e_688a0127b8548324b67d3f18639eaa33