### PR TITLE
Fix unused import in 457A verifier

### DIFF
--- a/0-999/400-499/450-459/457/verifierA.go
+++ b/0-999/400-499/450-459/457/verifierA.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math"


### PR DESCRIPTION
## Summary
- remove unused `bytes` import from the 457A verifier so it builds correctly

## Testing
- `go build 0-999/400-499/450-459/457/verifierA.go`
- `go vet 0-999/400-499/450-459/457/verifierA.go`


------
https://chatgpt.com/codex/tasks/task_e_689984088934832488a6c3f35836fc2a