### PR TITLE
fix: correct verifier for 1935B

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1935/verifierB.go
+++ b/1000-1999/1900-1999/1930-1939/1935/verifierB.go
@@ -89,21 +89,29 @@ func canSplit(tc TestCase) (bool, int) {
 	if m == tc.n {
 		return false, m
 	}
-	if m == 0 {
-		return true, m
-	}
-	freq := make([]int, m)
-	for _, v := range tc.arr {
-		if v < m {
-			freq[v]++
+
+	n := tc.n
+	// try all possible partitions using a bitmask over the n-1 gaps
+	for mask := 1; mask < (1 << (n - 1)); mask++ {
+		l := 0
+		ok := true
+		for i := 0; i < n-1; i++ {
+			if (mask>>i)&1 == 1 {
+				if mexRange(tc.arr, l, i) != m {
+					ok = false
+					break
+				}
+				l = i + 1
+			}
+		}
+		if !ok {
+			continue
+		}
+		if mexRange(tc.arr, l, n-1) == m {
+			return true, m
 		}
 	}
-	for _, c := range freq {
-		if c < 2 {
-			return false, m
-		}
-	}
-	return true, m
+	return false, m
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- fix 1935B verifier to brute-force test partitions so solutions returning -1 aren't misflagged

## Testing
- `go build -o verifierB verifierB.go`
- `./verifierB 1935B.go`


------
https://chatgpt.com/codex/tasks/task_e_68904e5e8ab883249bffa3cfe17669ea