### PR TITLE
fix: ensure even n in 1515D verifier

### DIFF
--- a/1000-1999/1500-1599/1510-1519/1515/verifierD.go
+++ b/1000-1999/1500-1599/1510-1519/1515/verifierD.go
@@ -44,7 +44,7 @@ func genCase(rng *rand.Rand) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%d\n", t))
 	for i := 0; i < t; i++ {
-		n := rng.Intn(12) + 2
+		n := rng.Intn(6)*2 + 2 // ensure n is even
 		l := rng.Intn(n + 1)
 		r := n - l
 		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, l, r))


### PR DESCRIPTION
## Summary
- enforce even `n` in the random case generator for the 1515D verifier

## Testing
- `cd 1000-1999/1500-1599/1510-1519/1515 && go build -o verifierD verifierD.go && ./verifierD 1515D.go`


------
https://chatgpt.com/codex/tasks/task_e_688af6ffdc6c8324887cd7f444b47d26