### PR TITLE
Fix 382D verifier to avoid overcounting overlapping paths

### DIFF
--- a/0-999/300-399/380-389/382/382D.go
+++ b/0-999/300-399/380-389/382/382D.go
@@ -1,125 +1,148 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   var n, m int
-   if _, err := fmt.Fscan(reader, &n, &m); err != nil {
-       return
-   }
-   grid := make([][]byte, n)
-   for i := 0; i < n; i++ {
-       line, err := reader.ReadString('\n')
-       if err != nil && len(line) == 0 {
-           return
-       }
-       if len(line) < m {
-           // read until full line
-           more, _ := reader.ReadString('\n')
-           line += more
-       }
-       grid[i] = []byte(line[:m])
-   }
-   size := n * m
-   dist := make([]int, size)
-   queue := make([]int, 0, size)
-   // initial nodes: arrows pointing to blocked
-   for i := 0; i < n; i++ {
-       for j := 0; j < m; j++ {
-           u := grid[i][j]
-           if u == '<' || u == '>' || u == '^' || u == 'v' {
-               var ni, nj int
-               switch u {
-               case '<': ni, nj = i, j-1
-               case '>': ni, nj = i, j+1
-               case '^': ni, nj = i-1, j
-               case 'v': ni, nj = i+1, j
-               }
-               if grid[ni][nj] == '#' {
-                   idx := i*m + j
-                   dist[idx] = 1
-                   queue = append(queue, idx)
-               }
-           }
-       }
-   }
-   // BFS in reverse graph
-   head := 0
-   for head < len(queue) {
-       v := queue[head]
-       head++
-       vi := v / m
-       vj := v % m
-       // check neighbors u that point to v
-       // up neighbor (i-1,j) with 'v'
-       if vi > 0 {
-           ui, uj := vi-1, vj
-           if grid[ui][uj] == 'v' {
-               u := ui*m + uj
-               if dist[u] == 0 {
-                   dist[u] = dist[v] + 1
-                   queue = append(queue, u)
-               }
-           }
-       }
-       // down neighbor (i+1,j) with '^'
-       if vi+1 < n {
-           ui, uj := vi+1, vj
-           if grid[ui][uj] == '^' {
-               u := ui*m + uj
-               if dist[u] == 0 {
-                   dist[u] = dist[v] + 1
-                   queue = append(queue, u)
-               }
-           }
-       }
-       // left neighbor (i,j-1) with '>'
-       if vj > 0 {
-           ui, uj := vi, vj-1
-           if grid[ui][uj] == '>' {
-               u := ui*m + uj
-               if dist[u] == 0 {
-                   dist[u] = dist[v] + 1
-                   queue = append(queue, u)
-               }
-           }
-       }
-       // right neighbor (i,j+1) with '<'
-       if vj+1 < m {
-           ui, uj := vi, vj+1
-           if grid[ui][uj] == '<' {
-               u := ui*m + uj
-               if dist[u] == 0 {
-                   dist[u] = dist[v] + 1
-                   queue = append(queue, u)
-               }
-           }
-       }
-   }
-   // detect cycles and find top two
-   max1, max2 := 0, 0
-   for i := 0; i < n; i++ {
-       for j := 0; j < m; j++ {
-           c := grid[i][j]
-           if c == '<' || c == '>' || c == '^' || c == 'v' {
-               d := dist[i*m+j]
-               if d == 0 {
-                   fmt.Println(-1)
-                   return
-               }
-               if d > max1 {
-                   max2 = max1
-                   max1 = d
-               } else if d > max2 {
-                   max2 = d
-               }
-           }
-       }
-   }
-   fmt.Println(max1 + max2)
+	reader := bufio.NewReader(os.Stdin)
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		line, err := reader.ReadString('\n')
+		if err != nil && len(line) == 0 {
+			return
+		}
+		if len(line) < m {
+			// read until full line
+			more, _ := reader.ReadString('\n')
+			line += more
+		}
+		grid[i] = []byte(line[:m])
+	}
+	size := n * m
+	dist := make([]int, size)
+	root := make([]int, size)
+	queue := make([]int, 0, size)
+	// initial nodes: arrows pointing to blocked
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			u := grid[i][j]
+			if u == '<' || u == '>' || u == '^' || u == 'v' {
+				var ni, nj int
+				switch u {
+				case '<':
+					ni, nj = i, j-1
+				case '>':
+					ni, nj = i, j+1
+				case '^':
+					ni, nj = i-1, j
+				case 'v':
+					ni, nj = i+1, j
+				}
+				if grid[ni][nj] == '#' {
+					idx := i*m + j
+					dist[idx] = 1
+					root[idx] = idx
+					queue = append(queue, idx)
+				}
+			}
+		}
+	}
+	// BFS in reverse graph
+	head := 0
+	for head < len(queue) {
+		v := queue[head]
+		head++
+		vi := v / m
+		vj := v % m
+		r := root[v]
+		// check neighbors u that point to v
+		// up neighbor (i-1,j) with 'v'
+		if vi > 0 {
+			ui, uj := vi-1, vj
+			if grid[ui][uj] == 'v' {
+				u := ui*m + uj
+				if dist[u] == 0 {
+					dist[u] = dist[v] + 1
+					root[u] = r
+					queue = append(queue, u)
+				}
+			}
+		}
+		// down neighbor (i+1,j) with '^'
+		if vi+1 < n {
+			ui, uj := vi+1, vj
+			if grid[ui][uj] == '^' {
+				u := ui*m + uj
+				if dist[u] == 0 {
+					dist[u] = dist[v] + 1
+					root[u] = r
+					queue = append(queue, u)
+				}
+			}
+		}
+		// left neighbor (i,j-1) with '>'
+		if vj > 0 {
+			ui, uj := vi, vj-1
+			if grid[ui][uj] == '>' {
+				u := ui*m + uj
+				if dist[u] == 0 {
+					dist[u] = dist[v] + 1
+					root[u] = r
+					queue = append(queue, u)
+				}
+			}
+		}
+		// right neighbor (i,j+1) with '<'
+		if vj+1 < m {
+			ui, uj := vi, vj+1
+			if grid[ui][uj] == '<' {
+				u := ui*m + uj
+				if dist[u] == 0 {
+					dist[u] = dist[v] + 1
+					root[u] = r
+					queue = append(queue, u)
+				}
+			}
+		}
+	}
+	// detect cycles and find top two per component
+	maxPerRoot := make(map[int]int)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			c := grid[i][j]
+			if c == '<' || c == '>' || c == '^' || c == 'v' {
+				idx := i*m + j
+				d := dist[idx]
+				if d == 0 {
+					fmt.Println(-1)
+					return
+				}
+				r := root[idx]
+				if d > maxPerRoot[r] {
+					maxPerRoot[r] = d
+				}
+			}
+		}
+	}
+	max1, max2 := 0, 0
+	for _, d := range maxPerRoot {
+		if d > max1 {
+			max2 = max1
+			max1 = d
+		} else if d > max2 {
+			max2 = d
+		}
+	}
+	second := max2
+	if max1-1 > second {
+		second = max1 - 1
+	}
+	fmt.Println(max1 + second)
 }

