### PR TITLE
Improve copy button on evaluation pages

### DIFF
--- a/webserver.go
+++ b/webserver.go
@@ -323,9 +323,17 @@ var textTmpl = template.Must(template.New("text").Parse(`
       .btn:hover { background:#243042; }
     </style>
     <script>
-      function copyAll(){
+      async function copyAll(){
         const t = document.getElementById("content").innerText;
-        navigator.clipboard.writeText(t);
+        try {
+          await navigator.clipboard.writeText(t);
+          const btn = document.getElementById("copyBtn");
+          const original = btn.innerText;
+          btn.innerText = "Copied!";
+          setTimeout(() => { btn.innerText = original; }, 2000);
+        } catch (err) {
+          console.error('Copy failed', err);
+        }
       }
     </script>
   </head>
@@ -333,7 +341,7 @@ var textTmpl = template.Must(template.New("text").Parse(`
     <div class="container">
       <div class="row">
         <a href="/">← Home</a>
-        <button class="btn" onclick="copyAll()">Copy</button>
+        <button id="copyBtn" class="btn" onclick="copyAll()">Copy</button>
       </div>
       <pre id="content">{{.}}</pre>
     </div>


### PR DESCRIPTION
## Summary
- Ensure evaluation content pages copy to clipboard
- Show temporary "Copied!" message after pressing Copy

## Testing
- `GO111MODULE=off go build webserver.go` *(fails: cannot find package "github.com/go-sql-driver/mysql")*

------
https://chatgpt.com/codex/tasks/task_e_68974a2edbf883248f61c622cd68b0e1