### PR TITLE
Fix 164B oracle to compute correct results

### DIFF
--- a/0-999/100-199/160-169/164/164B.go
+++ b/0-999/100-199/160-169/164/164B.go
@@ -1,86 +1,60 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
+func isSubseq(sub []int, b []int) bool {
+	j := 0
+	for _, x := range b {
+		if j < len(sub) && x == sub[j] {
+			j++
+			if j == len(sub) {
+				return true
+			}
+		}
+	}
+	return j == len(sub)
+}
+
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   var la, lb int
-   if _, err := fmt.Fscan(reader, &la, &lb); err != nil {
-       return
-   }
-   a := make([]int, la)
-   for i := 0; i < la; i++ {
-       fmt.Fscan(reader, &a[i])
-   }
-   // positions in b
-   bpos := make([]int, 1000001)
-   for i := range bpos {
-       bpos[i] = -1
-   }
-   for i := 0; i < lb; i++ {
-       var x int
-       fmt.Fscan(reader, &x)
-       bpos[x] = i
-   }
-   // build P array for two copies of a
-   n := la * 2
-   P := make([]int, n)
-   for i := 0; i < n; i++ {
-       pos := bpos[a[i%la]]
-       P[i] = pos
-   }
-   best := 0
-   l := 0
-   sumDelta := 0
-   // sliding window over P[0..n)
-   for r := 0; r < n; r++ {
-       if P[r] < 0 {
-           // reset window
-           l = r + 1
-           sumDelta = 0
-           continue
-       }
-       if r > l {
-           // compute delta from r-1 to r
-           prev := P[r-1]
-           if prev < 0 {
-               // start of valid run
-           } else {
-               // mod difference
-               d := P[r] - prev
-               if d < 0 {
-                   d += lb
-               }
-               sumDelta += d
-           }
-       }
-       // shrink if sumDelta >= lb or window too big
-       for l < r && (sumDelta >= lb || r-l+1 > la) {
-           // remove delta between l and l+1
-           if P[l] >= 0 && P[l+1] >= 0 {
-               d := P[l+1] - P[l]
-               if d < 0 {
-                   d += lb
-               }
-               sumDelta -= d
-           }
-           l++
-       }
-       // update best
-       if r-l+1 > best {
-           best = r - l + 1
-       }
-   }
-   // best cannot exceed la or lb
-   if best > la {
-       best = la
-   }
-   if best > lb {
-       best = lb
-   }
-   fmt.Println(best)
+	reader := bufio.NewReader(os.Stdin)
+	var la, lb int
+	if _, err := fmt.Fscan(reader, &la, &lb); err != nil {
+		return
+	}
+	a := make([]int, la)
+	for i := 0; i < la; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	b := make([]int, lb)
+	for i := 0; i < lb; i++ {
+		fmt.Fscan(reader, &b[i])
+	}
+	best := 0
+	for sa := 0; sa < la; sa++ {
+		aa := append(append([]int{}, a[sa:]...), a[:sa]...)
+		for sb := 0; sb < lb; sb++ {
+			bb := append(append([]int{}, b[sb:]...), b[:sb]...)
+			for l := 0; l < la; l++ {
+				for r := l; r < la; r++ {
+					sub := aa[l : r+1]
+					if isSubseq(sub, bb) {
+						if len(sub) > best {
+							best = len(sub)
+						}
+					}
+				}
+			}
+		}
+	}
+	if best > la {
+		best = la
+	}
+	if best > lb {
+		best = lb
+	}
+	fmt.Println(best)
 }


### PR DESCRIPTION
## Summary
- replace 164B oracle with simple exhaustive rotation/subsequence search

## Testing
- `go run verifierB.go ./candidate`

------
https://chatgpt.com/codex/tasks/task_e_6898a0f3ddb48324841b251a67626a83