### PR TITLE
Fix uniqueness checks in 1051C verifier

### DIFF
--- a/1000-1999/1000-1099/1050-1059/1051/verifierC.go
+++ b/1000-1999/1000-1099/1050-1059/1051/verifierC.go
@@ -30,11 +30,11 @@ func runCandidate(bin, input string) (string, error) {
 }
 
 func possible(nums []int) bool {
-        // numbers are in the range [1, 100]
-        cnt := make([]int, 101)
-        for _, v := range nums {
-                cnt[v]++
-        }
+	// numbers are in the range [1, 100]
+	cnt := make([]int, 101)
+	for _, v := range nums {
+		cnt[v]++
+	}
 	calc := make([]int, 4)
 	for _, c := range cnt {
 		if c <= 2 {
@@ -50,34 +50,40 @@ func isValid(nums []int, assign string) bool {
 	if len(assign) != len(nums) {
 		return false
 	}
-	cnt := make(map[int]int)
-	for _, v := range nums {
-		cnt[v]++
-	}
-	aNice, bNice := 0, 0
+	countA := make(map[int]int)
+	countB := make(map[int]int)
 	for i, ch := range assign {
-		if ch != 'A' && ch != 'B' {
+		switch ch {
+		case 'A':
+			countA[nums[i]]++
+		case 'B':
+			countB[nums[i]]++
+		default:
 			return false
 		}
-		if cnt[nums[i]] == 1 {
-			if ch == 'A' {
-				aNice++
-			} else {
-				bNice++
-			}
+	}
+	aNice, bNice := 0, 0
+	for _, c := range countA {
+		if c == 1 {
+			aNice++
+		}
+	}
+	for _, c := range countB {
+		if c == 1 {
+			bNice++
 		}
 	}
 	return aNice == bNice
 }
 
 func genCase(rng *rand.Rand) []int {
-        n := rng.Intn(8) + 2
-        nums := make([]int, n)
-        for i := 0; i < n; i++ {
-                // generate values within the problem constraints [1, 100]
-                nums[i] = rng.Intn(100) + 1
-        }
-        return nums
+	n := rng.Intn(8) + 2
+	nums := make([]int, n)
+	for i := 0; i < n; i++ {
+		// generate values within the problem constraints [1, 100]
+		nums[i] = rng.Intn(100) + 1
+	}
+	return nums
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- correct validation of contestant assignments by counting unique numbers within each group

## Testing
- `go run 1000-1999/1000-1099/1050-1059/1051/verifierC.go /tmp/candidate`

------
https://chatgpt.com/codex/tasks/task_e_68987764d3e48324b66f34e7acd550da