### PR TITLE
fix: remove unused import in problem 1366D verifier

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1366/verifierD.go
+++ b/1000-1999/1300-1399/1360-1369/1366/verifierD.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"math"
 	"os"
 	"os/exec"
 	"strconv"


### PR DESCRIPTION
## Summary
- remove stray math import from 1366D verifier to fix build

## Testing
- `go build verifierD.go`

------
https://chatgpt.com/codex/tasks/task_e_68905246a62c8324ab81fc9cff187136