### PR TITLE
Fix missing blank line in 1619D verifier

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1619/verifierD.go
+++ b/1000-1999/1600-1699/1610-1619/1619/verifierD.go
@@ -78,7 +78,7 @@ func generateCase(rng *rand.Rand) (string, string) {
 	n := rng.Intn(5) + 2
 	matrix := make([][]int, m)
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "1\n%d %d\n", m, n)
+	fmt.Fprintf(&sb, "1\n\n%d %d\n", m, n)
 	for i := 0; i < m; i++ {
 		matrix[i] = make([]int, n)
 		for j := 0; j < n; j++ {


### PR DESCRIPTION
## Summary
- Ensure generated testcases for problem 1619D include a blank line after the test count

## Testing
- `go run 1000-1999/1600-1699/1610-1619/1619/verifierD.go /tmp/solution`

------
https://chatgpt.com/codex/tasks/task_e_68984ddee45083249c2b02a8d6f4f00f