--- a/0-999/300-399/380-389/382/verifierD.go
+++ b/0-999/300-399/380-389/382/verifierD.go
@@ -19,6 +19,7 @@ func compute(grid [][]byte) int {
 	m := len(grid[0])
 	size := n * m
 	dist := make([]int, size)
+	root := make([]int, size)
 	queue := make([]int, 0, size)
 	for i := 0; i < n; i++ {
 		for j := 0; j < m; j++ {
@@ -38,6 +39,7 @@ func compute(grid [][]byte) int {
 				if grid[ni][nj] == '#' {
 					idx := i*m + j
 					dist[idx] = 1
+					root[idx] = idx
 					queue = append(queue, idx)
 				}
 			}
@@ -49,12 +51,14 @@ func compute(grid [][]byte) int {
 		head++
 		vi := v / m
 		vj := v % m
+		r := root[v]
 		if vi > 0 {
 			ui, uj := vi-1, vj
 			if grid[ui][uj] == 'v' {
 				u := ui*m + uj
 				if dist[u] == 0 {
 					dist[u] = dist[v] + 1
+					root[u] = r
 					queue = append(queue, u)
 				}
 			}
@@ -65,6 +69,7 @@ func compute(grid [][]byte) int {
 				u := ui*m + uj
 				if dist[u] == 0 {
 					dist[u] = dist[v] + 1
+					root[u] = r
 					queue = append(queue, u)
 				}
 			}
@@ -75,6 +80,7 @@ func compute(grid [][]byte) int {
 				u := ui*m + uj
 				if dist[u] == 0 {
 					dist[u] = dist[v] + 1
+					root[u] = r
 					queue = append(queue, u)
 				}
 			}
@@ -85,30 +91,43 @@ func compute(grid [][]byte) int {
 				u := ui*m + uj
 				if dist[u] == 0 {
 					dist[u] = dist[v] + 1
+					root[u] = r
 					queue = append(queue, u)
 				}
 			}
 		}
 	}
-	max1, max2 := 0, 0
+	maxPerRoot := make(map[int]int)
 	for i := 0; i < n; i++ {
 		for j := 0; j < m; j++ {
 			c := grid[i][j]
 			if c == '<' || c == '>' || c == '^' || c == 'v' {
-				d := dist[i*m+j]
+				idx := i*m + j
+				d := dist[idx]
 				if d == 0 {
 					return -1
 				}
-				if d > max1 {
-					max2 = max1
-					max1 = d
-				} else if d > max2 {
-					max2 = d
+				r := root[idx]
+				if d > maxPerRoot[r] {
+					maxPerRoot[r] = d
 				}
 			}
 		}
 	}
-	return max1 + max2
+	max1, max2 := 0, 0
+	for _, d := range maxPerRoot {
+		if d > max1 {
+			max2 = max1
+			max1 = d
+		} else if d > max2 {
+			max2 = d
+		}
+	}
+	second := max2
+	if max1-1 > second {
+		second = max1 - 1
+	}
+	return max1 + second
 }
 
 func genCase(r *rand.Rand) Test {


### PR DESCRIPTION
## Summary
- Track root components for each arrow to detect overlapping paths and compute the best two pawn paths without double-counting.
- Update solver and verifier to apply the corrected scoring formula `max1 + max(max1-1, max2)`.

## Testing
- `printf "4 4\n####\n##v#\n#>>#\n####\n" | go run 382D.go`
- `go build 382D.go`
- `go run verifierD.go ./382D`


------
https://chatgpt.com/codex/tasks/task_e_6899eac98b208324b941fdaf48b7b895