### PR TITLE
Fix reference solution for 925C verifier

### DIFF
--- a/0-999/900-999/920-929/925/925C.go
+++ b/0-999/900-999/920-929/925/925C.go
@@ -5,35 +5,63 @@ import (
 	"fmt"
 	"math/bits"
 	"os"
-	"sort"
 )
 
 func main() {
 	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
 	var n int
 	if _, err := fmt.Fscan(in, &n); err != nil {
 		return
 	}
-	nums := make([]uint64, n)
-	used := make([]bool, 60)
+	g := make([][]uint64, 60)
 	for i := 0; i < n; i++ {
 		var x uint64
 		fmt.Fscan(in, &x)
-		nums[i] = x
-		bit := 63 - bits.LeadingZeros64(x)
-		if used[bit] {
-			fmt.Println("No")
+		b := bits.Len64(x) - 1
+		g[b] = append(g[b], x)
+	}
+
+	res := make([]uint64, 0, n)
+	for bit := 59; bit >= 0; bit-- {
+		arr := g[bit]
+		if len(arr) == 0 {
+			continue
+		}
+		idx := 0
+		newRes := make([]uint64, 0, len(res)+len(arr))
+		var p uint64
+		j := 0
+		for j < len(res) {
+			for idx < len(arr) && ((p>>uint(bit))&1) == 0 {
+				newRes = append(newRes, arr[idx])
+				p ^= arr[idx]
+				idx++
+			}
+			newRes = append(newRes, res[j])
+			p ^= res[j]
+			j++
+		}
+		for idx < len(arr) && ((p>>uint(bit))&1) == 0 {
+			newRes = append(newRes, arr[idx])
+			p ^= arr[idx]
+			idx++
+		}
+		if idx != len(arr) {
+			fmt.Fprintln(out, "No")
 			return
 		}
-		used[bit] = true
+		res = newRes
 	}
-	sort.Slice(nums, func(i, j int) bool { return nums[i] < nums[j] })
-	fmt.Println("Yes")
-	for i := 0; i < n; i++ {
+
+	fmt.Fprintln(out, "Yes")
+	for i := 0; i < len(res); i++ {
 		if i > 0 {
-			fmt.Print(" ")
+			fmt.Fprint(out, " ")
 		}
-		fmt.Print(nums[i])
+		fmt.Fprint(out, res[i])
 	}
-	fmt.Println()
+	fmt.Fprintln(out)
 }


### PR DESCRIPTION
## Summary
- Replace incorrect 925C reference solution with proper algorithm that constructs permutation ensuring strictly increasing prefix XOR

## Testing
- `go build -o /tmp/925C.bin 0-999/900-999/920-929/925/925C.go`
- `(cd 0-999/900-999/920-929/925 && go run verifierC.go /tmp/candidate.bin)`

------
https://chatgpt.com/codex/tasks/task_e_68984ae1436c832481166a74634e8b7c