### PR TITLE
Fix verifier for 1725H

### DIFF
--- a/1000-1999/1700-1799/1720-1729/1725/verifierH.go
+++ b/1000-1999/1700-1799/1720-1729/1725/verifierH.go
@@ -49,7 +49,7 @@ func genCases() []Case {
 	preset := []struct {
 		n    int
 		vals []int
-	}{{1, []int{0}}, {2, []int{1, 2}}}
+	}{{2, []int{1, 2}}, {4, []int{1, 2, 3, 4}}}
 	for _, p := range preset {
 		var sb strings.Builder
 		sb.WriteString(fmt.Sprintf("%d\n", p.n))
@@ -63,14 +63,14 @@ func genCases() []Case {
 		cases = append(cases, Case{sb.String()})
 	}
 	for len(cases) < 100 {
-		n := rng.Intn(6) + 1
+		n := rng.Intn(3)*2 + 2
 		var sb strings.Builder
 		sb.WriteString(fmt.Sprintf("%d\n", n))
 		for i := 0; i < n; i++ {
 			if i > 0 {
 				sb.WriteByte(' ')
 			}
-			sb.WriteString(fmt.Sprintf("%d", rng.Intn(10)))
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(10)+1))
 		}
 		sb.WriteByte('\n')
 		cases = append(cases, Case{sb.String()})


### PR DESCRIPTION
## Summary
- ensure 1725H verifier only generates even-numbered test cases with positive values

## Testing
- `gofmt -w 1000-1999/1700-1799/1720-1729/1725/verifierH.go`
- `go build -o /tmp/verifierH 1000-1999/1700-1799/1720-1729/1725/verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_688b146cd0988324adac4af4e1c6131c