### PR TITLE
Fix verifier for 1936A to avoid invalid n=1 cases

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1936/verifierA.go
+++ b/1000-1999/1900-1999/1930-1939/1936/verifierA.go
@@ -95,7 +95,11 @@ func main() {
 	ns := make([]int, t)
 	perms := make([][]int, t)
 	for i := 0; i < t; i++ {
-		n := rng.Intn(10) + 1
+		// The problem statement guarantees n \ge 2.  Generating n = 1 causes
+		// some valid solutions to terminate unexpectedly (e.g. by panicking
+		// on empty candidate sets).  Ensure that the verifier only produces
+		// test cases within the specified constraints.
+		n := rng.Intn(9) + 2
 		perm := rng.Perm(n)
 		ns[i] = n
 		perms[i] = perm


### PR DESCRIPTION
## Summary
- restrict verifier to generate `n >= 2`
- document why n=1 causes solution panics

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1936/verifierA.go`


------
https://chatgpt.com/codex/tasks/task_e_6898d92d69a483249275e8ca7a1a5993