### PR TITLE
Fix oracle path in 1183B verifier

### DIFF
--- a/1000-1999/1100-1199/1180-1189/1183/verifierB.go
+++ b/1000-1999/1100-1199/1180-1189/1183/verifierB.go
@@ -12,7 +12,7 @@ import (
 )
 
 func buildOracle() (string, error) {
-	oracle := "oracleB"
+	oracle := "./oracleB"
 	cmd := exec.Command("go", "build", "-o", oracle, "1183B.go")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)


### PR DESCRIPTION
## Summary
- ensure verifier executes oracle by using `./oracleB` path when building

## Testing
- `go build -o sol 1183B.go && go run verifierB.go ./sol`

------
https://chatgpt.com/codex/tasks/task_e_688c41c17edc8324b48283366729aedd