### PR TITLE
Fix reference execution path in 852D verifier

### DIFF
--- a/0-999/800-899/850-859/852/verifierD.go
+++ b/0-999/800-899/850-859/852/verifierD.go
@@ -11,7 +11,7 @@ import (
 )
 
 func buildRef() (string, error) {
-	ref := "refD.bin"
+	ref := "./refD.bin"
 	cmd := exec.Command("go", "build", "-o", ref, "852D.go")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)


### PR DESCRIPTION
## Summary
- ensure 852D verifier builds and runs reference solution by using a relative path

## Testing
- `go build -o cand852 852D.go`
- `./verifierD ./cand852`

------
https://chatgpt.com/codex/tasks/task_e_6898797a63988324a01660dbf003630b