### PR TITLE
Increase evaluation iterations to 50

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -144,7 +144,7 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	estimatedRating := 800
-	for i := 0; i < 25; i++ {
+	for i := 0; i < 50; i++ {
 		actualRating := clampToNearest(estimatedRating, availableRatings)
 		fmt.Printf("Attempt %d: Targeting estimated %d (using actual rating %d)\n", i+1, estimatedRating, actualRating)
 		problem, verifierFile := getRandomProblem(db, actualRating)


### PR DESCRIPTION
## Summary
- update evaluation loop to iterate through 50 problems rather than 25

## Testing
- `GO111MODULE=off go vet eval.go`
- `GO111MODULE=off go build eval.go`


------
https://chatgpt.com/codex/tasks/task_e_6893219fe628832493c96ef30a58db66