### PR TITLE
Fix allocation logic in 720A verifier

### DIFF
--- a/0-999/700-799/720-729/720/verifierA.go
+++ b/0-999/700-799/720-729/720/verifierA.go
@@ -70,19 +70,19 @@ func solve(n, m int, A, B []int) string {
 	}
 	sort.Ints(onlyA)
 	for i, d := range onlyA {
-		if A[i] < d {
+		if A[k-len(onlyA)+i] < d {
 			return "NO"
 		}
 	}
 	sort.Ints(onlyB)
 	for i, d := range onlyB {
-		if B[i] < d {
+		if B[l-len(onlyB)+i] < d {
 			return "NO"
 		}
 	}
 	remA := k - len(onlyA)
-	Arem := A[len(onlyA):]
-	Brem := B[len(onlyB):]
+	Arem := A[:remA]
+	Brem := B[:l-len(onlyB)]
 	sort.Slice(both, func(i, j int) bool { return both[i][0] < both[j][0] })
 	assignA := make([]int, 0, remA)
 	assignB := make([]int, 0, len(both)-remA)


### PR DESCRIPTION
## Summary
- ensure strongest students are used for seats only available to one group
- adjust remaining pools used for shared seats in the 720A verifier

## Testing
- `go run verifierA.go ./corr`


------
https://chatgpt.com/codex/tasks/task_e_68987a57df448324a783f553ea15c878