### PR TITLE
Fix incorrect oracle for 295D verifier

### DIFF
--- a/0-999/200-299/290-299/295/295D.go
+++ b/0-999/200-299/290-299/295/295D.go
@@ -1,93 +1,106 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
-const MOD = 1000000007
+const MOD int64 = 1000000007
 
-func modpow(a, e int64) int64 {
-   res := int64(1)
-   for e > 0 {
-       if e&1 != 0 {
-           res = res * a % MOD
-       }
-       a = a * a % MOD
-       e >>= 1
-   }
-   return res
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = (res * a) % MOD
+		}
+		a = (a * a) % MOD
+		e >>= 1
+	}
+	return res
 }
 
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   writer := bufio.NewWriter(os.Stdout)
-   defer writer.Flush()
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+	if m < 2 {
+		fmt.Println(0)
+		return
+	}
 
-   var n, m int
-   fmt.Fscan(reader, &n, &m)
-   if n <= 0 || m < 2 {
-       fmt.Fprintln(writer, 0)
-       return
-   }
-   // Precompute f[w] = number of ways to place interval of width w: m-1-w, w=0..m-2
-   maxW := m - 2
-   f := make([]int, maxW+1)
-   invf := make([]int64, maxW+1)
-   for w := 0; w <= maxW; w++ {
-       val := m - 1 - w
-       f[w] = val % MOD
-       invf[w] = modpow(int64(val), MOD-2)
-   }
-   // dp[u][w]: sum of products for non-decreasing sequences length u ending at w
-   dp := make([][]int, n+1)
-   dp[1] = make([]int, maxW+1)
-   for w := 0; w <= maxW; w++ {
-       dp[1][w] = f[w]
-   }
-   // Build dp for u=2..n
-   for u := 2; u <= n; u++ {
-       dp[u] = make([]int, maxW+1)
-       sum := 0
-       for w := 0; w <= maxW; w++ {
-           sum = (sum + dp[u-1][w]) % MOD
-           dp[u][w] = int(int64(f[w]) * int64(sum) % MOD)
-       }
-   }
-   // Compute answer
-   var ans int64
-   // Temporary prefix arrays
-   prefix1 := make([]int64, n+2)
-   prefix2 := make([]int64, n+2)
-   for w := 0; w <= maxW; w++ {
-       // A[u] = dp[u][w] for u=1..n
-       // Build prefix sums over u
-       prefix1[0] = 0
-       prefix2[0] = 0
-       for u := 1; u <= n; u++ {
-           av := int64(dp[u][w])
-           prefix1[u] = (prefix1[u-1] + av) % MOD
-           prefix2[u] = (prefix2[u-1] + av*int64(u)%MOD) % MOD
-       }
-       // Sum over u and v
-       var sumUV int64
-       for u := 1; u <= n; u++ {
-           // v from 1 to n-u+1
-           lim := n - u + 1
-           if lim < 1 {
-               break
-           }
-           total1 := prefix1[lim]
-           total2 := prefix2[lim]
-           coeff := (int64(n+2-u)*total1 - total2) % MOD
-           if coeff < 0 {
-               coeff += MOD
-           }
-           sumUV = (sumUV + int64(dp[u][w]) * coeff) % MOD
-       }
-       // divide by f[w] to correct double count of peak
-       ans = (ans + sumUV*invf[w]) % MOD
-   }
-   fmt.Fprintln(writer, ans)
+	maxN := m + 2*n + 5
+	fac := make([]int64, maxN+1)
+	ifac := make([]int64, maxN+1)
+	fac[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fac[i] = (fac[i-1] * int64(i)) % MOD
+	}
+	ifac[maxN] = modPow(fac[maxN], MOD-2)
+	for i := maxN - 1; i >= 0; i-- {
+		ifac[i] = (ifac[i+1] * int64(i+1)) % MOD
+	}
+
+	comb := func(nv, kv int) int64 {
+		if nv < 0 || kv < 0 || kv > nv {
+			return 0
+		}
+		return (((fac[nv] * ifac[kv]) % MOD) * ifac[nv-kv]) % MOD
+	}
+
+	A := make([]int64, n)
+	Astar := make([]int64, n)
+	S0 := make([]int64, n)
+	S1 := make([]int64, n)
+
+	var ans int64 = 0
+	for W := 0; W <= m-2; W++ {
+		for k := 0; k < n; k++ {
+			top := W + 2*k
+			A[k] = comb(top, 2*k)
+		}
+		for k := 0; k < n; k++ {
+			if k == 0 {
+				// No rows before apex, unique choice
+				Astar[k] = 1
+			} else {
+				t1 := comb(W-1+2*k, 2*k)
+				t2 := comb(W-2+2*k, 2*k)
+				val := (2*t1 - t2) % MOD
+				if val < 0 {
+					val += MOD
+				}
+				Astar[k] = val
+			}
+		}
+		// Prefix sums for A
+		var s0, s1 int64 = 0, 0
+		for i := 0; i < n; i++ {
+			s0 += A[i]
+			if s0 >= MOD {
+				s0 -= MOD
+			}
+			S0[i] = s0
+			s1 = (s1 + int64(i)*A[i]) % MOD
+			S1[i] = s1
+		}
+
+		var T int64 = 0
+		for k := 0; k < n; k++ {
+			Nk := n - 1 - k
+			rk := (int64(n-k)*S0[Nk] - S1[Nk]) % MOD
+			if rk < 0 {
+				rk += MOD
+			}
+			T = (T + Astar[k]*rk) % MOD
+		}
+		mult := int64(m - W - 1)
+		ans = (ans + T*mult) % MOD
+	}
+	if ans < 0 {
+		ans += MOD
+	}
+	fmt.Println(ans % MOD)
 }


### PR DESCRIPTION
## Summary
- replace 295D oracle solution with correct combinatorial implementation to match problem requirements

## Testing
- `go build 0-999/200-299/290-299/295/295D.go`
- `go run verifierD.go ./bin295D`

------
https://chatgpt.com/codex/tasks/task_e_689846e44e008324bed5c907ced079d7