### PR TITLE
Fix 555A verifier case generator

### DIFF
--- a/0-999/500-599/550-559/555/verifierA.go
+++ b/0-999/500-599/550-559/555/verifierA.go
@@ -55,9 +55,16 @@ func genCases() []Case {
 		for i := 0; i < k; i++ {
 			remain := n - pos
 			groupsLeft := k - i
-			m := 1
-			if remain-groupsLeft > 0 {
-				m += rng.Intn(remain - groupsLeft + 1)
+			var m int
+			if i == k-1 {
+				// ensure the last chain consumes all remaining elements
+				m = remain
+			} else {
+				m = 1
+				extra := remain - groupsLeft
+				if extra > 0 {
+					m += rng.Intn(extra + 1)
+				}
 			}
 			chain := make([]int, m)
 			for j := 0; j < m; j++ {


### PR DESCRIPTION
## Summary
- fix 555A verifier to allocate all remaining dolls to last chain

## Testing
- `go build -o verifier verifierA.go && ./verifier ./555A.go | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688af4a70cf48324ba3826c4d7369177