### PR TITLE
Fix CF1806D verifier with correct oracle implementation

### DIFF
--- a/1000-1999/1800-1899/1800-1809/1806/1806D.go
+++ b/1000-1999/1800-1899/1800-1809/1806/1806D.go
@@ -2,33 +2,101 @@ package main
 
 import (
 	"bufio"
-	"fmt"
+	"io"
 	"os"
 )
 
-const mod int64 = 998244353
+const MOD int64 = 998244353
+const MAXN = 500000 + 5
 
-// TODO: implement a correct solution. This placeholder outputs zeros.
+func modAdd(a, b int64) int64 {
+	x := a + b
+	if x >= MOD {
+		x -= MOD
+	}
+	return x
+}
+func modMul(a, b int64) int64 { return (a * b) % MOD }
+
 func main() {
-	in := bufio.NewReader(os.Stdin)
+	data, _ := io.ReadAll(os.Stdin)
+	idx := 0
+	nextInt := func() int {
+		n := len(data)
+		for idx < n && (data[idx] <= ' ') {
+			idx++
+		}
+		sign := 1
+		if idx < n && data[idx] == '-' {
+			sign = -1
+			idx++
+		}
+		x := 0
+		for idx < n && data[idx] >= '0' && data[idx] <= '9' {
+			x = x*10 + int(data[idx]-'0')
+			idx++
+		}
+		return x * sign
+	}
+
+	inv := make([]int64, MAXN)
+	fact := make([]int64, MAXN)
+	inv[1] = 1
+	for i := 2; i < MAXN; i++ {
+		inv[i] = MOD - (MOD/int64(i))*inv[int(MOD%int64(i))]%MOD
+	}
+	fact[0] = 1
+	for i := 1; i < MAXN; i++ {
+		fact[i] = modMul(fact[i-1], int64(i))
+	}
+
 	out := bufio.NewWriter(os.Stdout)
 	defer out.Flush()
 
-	var t int
-	fmt.Fscan(in, &t)
+	writeInt := func(x int64) {
+		if x == 0 {
+			out.WriteByte('0')
+			return
+		}
+		if x < 0 {
+			out.WriteByte('-')
+			x = -x
+		}
+		var buf [20]byte
+		i := len(buf)
+		for x > 0 {
+			i--
+			buf[i] = byte('0' + x%10)
+			x /= 10
+		}
+		out.Write(buf[i:])
+	}
+
+	t := nextInt()
 	for ; t > 0; t-- {
-		var n int
-		fmt.Fscan(in, &n)
-		for i := 0; i < n-1; i++ {
-			var tmp int
-			fmt.Fscan(in, &tmp)
+		n := nextInt()
+		a := make([]int, n)
+		for i := 1; i <= n-1; i++ {
+			a[i] = nextInt()
 		}
-		for k := 1; k < n; k++ {
-			if k > 1 {
-				fmt.Fprint(out, " ")
+		pref := int64(1)
+		sum := int64(0)
+		for k := 1; k <= n-1; k++ {
+			if a[k] == 1 {
+				pref = modMul(pref, modMul(int64(k-1), inv[k]))
 			}
-			fmt.Fprint(out, 0)
+			if a[k] == 0 {
+				add := modMul(inv[k], pref)
+				sum = modAdd(sum, add)
+			}
+			ans := modMul(fact[k], sum)
+			writeInt(ans)
+			if k < n-1 {
+				out.WriteByte(' ')
+			}
 		}
-		fmt.Fprintln(out)
+		if n-1 > 0 {
+			out.WriteByte('\n')
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- replace placeholder 1806D solution with full implementation using modular arithmetic and precomputed factorials for accurate verification

## Testing
- `go build -o /tmp/verifier1806D.bin 1000-1999/1800-1899/1800-1809/1806/verifierD.go`
- `(cd 1000-1999/1800-1899/1800-1809/1806 && /tmp/verifier1806D.bin 1806D.go)`

------
https://chatgpt.com/codex/tasks/task_e_68984790dd2c8324926b871b33bf308c