### PR TITLE
Fix 1364B verifier input format

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1364/verifierB.go
+++ b/1000-1999/1300-1399/1360-1369/1364/verifierB.go
@@ -52,8 +52,15 @@ func main() {
 			fmt.Printf("missing test case %d\n", i)
 			os.Exit(1)
 		}
-		line := strings.TrimSpace(scanner.Text())
-		input := fmt.Sprintf("1\n%s\n", line)
+                line := strings.TrimSpace(scanner.Text())
+                fields := strings.Fields(line)
+                if len(fields) == 0 {
+                        fmt.Printf("empty test case %d\n", i)
+                        os.Exit(1)
+                }
+                n := fields[0]
+                arr := strings.Join(fields[1:], " ")
+                input := fmt.Sprintf("1\n%s\n%s\n", n, arr)
 		want, err := run(ref, input)
 		if err != nil {
 			fmt.Printf("reference runtime error on test %d: %v\n", i, err)


### PR DESCRIPTION
## Summary
- parse test cases into separate lines for n and permutation
- guard against empty test case lines in 1364B verifier

## Testing
- `go run verifierB.go ./candB.bin`

------
https://chatgpt.com/codex/tasks/task_e_689862e46c148324b4a99ab8d9eeecfa