### PR TITLE
Fix verifier input format for 858D

### DIFF
--- a/0-999/800-899/850-859/858/verifierD.go
+++ b/0-999/800-899/850-859/858/verifierD.go
@@ -51,7 +51,14 @@ func main() {
 			continue
 		}
 		idx++
-		input := line + "\n"
+		parts := strings.Fields(line)
+		if len(parts) == 0 {
+			continue
+		}
+		input := parts[0] + "\n"
+		if len(parts) > 1 {
+			input += strings.Join(parts[1:], "\n") + "\n"
+		}
 		cmdO := exec.Command(oracle)
 		cmdO.Stdin = strings.NewReader(input)
 		var outO bytes.Buffer


### PR DESCRIPTION
## Summary
- Ensure verifierD transforms test cases into newline-separated input so solutions expecting line-based input do not panic.

## Testing
- `go vet 0-999/800-899/850-859/858/verifierD.go`
- `go run verifierD.go /tmp/sol` (100 tests passed)


------
https://chatgpt.com/codex/tasks/task_e_689875183dd48324b71ff471a0d4516c