### PR TITLE
Fix 1415D verifier to generate sorted test arrays

### DIFF
--- a/1000-1999/1400-1499/1410-1419/1415/verifierD.go
+++ b/1000-1999/1400-1499/1410-1419/1415/verifierD.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 )
@@ -104,6 +105,7 @@ func main() {
 		for i := range arr {
 			arr[i] = rng.Intn(1000)
 		}
+		sort.Ints(arr)
 		if err := runCase(bin, arr); err != nil {
 			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", total+1, err)
 			os.Exit(1)


### PR DESCRIPTION
## Summary
- Ensure random test arrays are sorted to respect the non-decreasing constraint
- Import sort package for verifier

## Testing
- `/tmp/verifierD 1000-1999/1400-1499/1410-1419/1415/1415D.go`

------
https://chatgpt.com/codex/tasks/task_e_6898555941488324a0a18d6c7c4b02f6