### PR TITLE
fix 1726D verifier to allow multiple valid outputs

### DIFF
--- a/1000-1999/1700-1799/1720-1729/1726/verifierD.go
+++ b/1000-1999/1700-1799/1720-1729/1726/verifierD.go
@@ -95,6 +95,42 @@ func min(a, b int) int {
 	return b
 }
 
+func components(n int, edges []Edge, s string, color byte) int {
+	parent := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(a, b int) {
+		fa, fb := find(a), find(b)
+		if fa != fb {
+			parent[fb] = fa
+		}
+	}
+	for i, e := range edges {
+		if s[i] == color {
+			union(e.u, e.v)
+		}
+	}
+	cnt := 0
+	for i := 1; i <= n; i++ {
+		if find(i) == i {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func sumComponents(n int, edges []Edge, s string) int {
+	return components(n, edges, s, '0') + components(n, edges, s, '1')
+}
+
 func main() {
 	if len(os.Args) != 2 {
 		fmt.Println("Usage: go run verifierD.go /path/to/binary")
@@ -121,8 +157,20 @@ func main() {
 			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
 			os.Exit(1)
 		}
-		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
-			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+		exp = strings.TrimSpace(exp)
+		got = strings.TrimSpace(got)
+		if len(got) != tc.m {
+			fmt.Printf("Test %d failed\nInput:%sExpected length %d Got length %d\n", i+1, input, tc.m, len(got))
+			os.Exit(1)
+		}
+		if strings.IndexFunc(got, func(r rune) bool { return r != '0' && r != '1' }) != -1 {
+			fmt.Printf("Test %d failed\nInput:%sOutput contains invalid characters: %s\n", i+1, input, got)
+			os.Exit(1)
+		}
+		expVal := sumComponents(tc.n, tc.edges, exp)
+		gotVal := sumComponents(tc.n, tc.edges, got)
+		if expVal != gotVal {
+			fmt.Printf("Test %d failed\nInput:%sExpected value %d Got value %d\nExpected:%s\nGot:%s\n", i+1, input, expVal, gotVal, exp, got)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Summary
- update 1726D verifier to validate any optimal coloring rather than matching a specific string
- add component count helpers and ensure output length/characters are correct

## Testing
- `go vet 1000-1999/1700-1799/1720-1729/1726/verifierD.go`
- `go build 1000-1999/1700-1799/1720-1729/1726/verifierD.go`
- `cd 1000-1999/1700-1799/1720-1729/1726 && go run verifierD.go ../../../../cand.bin`


------
https://chatgpt.com/codex/tasks/task_e_6899c949da90832495c58d678da03cb5