### PR TITLE
Fix input parsing in 1862D verifier

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1862/verifierD.go
+++ b/1000-1999/1800-1899/1860-1869/1862/verifierD.go
@@ -63,8 +63,9 @@ func main() {
 	bin := os.Args[1]
 	cases := genCases()
 	for i, tc := range cases {
+		var t int
 		var n int64
-		fmt.Sscan(strings.TrimSpace(tc), &n)
+		fmt.Sscan(tc, &t, &n)
 		want := solveD(n)
 		got, err := runCase(bin, tc)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Correct the verifier for 1862D to parse both the test count and `n`

## Testing
- `go vet 1000-1999/1800-1899/1860-1869/1862/verifierD.go`
- `go build 1000-1999/1800-1899/1860-1869/1862/verifierD.go`
- `go build -o /tmp/1862D_bin 1000-1999/1800-1899/1860-1869/1862/1862D.go`
- `go run 1000-1999/1800-1899/1860-1869/1862/verifierD.go /tmp/1862D_bin`


------
https://chatgpt.com/codex/tasks/task_e_6894f0a683048324a59aef259abb4245