### PR TITLE
fix: remove unused code in 386D verifier

### DIFF
--- a/0-999/300-399/380-389/386/verifierD.go
+++ b/0-999/300-399/380-389/386/verifierD.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"math/rand"
@@ -87,7 +86,6 @@ func main() {
 	cases := []string{}
 	// simple deterministic case
 	cases = append(cases, func() string {
-		n := 3
 		var sb strings.Builder
 		sb.WriteString("3\n1 2 3\n")
 		sb.WriteString("*aa\n")


### PR DESCRIPTION
## Summary
- drop unused bufio import in 386D verifier
- remove stray n variable in deterministic case

## Testing
- `go build 0-999/300-399/380-389/386/verifierD.go`


------
https://chatgpt.com/codex/tasks/task_e_6899a9f6dcb0832483536d6aa20d9ef7