### PR TITLE
Adjust tolerance in problem 30C verifier

### DIFF
--- a/0-999/0-99/30-39/30/verifierC.go
+++ b/0-999/0-99/30-39/30/verifierC.go
@@ -87,7 +87,13 @@ func runCase(bin, input, expected string) error {
 	outStr := strings.TrimSpace(out.String())
 	if valOut, err := strconv.ParseFloat(outStr, 64); err == nil {
 		valExp, _ := strconv.ParseFloat(expected, 64)
-		if math.Abs(valOut-valExp) > 1e-6 {
+		// Allow a slightly larger error tolerance to avoid false negatives
+		// when both the contestant's solution and the internal solver are
+		// correct but differ by small floating point inaccuracies. The
+		// previous threshold of 1e-6 caused legitimate solutions to fail
+		// verification on edge cases (e.g. case 5 in the report) due to
+		// rounding differences.
+		if math.Abs(valOut-valExp) > 1e-5 {
 			return fmt.Errorf("expected %.9f got %s", valExp, outStr)
 		}
 	} else {


### PR DESCRIPTION
## Summary
- relax comparison tolerance in 30C verifier to avoid false negatives from floating point rounding

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6898a2a656b883248668d0804e937a5a