### PR TITLE
Fix 1580A oracle import

### DIFF
--- a/1000-1999/1500-1599/1580-1589/1580/1580A.go
+++ b/1000-1999/1500-1599/1580-1589/1580/1580A.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-	"strings"
+        "bufio"
+        "fmt"
+        "os"
 )
 
 func solveCase(grid [][]byte, n, m int) int32 {


### PR DESCRIPTION
## Summary
- remove unused strings import from 1580A reference solution

## Testing
- `go run 1000-1999/1500-1599/1580-1589/1580/1580A.go << 'EOF'
1
8 7
1010010
0001101
0001001
0111011
0000001
0011001
0000101
1010010
EOF
`
- `go build -o /tmp/solver.bin 1000-1999/1500-1599/1580-1589/1580/1580A.go`
- `go run 1000-1999/1500-1599/1580-1589/1580/verifierA.go /tmp/solver.bin`


------
https://chatgpt.com/codex/tasks/task_e_688c5abeb6e88324839db92830081ef6