### PR TITLE
Fix 1419D1 verifier to accept any valid arrangement

### DIFF
--- a/1000-1999/1400-1499/1410-1419/1419/verifierD1.go
+++ b/1000-1999/1400-1499/1410-1419/1419/verifierD1.go
@@ -6,19 +6,11 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
-	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
-
-func buildOracle() (string, error) {
-	exe := filepath.Join(os.TempDir(), "oracleD1")
-	cmd := exec.Command("go", "build", "-o", exe, "1419D1.go")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
-	}
-	return exe, nil
-}
 
 func runProg(prog, input string) (string, error) {
 	var cmd *exec.Cmd
@@ -53,34 +45,99 @@ func genCase(rng *rand.Rand) string {
 	return sb.String()
 }
 
+func parseInput(s string) (int, []int, error) {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return 0, nil, fmt.Errorf("empty input")
+	}
+	n, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, nil, err
+	}
+	if len(fields) != n+1 {
+		return 0, nil, fmt.Errorf("expected %d numbers, got %d", n, len(fields)-1)
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		v, err := strconv.Atoi(fields[i+1])
+		if err != nil {
+			return 0, nil, err
+		}
+		arr[i] = v
+	}
+	return n, arr, nil
+}
+
+func parseOutput(s string, n int) (int, []int, error) {
+	fields := strings.Fields(s)
+	if len(fields) != n+1 {
+		return 0, nil, fmt.Errorf("expected %d numbers, got %d", n+1, len(fields))
+	}
+	k, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, nil, fmt.Errorf("invalid k: %v", err)
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		v, err := strconv.Atoi(fields[i+1])
+		if err != nil {
+			return 0, nil, fmt.Errorf("invalid number: %v", err)
+		}
+		arr[i] = v
+	}
+	return k, arr, nil
+}
+
+func checkCase(input, output string) error {
+	n, orig, err := parseInput(input)
+	if err != nil {
+		return fmt.Errorf("parse input: %v", err)
+	}
+	k, arr, err := parseOutput(output, n)
+	if err != nil {
+		return fmt.Errorf("parse output: %v", err)
+	}
+	if k != (n-1)/2 {
+		return fmt.Errorf("reported %d beautiful numbers, expected %d", k, (n-1)/2)
+	}
+	sortedOrig := append([]int(nil), orig...)
+	sortedArr := append([]int(nil), arr...)
+	sort.Ints(sortedOrig)
+	sort.Ints(sortedArr)
+	for i := 0; i < n; i++ {
+		if sortedOrig[i] != sortedArr[i] {
+			return fmt.Errorf("output numbers are not a permutation of input")
+		}
+	}
+	cnt := 0
+	for i := 1; i+1 < n; i++ {
+		if arr[i] < arr[i-1] && arr[i] < arr[i+1] {
+			cnt++
+		}
+	}
+	if cnt != k {
+		return fmt.Errorf("reported %d beautiful numbers, found %d", k, cnt)
+	}
+	return nil
+}
+
 func main() {
 	if len(os.Args) != 2 {
 		fmt.Println("usage: go run verifierD1.go /path/to/binary")
 		return
 	}
 	bin := os.Args[1]
-	oracle, err := buildOracle()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	defer os.Remove(oracle)
 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < 100; i++ {
 		input := genCase(rng)
-		exp, err := runProg(oracle, input)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "oracle runtime error on case %d: %v\n", i+1, err)
-			os.Exit(1)
-		}
 		got, err := runProg(bin, input)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
 			os.Exit(1)
 		}
-		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
-			fmt.Fprintf(os.Stderr, "wrong answer on case %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, input, exp, got)
+		if err := checkCase(input, got); err != nil {
+			fmt.Fprintf(os.Stderr, "wrong answer on case %d\ninput:\n%soutput:\n%s\n%v", i+1, input, got, err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Summary
- stop comparing candidate output to a single oracle result
- parse candidate output, verify it is a permutation of the input, and check the number of "beautiful" positions

## Testing
- `go vet verifierD1.go`
- `go build verifierD1.go && ./verifierD1 1419D1.go`

------
https://chatgpt.com/codex/tasks/task_e_68988a040ef08324af0b84342aac8b4b