### PR TITLE
Handle flexible whitespace in 598D verifier

### DIFF
--- a/0-999/500-599/590-599/598/verifierD.go
+++ b/0-999/500-599/590-599/598/verifierD.go
@@ -129,10 +129,15 @@ func runCase(exe, input, expected string) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
 	}
-	got := strings.TrimSpace(out.String())
-	exp := strings.TrimSpace(expected)
-	if got != exp {
-		return fmt.Errorf("expected\n%s\ngot\n%s", exp, got)
+	gotFields := strings.Fields(out.String())
+	expFields := strings.Fields(expected)
+	if len(gotFields) != len(expFields) {
+		return fmt.Errorf("expected\n%s\ngot\n%s", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	for i := range expFields {
+		if gotFields[i] != expFields[i] {
+			return fmt.Errorf("expected\n%s\ngot\n%s", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Make 598D verifier compare tokenized outputs instead of exact strings to allow trailing spaces or newlines.

## Testing
- `go build 0-999/500-599/590-599/598/verifierD.go`
- `go run 0-999/500-599/590-599/598/verifierD.go /tmp/598D_spaces`

------
https://chatgpt.com/codex/tasks/task_e_6898a320b7fc832487cbf38b0c124f9a