### PR TITLE
Allow multiple optimal outputs in 846C verifier

### DIFF
--- a/0-999/800-899/840-849/846/verifierC.go
+++ b/0-999/800-899/840-849/846/verifierC.go
@@ -8,7 +8,57 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 )
+
+func parseInput(input []byte) ([]int64, error) {
+	r := bytes.NewReader(input)
+	var n int
+	if _, err := fmt.Fscan(r, &n); err != nil {
+		return nil, err
+	}
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		if _, err := fmt.Fscan(r, &a[i]); err != nil {
+			return nil, err
+		}
+	}
+	return a, nil
+}
+
+func bestValue(a []int64) (int64, []int64) {
+	n := len(a)
+	p := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		p[i+1] = p[i] + a[i]
+	}
+	prefVal := make([]int64, n+1)
+	prefVal[0] = p[0]
+	for j := 1; j <= n; j++ {
+		if p[j] > prefVal[j-1] {
+			prefVal[j] = p[j]
+		} else {
+			prefVal[j] = prefVal[j-1]
+		}
+	}
+	suffVal := make([]int64, n+1)
+	suffVal[n] = p[n]
+	for j := n - 1; j >= 0; j-- {
+		if p[j] >= suffVal[j+1] {
+			suffVal[j] = p[j]
+		} else {
+			suffVal[j] = suffVal[j+1]
+		}
+	}
+	best := int64(-1 << 63)
+	for j := 0; j <= n; j++ {
+		cur := prefVal[j] - p[j] + suffVal[j]
+		if cur > best {
+			best = cur
+		}
+	}
+	return best, p
+}
 
 func runTests(dir, binary string) error {
 	files, err := filepath.Glob(filepath.Join(dir, "*.in"))
@@ -17,23 +67,32 @@ func runTests(dir, binary string) error {
 	}
 	sort.Strings(files)
 	for _, inFile := range files {
-		outFile := inFile[:len(inFile)-3] + ".out"
 		input, err := os.ReadFile(inFile)
 		if err != nil {
 			return err
 		}
-		expected, err := os.ReadFile(outFile)
+		a, err := parseInput(input)
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: %v", filepath.Base(inFile), err)
 		}
+		best, prefix := bestValue(a)
 		cmd := exec.Command(binary)
 		cmd.Stdin = bytes.NewReader(input)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("%s: %v", filepath.Base(inFile), err)
 		}
-		if string(out) != string(expected) {
-			return fmt.Errorf("%s: expected\n%sbut got\n%s", filepath.Base(inFile), expected, out)
+		var d0, d1, d2 int
+		if _, err := fmt.Fscan(strings.NewReader(string(out)), &d0, &d1, &d2); err != nil {
+			return fmt.Errorf("%s: could not parse output %q", filepath.Base(inFile), strings.TrimSpace(string(out)))
+		}
+		n := len(a)
+		if d0 < 0 || d0 > d1 || d1 > d2 || d2 > n {
+			return fmt.Errorf("%s: invalid indices %d %d %d", filepath.Base(inFile), d0, d1, d2)
+		}
+		val := prefix[d0] - prefix[d1] + prefix[d2]
+		if val != best {
+			return fmt.Errorf("%s: expected value %d but got %d", filepath.Base(inFile), best, val)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Improve 846C verifier to compute the optimal score from inputs and validate contestant indices rather than rely on fixed outputs.
- Accept any set of indices that achieves the optimal value, enabling multiple correct answers.

## Testing
- `go run 0-999/800-899/840-849/846/verifierC.go /tmp/846C_rs`


------
https://chatgpt.com/codex/tasks/task_e_6895ba18b10483249b0c3158404b0f94