### PR TITLE
Fix 164B verifier for equal positions

### DIFF
--- a/0-999/100-199/160-169/164/164B.go
+++ b/0-999/100-199/160-169/164/164B.go
@@ -66,7 +66,7 @@ func main() {
 			continue
 		}
 		cur := int64(p)
-		if prev != INF && cur <= prev {
+		if prev != INF && cur < prev {
 			cur += ((prev-cur)/lb64 + 1) * lb64
 		}
 		arr[i] = cur

--- a/0-999/100-199/160-169/164/verifierB.go
+++ b/0-999/100-199/160-169/164/verifierB.go
@@ -48,7 +48,7 @@ func solve(la, lb int, a, b []int) int {
 			continue
 		}
 		cur := int64(p)
-		if prev != INF && cur <= prev {
+		if prev != INF && cur < prev {
 			cur += ((prev-cur)/lb64 + 1) * lb64
 		}
 		arr[i] = cur


### PR DESCRIPTION
## Summary
- Correct 164B verifier to unwrap positions only when the current index is less than the previous, allowing zero-distance repeats
- Apply the same fix to the reference 164B solution

## Testing
- `go run verifierB.go /workspace/codeforces/0-999/100-199/160-169/164/sol_rust`
- `go run verifierB.go /workspace/codeforces/0-999/100-199/160-169/164/sol_go`


------
https://chatgpt.com/codex/tasks/task_e_6898b302b1fc8324af3d2919c0269e6e