### PR TITLE
Fix 678E verifier

### DIFF
--- a/0-999/600-699/670-679/678/678E.go
+++ b/0-999/600-699/670-679/678/678E.go
@@ -3,74 +3,101 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"math/bits"
 	"os"
 )
 
-var (
-	n int
-	p [][]float64
-)
-
-// calc computes the probability based on sequence seq
-func calc(seq []int) float64 {
-	l := len(seq)
-	// reverse seq
-	rev := make([]int, l)
-	for i, v := range seq {
-		rev[l-1-i] = v
-	}
-	// dp[0] and dp[1] rows
-	dp := [2][]float64{}
-	dp[0] = make([]float64, n)
-	dp[1] = make([]float64, n)
-	dp[0][rev[0]] = 1.0
-	// iterate transitions
-	for i := 0; i < l-1; i++ {
-		i0 := i & 1
-		i1 := i0 ^ 1
-		nw := rev[i+1]
-		sum := 0.0
-		for j := 0; j < n; j++ {
-			dp[i1][j] = dp[i0][j] * p[j][nw]
-			sum += dp[i1][j]
-		}
-		dp[i1][nw] = 1.0 - sum
-	}
-	return dp[(l-1)&1][0]
-}
-
 func main() {
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Fscan(reader, &n)
-	p = make([][]float64, n)
-	for i := 0; i < n; i++ {
-		p[i] = make([]float64, n)
-		for j := 0; j < n; j++ {
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	p := make([][]float64, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = make([]float64, n+1)
+		for j := 1; j <= n; j++ {
 			fmt.Fscan(reader, &p[i][j])
 		}
 	}
-	use := make([]bool, n)
-	seq := make([]int, 1, n)
-	seq[0] = 0
-	// greedy build sequence
-	for len(seq) < n {
-		bestVal := -1.0
-		bestIdx := -1
-		for j := 1; j < n; j++ {
-			if use[j] {
+
+	maxMask := (1 << uint(n)) - 1
+	dp := make([][]float64, n+1)
+	for i := 0; i <= n; i++ {
+		dp[i] = make([]float64, maxMask+1)
+	}
+
+	for mask := 0; mask <= maxMask; mask++ {
+		bitsCnt := bits.OnesCount(uint(mask))
+		for c := 0; c <= n; c++ {
+			if c != 0 && (mask&(1<<(c-1))) != 0 {
+				dp[c][mask] = 0
 				continue
 			}
-			seq = append(seq, j)
-			val := calc(seq)
-			if val > bestVal {
-				bestVal = val
-				bestIdx = j
+			if bitsCnt == 0 {
+				if c == 1 {
+					dp[c][mask] = 1.0
+				} else {
+					dp[c][mask] = 0.0
+				}
+				continue
 			}
-			seq = seq[:len(seq)-1]
+
+			if c != 0 {
+				mx := 0.0
+				for ib := 0; ib < n; ib++ {
+					if mask&(1<<ib) == 0 {
+						continue
+					}
+					x := ib + 1
+					newMask := mask &^ (1 << ib)
+					prob := p[c][x]*dp[c][newMask] + p[x][c]*dp[x][newMask]
+					if prob > mx {
+						mx = prob
+					}
+				}
+				dp[c][mask] = mx
+			} else {
+				if bitsCnt == 1 {
+					var x int
+					for ib := 0; ib < n; ib++ {
+						if mask&(1<<ib) != 0 {
+							x = ib + 1
+							break
+						}
+					}
+					if x == 1 {
+						dp[0][mask] = 1.0
+					} else {
+						dp[0][mask] = 0.0
+					}
+				} else if bitsCnt >= 2 {
+					mx := 0.0
+					for ib := 0; ib < n; ib++ {
+						if mask&(1<<ib) == 0 {
+							continue
+						}
+						for jb := ib + 1; jb < n; jb++ {
+							if mask&(1<<jb) == 0 {
+								continue
+							}
+							x := ib + 1
+							y := jb + 1
+							newMask := mask &^ ((1 << ib) | (1 << jb))
+							prob := p[x][y]*dp[x][newMask] + p[y][x]*dp[y][newMask]
+							if prob > mx {
+								mx = prob
+							}
+						}
+					}
+					dp[0][mask] = mx
+				} else {
+					dp[0][mask] = 0.0
+				}
+			}
 		}
-		seq = append(seq, bestIdx)
-		use[bestIdx] = true
 	}
-	result := calc(seq)
-	fmt.Printf("%.20f\n", result)
+
+	fmt.Printf("%.10f\n", dp[0][maxMask])
 }


### PR DESCRIPTION
## Summary
- replace incorrect greedy oracle for 678E with subset DP that maximizes player 1 win probability

## Testing
- `go run verifierE.go ./sol`

------
https://chatgpt.com/codex/tasks/task_e_68984ee2dae08324ae3e0e9eede7a0fb