### PR TITLE
Fix prompt to say correct solution

### DIFF
--- a/webserver.go
+++ b/webserver.go
@@ -696,7 +696,7 @@ func submissionFixPromptHandler(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	prompt := fmt.Sprintf("For problem %s%s this is a correction solution , but verifier ends with %s can you fix the verifier ? %s", contestID, letter, stderr, code)
+	prompt := fmt.Sprintf("For problem %s%s this is a correct solution, but verifier ends with %s can you fix the verifier? %s", contestID, letter, stderr, code)
 	textTmpl.Execute(w, prompt)
 }
 
@@ -738,7 +738,7 @@ func evaluationFixPromptHandler(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	prompt := fmt.Sprintf("For problem %s%s this is a correction solution , but verifier ends with %s can you fix the verifier ? %s", contestID, letter, stderr, code)
+	prompt := fmt.Sprintf("For problem %s%s this is a correct solution, but verifier ends with %s can you fix the verifier? %s", contestID, letter, stderr, code)
 	textTmpl.Execute(w, prompt)
 }
 


### PR DESCRIPTION
## Summary
- fix typo in generated fix prompt replacing 'correction solution' with 'correct solution'

## Testing
- `go test` *(fails: cannot find main module)*
- `GO111MODULE=off go test` *(fails: cannot find package "github.com/go-sql-driver/mysql" in any path)*

------
https://chatgpt.com/codex/tasks/task_e_688af39ac1308324804a932e1147530d