### PR TITLE
Fix 74D verifier event generation

### DIFF
--- a/0-999/0-99/70-79/74/verifierD.go
+++ b/0-999/0-99/70-79/74/verifierD.go
@@ -26,12 +26,20 @@ func generateTest() (string, string) {
 	existingIDs := []int{}
 	nextID := 1
 	ensureQuery := false
-	for i := 0; i < q; i++ {
-		typ := rand.Intn(3)
-		if !ensureQuery && i == q-1 {
-			typ = 0 // ensure at least one query
-		}
-		switch typ {
+       for i := 0; i < q; i++ {
+               options := []int{0, 1, 2}
+               // avoid generating impossible events
+               if len(existingIDs) == 0 {
+                       options = []int{0, 1} // nobody to leave
+               }
+               if len(existingIDs) == n {
+                       options = []int{0, 2} // hanger is full
+               }
+               typ := options[rand.Intn(len(options))]
+               if !ensureQuery && i == q-1 {
+                       typ = 0 // ensure at least one query
+               }
+               switch typ {
 		case 0: // query
 			l := rand.Intn(n) + 1
 			r := rand.Intn(n) + 1


### PR DESCRIPTION
## Summary
- avoid generating impossible arrival/departure events in the 74D verifier
- ensure test generator selects a valid event type before producing queries/answers

## Testing
- `go build 74D.go`
- `go run verifierD.go ./74D`

------
https://chatgpt.com/codex/tasks/task_e_68987b0f43d483249f4ca50a01301be6