### PR TITLE
fix: allow verifier to ignore order of removed indices

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1249/verifierD2.go
+++ b/1000-1999/1200-1299/1240-1249/1249/verifierD2.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -55,6 +57,33 @@ func genCase(r *rand.Rand) string {
 	return sb.String()
 }
 
+// normalize parses an output string and returns the sorted list of removed
+// segment indices. It ensures that the count on the first line matches the
+// number of indices that follow so that order in the second line is irrelevant.
+func normalize(out string) ([]int, error) {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("empty output")
+	}
+	m, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return nil, err
+	}
+	if m != len(fields)-1 {
+		return nil, fmt.Errorf("mismatch count: expect %d numbers, got %d", m, len(fields)-1)
+	}
+	res := make([]int, m)
+	for i := 0; i < m; i++ {
+		v, err := strconv.Atoi(fields[i+1])
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	sort.Ints(res)
+	return res, nil
+}
+
 func main() {
 	if len(os.Args) != 2 {
 		fmt.Println("usage: go run verifierD2.go /path/to/binary")
@@ -81,9 +110,25 @@ func main() {
 			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
 			os.Exit(1)
 		}
-		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		expAns, err := normalize(expect)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle output parse error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		gotAns, err := normalize(got)
+		if err != nil {
+			fmt.Printf("case %d failed\ninput:\n%sparse error: %v\n", i, input, err)
+			os.Exit(1)
+		}
+		if len(expAns) != len(gotAns) {
 			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, input, expect, got)
 			os.Exit(1)
+		}
+		for j := range expAns {
+			if expAns[j] != gotAns[j] {
+				fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, input, expect, got)
+				os.Exit(1)
+			}
 		}
 	}
 	fmt.Println("All 100 tests passed")


### PR DESCRIPTION
## Summary
- handle unordered segment IDs in D2 verifier by parsing and sorting indices

## Testing
- `go build 1000-1999/1200-1299/1240-1249/1249/verifierD2.go`


------
https://chatgpt.com/codex/tasks/task_e_68984d48ff7c83249fd3cbc2392f03ce