### PR TITLE
fix: remove unused strings import in 744B verifier

### DIFF
--- a/0-999/700-799/740-749/744/verifierB.go
+++ b/0-999/700-799/740-749/744/verifierB.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 )
 


### PR DESCRIPTION
## Summary
- fix compile error in 744B Go verifier by removing unused `strings` import

## Testing
- `go build -o /tmp/verifierB 0-999/700-799/740-749/744/verifierB.go`


------
https://chatgpt.com/codex/tasks/task_e_6890525a445883249c48a1ed5518a294