### PR TITLE
Fix 1750D verifier handling of first element exceeding limit

### DIFF
--- a/1000-1999/1700-1799/1750-1759/1750/verifierD.go
+++ b/1000-1999/1700-1799/1750-1759/1750/verifierD.go
@@ -111,6 +111,10 @@ func solveD(r *bufio.Reader) string {
 		for i := 0; i < n; i++ {
 			fmt.Fscan(r, &a[i])
 		}
+		if a[0] > m {
+			out.WriteString("0\n")
+			continue
+		}
 		ans := int64(1)
 		ok := true
 		for i := 1; i < n && ok; i++ {


### PR DESCRIPTION
## Summary
- Ensure verifier for problem 1750D returns 0 when the first array element exceeds `m`.

## Testing
- `go build -o verifierD 1000-1999/1700-1799/1750-1759/1750/verifierD.go`
- `./verifierD 1000-1999/1700-1799/1750-1759/1750/temp_correct.go` *(passes 100 randomized tests)*

------
https://chatgpt.com/codex/tasks/task_e_6894f2528da483248c56c8a7ba20c0a0