### PR TITLE
Allow tolerance in 453A verifier

### DIFF
--- a/0-999/400-499/450-459/453/verifierA.go
+++ b/0-999/400-499/450-459/453/verifierA.go
@@ -4,8 +4,10 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -40,6 +42,15 @@ func main() {
 			os.Exit(1)
 		}
 		got := strings.TrimSpace(string(out))
+		if e, err1 := strconv.ParseFloat(expect, 64); err1 == nil {
+			if g, err2 := strconv.ParseFloat(got, 64); err2 == nil {
+				if math.Abs(e-g) > 1e-6 {
+					fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+					os.Exit(1)
+				}
+				continue
+			}
+		}
 		if got != expect {
 			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
 			os.Exit(1)


### PR DESCRIPTION
## Summary
- parse expected and actual outputs as floats and accept results within 1e-6 tolerance

## Testing
- `go run 0-999/400-499/450-459/453/verifierA.go /tmp/453a`

------
https://chatgpt.com/codex/tasks/task_e_6894f1bfcd848324b85a35d014a83b02