### PR TITLE
Fix 1005E1 verifier to generate permutation inputs

### DIFF
--- a/1000-1999/1000-1099/1000-1009/1005/verifierE1.go
+++ b/1000-1999/1000-1099/1000-1009/1005/verifierE1.go
@@ -38,14 +38,15 @@ func run(bin, input string) (string, error) {
 
 func genCase(r *rand.Rand) string {
 	n := r.Intn(10) + 1
-	m := r.Intn(10) + 1
+	perm := r.Perm(n)
+	m := r.Intn(n) + 1
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "%d %d\n", n, m)
 	for i := 0; i < n; i++ {
 		if i > 0 {
 			sb.WriteByte(' ')
 		}
-		fmt.Fprintf(&sb, "%d", r.Intn(20)+1)
+		fmt.Fprintf(&sb, "%d", perm[i]+1)
 	}
 	sb.WriteByte('\n')
 	return sb.String()


### PR DESCRIPTION
## Summary
- Ensure verifier for 1005E1 builds random permutations and selects valid m within them

## Testing
- `go run 1000-1999/1000-1099/1000-1009/1005/verifierE1.go /tmp/user1005E1.bin`


------
https://chatgpt.com/codex/tasks/task_e_6898d2d8cf4483249100f4d79fb0c0ae