### PR TITLE
Add Go verifiers for Codeforces 1991A–I

### DIFF
--- a/1000-1999/1900-1999/1990-1999/1991/verifierA.go
+++ b/1000-1999/1900-1999/1990-1999/1991/verifierA.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(input string) string {
+	// compute expected output for input of problem A
+	lines := strings.Split(strings.TrimSpace(input), "\n")
+	var t int
+	fmt.Sscan(lines[0], &t)
+	idx := 1
+	out := make([]string, t)
+	for caseNum := 0; caseNum < t; caseNum++ {
+		var n int
+		fmt.Sscan(lines[idx], &n)
+		idx++
+		arrStr := strings.Fields(lines[idx])
+		idx++
+		mx := int64(0)
+		for j := 0; j < n; j++ {
+			var v int64
+			fmt.Sscan(arrStr[j], &v)
+			if j%2 == 0 && v > mx {
+				mx = v
+			}
+		}
+		out[caseNum] = fmt.Sprintf("%d", mx)
+	}
+	return strings.Join(out, "\n") + "\n"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	t := 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	n := rng.Intn(49)*2 + 1 // odd up to 99
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Int63n(100) + 1
+	}
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	return input, expected(input)
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp = strings.TrimSpace(exp)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	// Predefined edge cases
+	cases := []string{
+		"1\n1\n6\n",
+		"1\n3\n1 3 2\n",
+		"1\n5\n4 7 4 2 9\n",
+	}
+	exps := []string{
+		expected(cases[0]),
+		expected(cases[1]),
+		expected(cases[2]),
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		in, exp := genCase(rng)
+		cases = append(cases, in)
+		exps = append(exps, exp)
+	}
+
+	for i := range cases {
+		if err := runCase(bin, cases[i], exps[i]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, cases[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1990-1999/1991/verifierB.go
+++ b/1000-1999/1900-1999/1990-1999/1991/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "time"
+)
+
+func buildOracle() (string, error) {
+    dir, err := os.Getwd()
+    if err != nil {
+        return "", err
+    }
+    oracle := filepath.Join(dir, "oracleB")
+    cmd := exec.Command("go", "build", "-o", oracle, "1991B.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+    }
+    return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+    n := rng.Intn(8) + 2
+    var sb strings.Builder
+    sb.WriteString("1\n")
+    sb.WriteString(fmt.Sprintf("%d\n", n))
+    for i := 1; i < n; i++ {
+        if i > 1 {
+            sb.WriteByte(' ')
+        }
+        sb.WriteString(fmt.Sprintf("%d", rng.Intn(1024)))
+    }
+    sb.WriteByte('\n')
+    return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errOut bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errOut
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("%v\n%s", err, errOut.String())
+    }
+    return out.String(), nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    oracle, err := buildOracle()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(oracle)
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    cases := make([]string, 0, 100)
+    for len(cases) < 100 {
+        cases = append(cases, genCase(rng))
+    }
+    for i, in := range cases {
+        exp, err := run(oracle, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        got, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+            fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", i+1, exp, got, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1900-1999/1990-1999/1991/verifierC.go
+++ b/1000-1999/1900-1999/1990-1999/1991/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "time"
+)
+
+func buildOracle() (string, error) {
+    dir, err := os.Getwd()
+    if err != nil {
+        return "", err
+    }
+    oracle := filepath.Join(dir, "oracleC")
+    cmd := exec.Command("go", "build", "-o", oracle, "1991C.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+    }
+    return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+    n := rng.Intn(10) + 1
+    var sb strings.Builder
+    sb.WriteString("1\n")
+    sb.WriteString(fmt.Sprintf("%d\n", n))
+    for i := 0; i < n; i++ {
+        if i > 0 {
+            sb.WriteByte(' ')
+        }
+        sb.WriteString(fmt.Sprintf("%d", rng.Intn(100)+1))
+    }
+    sb.WriteByte('\n')
+    return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errOut bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errOut
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("%v\n%s", err, errOut.String())
+    }
+    return out.String(), nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    oracle, err := buildOracle()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(oracle)
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    cases := make([]string, 0, 100)
+    for len(cases) < 100 {
+        cases = append(cases, genCase(rng))
+    }
+    for i, in := range cases {
+        exp, err := run(oracle, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        got, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+            fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", i+1, exp, got, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1900-1999/1990-1999/1991/verifierD.go
+++ b/1000-1999/1900-1999/1990-1999/1991/verifierD.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "time"
+)
+
+func buildOracle() (string, error) {
+    dir, err := os.Getwd()
+    if err != nil {
+        return "", err
+    }
+    oracle := filepath.Join(dir, "oracleD")
+    cmd := exec.Command("go", "build", "-o", oracle, "1991D.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+    }
+    return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+    n := rng.Intn(10) + 1
+    return fmt.Sprintf("1\n%d\n", n)
+}
+
+func run(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errOut bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errOut
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("%v\n%s", err, errOut.String())
+    }
+    return out.String(), nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    oracle, err := buildOracle()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(oracle)
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    cases := make([]string, 0, 100)
+    for len(cases) < 100 {
+        cases = append(cases, genCase(rng))
+    }
+    for i, in := range cases {
+        exp, err := run(oracle, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        got, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+            fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", i+1, exp, got, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1900-1999/1990-1999/1991/verifierE.go
+++ b/1000-1999/1900-1999/1990-1999/1991/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "time"
+)
+
+func buildOracle() (string, error) {
+    dir, err := os.Getwd()
+    if err != nil {
+        return "", err
+    }
+    oracle := filepath.Join(dir, "oracleE")
+    cmd := exec.Command("go", "build", "-o", oracle, "1991E.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+    }
+    return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+    n := rng.Intn(4) + 2
+    edges := make([][2]int, 0, n)
+    for i := 1; i < n; i++ {
+        edges = append(edges, [2]int{i, i + 1})
+    }
+    if n >= 3 && rng.Intn(2) == 0 {
+        edges = append(edges, [2]int{1, 3})
+    }
+    m := len(edges)
+    var sb strings.Builder
+    sb.WriteString("1\n")
+    sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+    for _, e := range edges {
+        sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+    }
+    for i := 0; i < n; i++ {
+        sb.WriteString(fmt.Sprintf("%d %d\n", rng.Intn(3)+1, rng.Intn(3)+1))
+    }
+    return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errOut bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errOut
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("%v\n%s", err, errOut.String())
+    }
+    return out.String(), nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    oracle, err := buildOracle()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(oracle)
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    cases := make([]string, 0, 100)
+    for len(cases) < 100 {
+        cases = append(cases, genCase(rng))
+    }
+    for i, in := range cases {
+        exp, err := run(oracle, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        got, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+            fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", i+1, exp, got, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1900-1999/1990-1999/1991/verifierF.go
+++ b/1000-1999/1900-1999/1990-1999/1991/verifierF.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "time"
+)
+
+func buildOracle() (string, error) {
+    dir, err := os.Getwd()
+    if err != nil {
+        return "", err
+    }
+    oracle := filepath.Join(dir, "oracleF")
+    cmd := exec.Command("go", "build", "-o", oracle, "1991F.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+    }
+    return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+    n := rng.Intn(5) + 2
+    q := rng.Intn(5) + 1
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+    for i := 0; i < n; i++ {
+        if i > 0 {
+            sb.WriteByte(' ')
+        }
+        sb.WriteString(fmt.Sprintf("%d", rng.Intn(30)+1))
+    }
+    sb.WriteByte('\n')
+    for i := 0; i < q; i++ {
+        x := rng.Intn(n) + 1
+        y := rng.Intn(n-x+1) + x
+        sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+    }
+    return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errOut bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errOut
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("%v\n%s", err, errOut.String())
+    }
+    return out.String(), nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    oracle, err := buildOracle()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(oracle)
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    cases := make([]string, 0, 100)
+    for len(cases) < 100 {
+        cases = append(cases, genCase(rng))
+    }
+    for i, in := range cases {
+        exp, err := run(oracle, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        got, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+            fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", i+1, exp, got, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1900-1999/1990-1999/1991/verifierG.go
+++ b/1000-1999/1900-1999/1990-1999/1991/verifierG.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "time"
+)
+
+func buildOracle() (string, error) {
+    dir, err := os.Getwd()
+    if err != nil {
+        return "", err
+    }
+    oracle := filepath.Join(dir, "oracleG")
+    cmd := exec.Command("go", "build", "-o", oracle, "1991G.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+    }
+    return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+    n := rng.Intn(4) + 1
+    m := rng.Intn(4) + 1
+    k := rng.Intn(min(n, m)) + 1
+    q := rng.Intn(5) + 1
+    var sb strings.Builder
+    sb.WriteString("1\n")
+    sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, k, q))
+    for i := 0; i < q; i++ {
+        if rng.Intn(2) == 0 {
+            sb.WriteByte('H')
+        } else {
+            sb.WriteByte('V')
+        }
+    }
+    sb.WriteByte('\n')
+    return sb.String()
+}
+
+func min(a, b int) int {
+    if a < b {
+        return a
+    }
+    return b
+}
+
+func run(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errOut bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errOut
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("%v\n%s", err, errOut.String())
+    }
+    return out.String(), nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierG.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    oracle, err := buildOracle()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(oracle)
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    cases := make([]string, 0, 100)
+    for len(cases) < 100 {
+        cases = append(cases, genCase(rng))
+    }
+    for i, in := range cases {
+        exp, err := run(oracle, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        got, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+            fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", i+1, exp, got, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1900-1999/1990-1999/1991/verifierH.go
+++ b/1000-1999/1900-1999/1990-1999/1991/verifierH.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "time"
+)
+
+func buildOracle() (string, error) {
+    dir, err := os.Getwd()
+    if err != nil {
+        return "", err
+    }
+    oracle := filepath.Join(dir, "oracleH")
+    cmd := exec.Command("go", "build", "-o", oracle, "1991H.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+    }
+    return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+    n := rng.Intn(8) + 2
+    var sb strings.Builder
+    sb.WriteString("1\n")
+    sb.WriteString(fmt.Sprintf("%d\n", n))
+    for i := 0; i < n; i++ {
+        if i > 0 {
+            sb.WriteByte(' ')
+        }
+        sb.WriteString(fmt.Sprintf("%d", rng.Intn(50)+1))
+    }
+    sb.WriteByte('\n')
+    return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errOut bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errOut
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("%v\n%s", err, errOut.String())
+    }
+    return out.String(), nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierH.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    oracle, err := buildOracle()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(oracle)
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    cases := make([]string, 0, 100)
+    for len(cases) < 100 {
+        cases = append(cases, genCase(rng))
+    }
+    for i, in := range cases {
+        exp, err := run(oracle, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        got, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+            fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", i+1, exp, got, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1900-1999/1990-1999/1991/verifierI.go
+++ b/1000-1999/1900-1999/1990-1999/1991/verifierI.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "time"
+)
+
+func buildOracle() (string, error) {
+    dir, err := os.Getwd()
+    if err != nil {
+        return "", err
+    }
+    oracle := filepath.Join(dir, "oracleI")
+    cmd := exec.Command("go", "build", "-o", oracle, "1991I.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+    }
+    return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+    n := rng.Intn(2) + 4
+    m := rng.Intn(2) + 4
+    moves := (n*m + 1) / 2
+    var sb strings.Builder
+    sb.WriteString("1\n")
+    sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+    for i := 0; i < moves; i++ {
+        sb.WriteString(fmt.Sprintf("%d %d\n", rng.Intn(n)+1, rng.Intn(m)+1))
+    }
+    return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var errOut bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &errOut
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("%v\n%s", err, errOut.String())
+    }
+    return out.String(), nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierI.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    oracle, err := buildOracle()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(oracle)
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    cases := make([]string, 0, 100)
+    for len(cases) < 100 {
+        cases = append(cases, genCase(rng))
+    }
+    for i, in := range cases {
+        exp, err := run(oracle, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        got, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "runtime error on case %d: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+            fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", i+1, exp, got, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+


### PR DESCRIPTION
## Summary
- Add Go-based verifiers for Codeforces 1991 problems B through I, each building the official solution as an oracle and running 100 randomized test cases

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go vet verifierF.go`
- `go vet verifierG.go`
- `go vet verifierH.go`
- `go vet verifierI.go`
- `go run verifierB.go ./1991B_bin`


------
https://chatgpt.com/codex/tasks/task_e_688df90c42048324ac09e0415d7646fc