### PR TITLE
Remove unused buildErrMsg variable in eval.go

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -163,7 +163,6 @@ func main() {
 		attempt := 1
 		var tempBinAbs string
 		var verifierStdout, verifierStderr string
-		var buildErrMsg string
 		for attempt <= *maxAttempts {
 			fmt.Printf("Verification attempt %d of %d\n", attempt, *maxAttempts)
 			buildSuccess, buildErrMsg, builtBinAbs := buildSolution(code, lang)


### PR DESCRIPTION
## Summary
- eliminate unused `buildErrMsg` variable declared before verification loop in eval.go

## Testing
- `go build eval.go` *(fails: no required module provides package github.com/go-sql-driver/mysql)*

------
https://chatgpt.com/codex/tasks/task_e_689597da55e88324b4b07372c0d65b02