### PR TITLE
Fix 1368C verifier to ignore order of cells

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1368/verifierC.go
+++ b/1000-1999/1300-1399/1360-1369/1368/verifierC.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -27,6 +28,38 @@ func genTest() []byte {
 	return []byte(fmt.Sprintf("%d\n", n))
 }
 
+type point struct{ x, y int }
+
+func parseOutput(out string) (int, map[point]int, error) {
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) == 0 {
+		return 0, nil, fmt.Errorf("empty output")
+	}
+	k, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, nil, err
+	}
+	if (len(fields)-1)%2 != 0 {
+		return 0, nil, fmt.Errorf("incomplete coordinate pair")
+	}
+	cnt := (len(fields) - 1) / 2
+	pts := make(map[point]int, cnt)
+	idx := 1
+	for i := 0; i < cnt; i++ {
+		x, err1 := strconv.Atoi(fields[idx])
+		y, err2 := strconv.Atoi(fields[idx+1])
+		if err1 != nil || err2 != nil {
+			return 0, nil, fmt.Errorf("invalid integer")
+		}
+		pts[point{x, y}]++
+		idx += 2
+	}
+	if k != cnt {
+		return 0, nil, fmt.Errorf("declared count %d but found %d", k, cnt)
+	}
+	return k, pts, nil
+}
+
 func main() {
 	var cand string
 	if len(os.Args) == 2 {
@@ -46,23 +79,53 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 	for i := 0; i < 100; i++ {
 		input := genTest()
-		want, err := runCmd(ref, input)
+		wantRaw, err := runCmd(ref, input)
 		if err != nil {
 			fmt.Println("reference failed:", err)
 			os.Exit(1)
 		}
-		got, err := runCmd(cand, input)
+		gotRaw, err := runCmd(cand, input)
 		if err != nil {
 			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
 			fmt.Println("input:\n", string(input))
 			os.Exit(1)
 		}
-		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+
+		wantCount, wantPts, err := parseOutput(wantRaw)
+		if err != nil {
+			fmt.Printf("reference output parse error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		gotCount, gotPts, err := parseOutput(gotRaw)
+		if err != nil {
+			fmt.Printf("candidate output parse error on test %d: %v\n", i+1, err)
+			fmt.Println("output:\n", gotRaw)
+			os.Exit(1)
+		}
+		if wantCount != gotCount || len(wantPts) != len(gotPts) {
 			fmt.Printf("wrong answer on test %d\n", i+1)
 			fmt.Println("input:\n", string(input))
-			fmt.Println("expected:\n", want)
-			fmt.Println("got:\n", got)
+			fmt.Println("expected:\n", wantRaw)
+			fmt.Println("got:\n", gotRaw)
 			os.Exit(1)
+		}
+		for p := range wantPts {
+			if gotPts[p] == 0 {
+				fmt.Printf("wrong answer on test %d\n", i+1)
+				fmt.Println("input:\n", string(input))
+				fmt.Println("expected:\n", wantRaw)
+				fmt.Println("got:\n", gotRaw)
+				os.Exit(1)
+			}
+		}
+		for p := range gotPts {
+			if wantPts[p] == 0 {
+				fmt.Printf("wrong answer on test %d\n", i+1)
+				fmt.Println("input:\n", string(input))
+				fmt.Println("expected:\n", wantRaw)
+				fmt.Println("got:\n", gotRaw)
+				os.Exit(1)
+			}
 		}
 	}
 	fmt.Println("All tests passed.")


### PR DESCRIPTION
## Summary
- update `verifierC.go` for problem 1368C
- parse program output and compare sets of cells instead of raw text

## Testing
- `go build 1000-1999/1300-1399/1360-1369/1368/verifierC.go`

------
https://chatgpt.com/codex/tasks/task_e_688a034f3db08324b71d03eb8257bbca