### PR TITLE
Normalize output in Codeforces 650C verifier

### DIFF
--- a/0-999/600-699/650-659/650/verifierC.go
+++ b/0-999/600-699/650-659/650/verifierC.go
@@ -32,7 +32,7 @@ func runBinary(bin, input string) (string, error) {
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
 	}
-	return strings.TrimSpace(out.String()), nil
+	return normalize(out.String()), nil
 }
 
 type Case struct{ input string }
@@ -69,10 +69,18 @@ func runCase(bin, ref string, c Case) error {
 	if err != nil {
 		return err
 	}
-	if expected != strings.TrimSpace(got) {
+	if expected != got {
 		return fmt.Errorf("expected %s got %s", expected, got)
 	}
 	return nil
+}
+
+func normalize(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- Avoid false negatives in verifierC by trimming whitespace on each output line before comparison
- Compare expected and actual outputs directly after normalization

## Testing
- `go build 0-999/600-699/650-659/650/verifierC.go`


------
https://chatgpt.com/codex/tasks/task_e_689852a35ab483248ca6ee0b74546d28