### PR TITLE
fix: ensure verifierF generates valid queries

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1921/verifierF.go
+++ b/1000-1999/1900-1999/1920-1929/1921/verifierF.go
@@ -50,8 +50,9 @@ func genTest() []byte {
 	sb.WriteString("\n")
 	for i := 0; i < q; i++ {
 		s := rand.Intn(n) + 1
-		d := rand.Intn(3) + 1
-		k := rand.Intn(3) + 1
+		d := rand.Intn(n) + 1
+		maxK := (n-s)/d + 1
+		k := rand.Intn(maxK) + 1
 		sb.WriteString(fmt.Sprintf("%d %d %d\n", s, d, k))
 	}
 	return []byte(sb.String())


### PR DESCRIPTION
## Summary
- adjust verifier for 1921F to generate only valid queries

## Testing
- `go build 1000-1999/1900-1999/1920-1929/1921/verifierF.go`
- `go run 1000-1999/1900-1999/1920-1929/1921/verifierF.go ./cand`


------
https://chatgpt.com/codex/tasks/task_e_689991d9e6e48324b9a404362e21c26a