### PR TITLE
Log compile output on failure

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -163,12 +163,14 @@ func main() {
 		attempt := 1
 		var tempBinAbs string
 		var verifierStdout, verifierStderr string
+		var buildErrMsg string
 		for attempt <= *maxAttempts {
 			fmt.Printf("Verification attempt %d of %d\n", attempt, *maxAttempts)
 			buildSuccess, buildErrMsg, builtBinAbs := buildSolution(code, lang)
 			tempBinAbs = builtBinAbs
 			if !buildSuccess {
 				if attempt == *maxAttempts {
+					verifierStderr = buildErrMsg
 					break
 				}
 				fixPrompt := fmt.Sprintf("The following %s code has compilation errors: %s\n\nFix the errors and output only the corrected code with no comments or explanation.", lang, buildErrMsg)

--- a/webserver.go
+++ b/webserver.go
@@ -340,6 +340,7 @@ func submitSolution(w http.ResponseWriter, r *http.Request, c *contestInfo, lett
 		output.WriteString("Compilation failed:\n")
 		output.WriteString(compileOut)
 		output.WriteString(err.Error())
+		stderrStr = compileOut + err.Error()
 	} else {
 		verifier := findVerifier(c.Path, letter)
 		if verifier != "" {


### PR DESCRIPTION
## Summary
- capture final build error for evaluations and store it in the `stderr` column
- persist compilation stderr for submissions when builds fail

## Testing
- `go build webserver.go` (fails: no required module provides package github.com/go-sql-driver/mysql)
- `go build eval.go` (fails: no required module provides package github.com/go-sql-driver/mysql)


------
https://chatgpt.com/codex/tasks/task_e_68957fd41aa88324809816dbe5d05e28