### PR TITLE
Fix verifierA spacing in CF303A

### DIFF
--- a/0-999/300-399/300-309/303/verifierA.go
+++ b/0-999/300-399/300-309/303/verifierA.go
@@ -9,6 +9,14 @@ import (
 	"strings"
 )
 
+func normalize(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
 func runRef(input string) (string, error) {
 	cmd := exec.Command("go", "run", "303A.go")
 	cmd.Stdin = strings.NewReader(input)
@@ -16,7 +24,7 @@ func runRef(input string) (string, error) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	err := cmd.Run()
-	return strings.TrimSpace(out.String()), err
+	return normalize(out.String()), err
 }
 
 func runBin(bin string, input string) (string, error) {
@@ -31,7 +39,7 @@ func runBin(bin string, input string) (string, error) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	err := cmd.Run()
-	return strings.TrimSpace(out.String()), err
+	return normalize(out.String()), err
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- Normalize whitespace per line in 303A verifier to avoid mismatches

## Testing
- `go build -o verifyA verifierA.go`
- `./verifyA 303A.go`

------
https://chatgpt.com/codex/tasks/task_e_688af3a5996c83249d169d3a311f30c9