### PR TITLE
fix missing max_tokens for Claude

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -28,8 +28,9 @@ type Message struct {
 }
 
 type Request struct {
-	Model    string    `json:"model"`
-	Messages []Message `json:"messages"`
+	Model     string    `json:"model"`
+	Messages  []Message `json:"messages"`
+	MaxTokens int       `json:"max_tokens,omitempty"`
 }
 
 type Response struct {
@@ -626,6 +627,9 @@ func sendPrompt(provider, model, apiKey, prompt string) string {
 	} else {
 		messages := []Message{{Role: "user", Content: prompt}}
 		reqBody := Request{Model: model, Messages: messages}
+		if lowerProvider == "claude" {
+			reqBody.MaxTokens = 4096
+		}
 		body, err = json.Marshal(reqBody)
 	}
 	if err != nil {


### PR DESCRIPTION
## Summary
- add `MaxTokens` field to API request structure
- populate `max_tokens` for Claude prompts to satisfy API requirements

## Testing
- `go build eval.go` *(fails: go.mod file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68997eee61cc83248475efc51d3a5fa1