### PR TITLE
Log PATH variable at server startup

### DIFF
--- a/webserver.go
+++ b/webserver.go
@@ -460,6 +460,14 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 	indexTmpl.Execute(w, list)
 }
 
+func pathHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/path" {
+		http.NotFound(w, r)
+		return
+	}
+	fmt.Fprintln(w, os.Getenv("PATH"))
+}
+
 func contestDir(id string) (string, error) {
 	n, err := strconv.Atoi(id)
 	if err != nil {
@@ -765,6 +773,7 @@ func evaluationContentHandler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	var err error
+	fmt.Println("PATH:", os.Getenv("PATH"))
 	contests, err = scanContests(".")
 	if err != nil {
 		panic(err)
@@ -795,6 +804,7 @@ func main() {
 		panic(err)
 	}
 	http.HandleFunc("/", rootHandler)
+	http.HandleFunc("/path", pathHandler)
 	http.HandleFunc("/addproblem", addProblemHandler)
 	http.HandleFunc("/contest/", func(w http.ResponseWriter, r *http.Request) {
 		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/contest/"), "/")


### PR DESCRIPTION
## Summary
- Print the PATH environment variable when starting the web server
- Add `/path` route to display current `PATH`

## Testing
- `go build webserver.go` *(fails: no required module provides package github.com/go-sql-driver/mysql)*

------
https://chatgpt.com/codex/tasks/task_e_688b03a90d9c83249bee645d1f8bc04e