### PR TITLE
Fix newline handling in 435C verifier

### DIFF
--- a/0-999/400-499/430-439/435/verifierC.go
+++ b/0-999/400-499/430-439/435/verifierC.go
@@ -103,7 +103,11 @@ func main() {
 		for i := 0; i < n; i++ {
 			arr[i], _ = strconv.Atoi(parts[1+i])
 		}
-		expect := expectedCardio(arr)
+		// Solutions may or may not print a trailing newline after the
+		// last row. Trim any trailing newlines from both the expected
+		// and actual output before comparison to avoid false
+		// mismatches.
+		expect := strings.TrimRight(expectedCardio(arr), "\n")
 		input := fmt.Sprintf("%d\n", n)
 		for i, a := range arr {
 			if i > 0 {
@@ -123,7 +127,7 @@ func main() {
 			fmt.Printf("test %d: runtime error: %v\nstderr: %s\n", idx, err, stderr.String())
 			os.Exit(1)
 		}
-		got := out.String()
+		got := strings.TrimRight(out.String(), "\n")
 		if got != expect {
 			fmt.Printf("test %d failed:\nexpected:\n%s\ngot:\n%s\n", idx, expect, got)
 			os.Exit(1)


### PR DESCRIPTION
## Summary
- prevent false mismatches by trimming trailing newlines from both expected and actual outputs in 435C verifier

## Testing
- `rustc /tmp/435C.rs -O -o /tmp/435C`
- `(cd 0-999/400-499/430-439/435 && go run verifierC.go /tmp/435C)`

------
https://chatgpt.com/codex/tasks/task_e_688c5c23de8c8324b4c7a00c0d7e3f1d