### PR TITLE
Fix 1353E verifier reference path

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1353/verifierE.go
+++ b/1000-1999/1300-1399/1350-1359/1353/verifierE.go
@@ -29,7 +29,7 @@ func runExe(path, input string) (string, error) {
 }
 
 func buildRef() (string, error) {
-	ref := "oracleE.bin"
+	ref := "./oracleE.bin"
 	cmd := exec.Command("go", "build", "-o", ref, "1353E.go")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))


### PR DESCRIPTION
## Summary
- fix reference executable path in `1353E` verifier

## Testing
- `go run verifierE.go ./cand.bin`

------
https://chatgpt.com/codex/tasks/task_e_688a0721bfc48324905415c669752a75