### PR TITLE
Fix verifier panic for problem 1498D

### DIFF
--- a/1000-1999/1400-1499/1490-1499/1498/verifierD.go
+++ b/1000-1999/1400-1499/1490-1499/1498/verifierD.go
@@ -44,7 +44,11 @@ func run(bin, input string) (string, error) {
 
 func generateCase(rng *rand.Rand) string {
 	n := rng.Intn(5) + 1
-	m := rng.Intn(30) + 1
+	// m must be at least 2, otherwise generating x' for type 2 operations
+	// (which requires x' > 1e5) would result in an empty range and cause
+	// rng.Intn to panic. Ensure m >= 2 here to mirror the problem
+	// constraints and keep the random generator valid.
+	m := rng.Intn(29) + 2
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
## Summary
- Ensure random test generator respects m ≥ 2 to prevent Intn panics.

## Testing
- `go vet 1000-1999/1400-1499/1490-1499/1498/verifierD.go`
- `go build 1000-1999/1400-1499/1490-1499/1498/verifierD.go`


------
https://chatgpt.com/codex/tasks/task_e_6899a7b89a588324a9c3a637e6eac2b6