### PR TITLE
Fix 587C verifier to ignore trailing spaces

### DIFF
--- a/0-999/500-599/580-589/587/verifierC.go
+++ b/0-999/500-599/580-589/587/verifierC.go
@@ -25,7 +25,15 @@ func run(bin, input string) (string, error) {
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
 	}
-	return strings.TrimSpace(out.String()), nil
+	return normalize(out.String()), nil
+}
+
+func normalize(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- Trim trailing whitespace from each line in 587C verifier outputs to avoid false mismatches

## Testing
- `go vet 0-999/500-599/580-589/587/verifierC.go`
- `go build 0-999/500-599/580-589/587/verifierC.go`
- `go run verifierC.go -- 587C.go`

------
https://chatgpt.com/codex/tasks/task_e_689851bbcffc83249ff6ce20548a0522