### PR TITLE
Fix verifier for 1479C

### DIFF
--- a/1000-1999/1400-1499/1470-1479/1479/verifierC.go
+++ b/1000-1999/1400-1499/1470-1479/1479/verifierC.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+// runCmd executes the binary at cmdPath with the provided input and returns
+// its combined standard output and error.
 func runCmd(cmdPath, input string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -20,7 +22,77 @@ func runCmd(cmdPath, input string) (string, error) {
 	c.Stdout = &out
 	c.Stderr = &out
 	err := c.Run()
-	return strings.TrimSpace(out.String()), err
+	return out.String(), err
+}
+
+// Edge represents a directed weighted edge.
+type Edge struct {
+	to, w int
+}
+
+// verify parses the candidate output and checks that the graph encodes all
+// integers in the range [l, r]. It also ensures there is no path whose length
+// is less than l.
+func verify(l, r int, out string) error {
+	rd := strings.NewReader(out)
+	var verdict string
+	if _, err := fmt.Fscan(rd, &verdict); err != nil {
+		return fmt.Errorf("failed to read verdict: %v", err)
+	}
+	if verdict != "YES" {
+		return fmt.Errorf("expected YES, got %q", verdict)
+	}
+
+	var n, m int
+	if _, err := fmt.Fscan(rd, &n, &m); err != nil {
+		return fmt.Errorf("failed to read n and m: %v", err)
+	}
+	if n <= 0 || m < 0 {
+		return fmt.Errorf("invalid n or m")
+	}
+
+	edges := make([][]Edge, n+1)
+	for i := 0; i < m; i++ {
+		var a, b, c int
+		if _, err := fmt.Fscan(rd, &a, &b, &c); err != nil {
+			return fmt.Errorf("failed to read edge %d: %v", i+1, err)
+		}
+		if a < 1 || b < 1 || a >= b || a > n || b > n || c < 0 {
+			return fmt.Errorf("invalid edge %d", i+1)
+		}
+		edges[a] = append(edges[a], Edge{to: b, w: c})
+	}
+
+	// Dynamic programming over the DAG to compute reachable path sums.
+	dp := make([][]bool, n+1)
+	for i := range dp {
+		dp[i] = make([]bool, r+1)
+	}
+	dp[1][0] = true
+	for u := 1; u <= n; u++ {
+		for sum := 0; sum <= r; sum++ {
+			if !dp[u][sum] {
+				continue
+			}
+			for _, e := range edges[u] {
+				if sum+e.w <= r {
+					dp[e.to][sum+e.w] = true
+				}
+			}
+		}
+	}
+
+	for x := 0; x < l; x++ {
+		if dp[n][x] {
+			return fmt.Errorf("found path with sum %d < %d", x, l)
+		}
+	}
+	for x := l; x <= r; x++ {
+		if !dp[n][x] {
+			return fmt.Errorf("missing path with sum %d", x)
+		}
+	}
+	return nil
 }
 
 func genTests() []string {
@@ -40,27 +112,18 @@ func main() {
 		os.Exit(1)
 	}
 	bin := os.Args[1]
-	refExe := "./solC.bin"
-	if err := exec.Command("go", "build", "-o", refExe, "1479C.go").Run(); err != nil {
-		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
-		os.Exit(1)
-	}
-	defer os.Remove(refExe)
 
 	tests := genTests()
 	for i, t := range tests {
-		want, err := runCmd(refExe, t)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
-			os.Exit(1)
-		}
+		var l, r int
+		fmt.Sscan(t, &l, &r)
 		got, err := runCmd(bin, t)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
 			os.Exit(1)
 		}
-		if strings.TrimSpace(got) != strings.TrimSpace(want) {
-			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\n", i+1, want, got)
+		if err := verify(l, r, got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\noutput:\n%s\n", i+1, err, got)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Summary
- rewrite 1479C verifier to parse candidate output and validate via dynamic programming instead of comparing against a single reference output

## Testing
- `go build 1000-1999/1400-1499/1470-1479/1479/verifierC.go`
- `go run 1000-1999/1400-1499/1470-1479/1479/verifierC.go /tmp/candidate.bin`


------
https://chatgpt.com/codex/tasks/task_e_6898565072cc8324bda676badfe85d2c