### PR TITLE
Fix verifier for Codeforces 1945E to accept multiple valid solutions

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1945/verifierE.go
+++ b/1000-1999/1900-1999/1940-1949/1945/verifierE.go
@@ -1,24 +1,18 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"math/rand"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
 
-func buildRef() (string, error) {
-	ref := "./refE.bin"
-	cmd := exec.Command("go", "build", "-o", ref, "1945E.go")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
-	}
-	return ref, nil
-}
-
+// generatePerm returns a random permutation of size n (1-indexed values).
 func generatePerm(rng *rand.Rand, n int) []int {
 	perm := rng.Perm(n)
 	for i := range perm {
@@ -27,7 +21,8 @@ func generatePerm(rng *rand.Rand, n int) []int {
 	return perm
 }
 
-func generateCase(rng *rand.Rand) string {
+// generateCase creates a single test case and also returns the permutation and target x.
+func generateCase(rng *rand.Rand) (string, []int, int) {
 	n := rng.Intn(20) + 1
 	x := rng.Intn(n) + 1
 	p := generatePerm(rng, n)
@@ -38,23 +33,65 @@ func generateCase(rng *rand.Rand) string {
 		if i > 0 {
 			sb.WriteByte(' ')
 		}
-		fmt.Fprintf(&sb, "%d", v)
+		sb.WriteString(strconv.Itoa(v))
 	}
 	sb.WriteByte('\n')
-	return sb.String()
+	return sb.String(), p, x
 }
 
-func runCase(exe, ref, input string) error {
-	cmdRef := exec.Command(ref)
-	cmdRef.Stdin = strings.NewReader(input)
-	var refOut bytes.Buffer
-	cmdRef.Stdout = &refOut
-	cmdRef.Stderr = &refOut
-	if err := cmdRef.Run(); err != nil {
-		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+// checkOutput validates the candidate output against the problem rules.
+func checkOutput(n, x int, p []int, out string) error {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("missing number of operations")
 	}
-	expected := strings.TrimSpace(refOut.String())
+	k, err := strconv.Atoi(scanner.Text())
+	if err != nil {
+		return fmt.Errorf("invalid number of operations: %v", err)
+	}
+	if k < 0 || k > 2 {
+		return fmt.Errorf("number of operations out of range: %d", k)
+	}
+	for i := 0; i < k; i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing index i for swap %d", i+1)
+		}
+		a, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("invalid index i for swap %d: %v", i+1, err)
+		}
+		if !scanner.Scan() {
+			return fmt.Errorf("missing index j for swap %d", i+1)
+		}
+		b, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("invalid index j for swap %d: %v", i+1, err)
+		}
+		if a < 1 || a > n || b < 1 || b > n {
+			return fmt.Errorf("swap indices out of range: %d %d", a, b)
+		}
+		p[a-1], p[b-1] = p[b-1], p[a-1]
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output detected: %s", scanner.Text())
+	}
+	l, r := 1, n+1
+	for r-l > 1 {
+		m := (l + r) / 2
+		if p[m-1] <= x {
+			l = m
+		} else {
+			r = m
+		}
+	}
+	if p[l-1] != x {
+		return fmt.Errorf("after operations binary search ends at value %d instead of %d", p[l-1], x)
+	}
+	return nil
+}
 
+func runCase(exe string, input string, p []int, x int) error {
 	cmd := exec.Command(exe)
 	cmd.Stdin = strings.NewReader(input)
 	var out bytes.Buffer
@@ -63,9 +100,8 @@ func runCase(exe, ref, input string) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
 	}
-	got := strings.TrimSpace(out.String())
-	if got != expected {
-		return fmt.Errorf("expected %s got %s", expected, got)
+	if err := checkOutput(len(p), x, append([]int(nil), p...), strings.TrimSpace(out.String())); err != nil {
+		return err
 	}
 	return nil
 }
@@ -76,17 +112,11 @@ func main() {
 		os.Exit(1)
 	}
 	exe := os.Args[1]
-	ref, err := buildRef()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	defer os.Remove(ref)
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < 100; i++ {
-		in := generateCase(rng)
-		if err := runCase(exe, ref, in); err != nil {
-			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+		input, p, x := generateCase(rng)
+		if err := runCase(exe, input, p, x); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Summary
- rewrite `verifierE.go` for problem 1945E to validate solutions by checking swaps and binary search result instead of comparing with reference output

## Testing
- `go build verifierE.go`
- `go run verifierE.go /tmp/test1945E.bin`


------
https://chatgpt.com/codex/tasks/task_e_6899cd6108e48324bcdff952a717dbe1