### PR TITLE
Fix 1399F verifier and solution for nested segments

### DIFF
--- a/1000-1999/1300-1399/1390-1399/1399/1399F.go
+++ b/1000-1999/1300-1399/1390-1399/1399/1399F.go
@@ -1,90 +1,106 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
-   "sort"
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
 )
 
+type Seg struct {
+	l, r int
+}
+
+type Child struct {
+	l, r, w int
+}
+
+func solve(segs []Seg) int {
+	sort.Slice(segs, func(i, j int) bool {
+		li := segs[i].r - segs[i].l
+		lj := segs[j].r - segs[j].l
+		if li != lj {
+			return li < lj
+		}
+		return segs[i].l < segs[j].l
+	})
+	n := len(segs)
+	dp := make([]int, n)
+	for i := 0; i < n; i++ {
+		var childs []Child
+		for j := 0; j < i; j++ {
+			if segs[i].l <= segs[j].l && segs[j].r <= segs[i].r {
+				childs = append(childs, Child{segs[j].l, segs[j].r, 1 + dp[j]})
+			}
+		}
+		if len(childs) == 0 {
+			dp[i] = 0
+			continue
+		}
+		sort.Slice(childs, func(a, b int) bool { return childs[a].r < childs[b].r })
+		ends := make([]int, len(childs))
+		for k := range childs {
+			ends[k] = childs[k].r
+		}
+		local := make([]int, len(childs)+1)
+		for k := 1; k <= len(childs); k++ {
+			lCur := childs[k-1].l
+			wCur := childs[k-1].w
+			q := sort.SearchInts(ends, lCur) - 1
+			prev := 0
+			if q >= 0 {
+				prev = local[q+1]
+			}
+			take := wCur + prev
+			if take > local[k-1] {
+				local[k] = take
+			} else {
+				local[k] = local[k-1]
+			}
+		}
+		dp[i] = local[len(childs)]
+	}
+	childs := make([]Child, n)
+	for k := 0; k < n; k++ {
+		childs[k] = Child{segs[k].l, segs[k].r, 1 + dp[k]}
+	}
+	sort.Slice(childs, func(a, b int) bool { return childs[a].r < childs[b].r })
+	ends := make([]int, n)
+	for k := range childs {
+		ends[k] = childs[k].r
+	}
+	local := make([]int, n+1)
+	for k := 1; k <= n; k++ {
+		lCur := childs[k-1].l
+		wCur := childs[k-1].w
+		q := sort.SearchInts(ends, lCur) - 1
+		prev := 0
+		if q >= 0 {
+			prev = local[q+1]
+		}
+		take := wCur + prev
+		if take > local[k-1] {
+			local[k] = take
+		} else {
+			local[k] = local[k-1]
+		}
+	}
+	return local[n]
+}
+
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   writer := bufio.NewWriter(os.Stdout)
-   defer writer.Flush()
-   var t int
-   fmt.Fscan(reader, &t)
-   for tc := 0; tc < t; tc++ {
-       var n int
-       fmt.Fscan(reader, &n)
-       segs := make([][2]int, n)
-       xs := make([]int, 0, 2*n)
-       for i := 0; i < n; i++ {
-           l, r := 0, 0
-           fmt.Fscan(reader, &l, &r)
-           segs[i][0], segs[i][1] = l, r
-           xs = append(xs, l, r)
-       }
-       sort.Ints(xs)
-       m := 0
-       last := -1
-       for _, v := range xs {
-           if v != last {
-               xs[m] = v
-               m++
-               last = v
-           }
-       }
-       xs = xs[:m]
-       // map original to index 1..m
-       idx := make(map[int]int, m)
-       for i, v := range xs {
-           idx[v] = i + 1
-       }
-       endsAt := make([][]int, m+2)
-       for _, s := range segs {
-           l := idx[s[0]]
-           r := idx[s[1]]
-           endsAt[r] = append(endsAt[r], l)
-       }
-       // DP f[i][j]: max arcs in [i..j]
-       // use int16 to save memory
-       f := make([][]int16, m+2)
-       for i := 0; i <= m+1; i++ {
-           f[i] = make([]int16, m+2)
-       }
-       for width := 0; width < m; width++ {
-           for i := 1; i+width <= m; i++ {
-               j := i + width
-               // skip j<i
-               var best int16
-               if j > i {
-                   best = f[i][j-1]
-               }
-               // consider any segment [l0,j]
-               for _, l0 := range endsAt[j] {
-                   if l0 < i {
-                       continue
-                   }
-                   // f[i][l0-1] + 1 + f[l0+1][j-1]
-                   cur := int16(1)
-                   if l0 > i {
-                       cur += f[i][l0-1]
-                   }
-                   if l0 < j {
-                       cur += f[l0+1][j-1]
-                   }
-                   if cur > best {
-                       best = cur
-                   }
-               }
-               f[i][j] = best
-           }
-       }
-       // result for full range
-       if m > 0 {
-           fmt.Fprintln(writer, f[1][m])
-       } else {
-           fmt.Fprintln(writer, 0)
-       }
-   }
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		segs := make([]Seg, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &segs[i].l, &segs[i].r)
+		}
+		fmt.Fprintln(out, solve(segs))
+	}
 }

--- a/1000-1999/1300-1399/1390-1399/1399/verifierF.go
+++ b/1000-1999/1300-1399/1390-1399/1399/verifierF.go
@@ -1,167 +1,178 @@
 package main
 
 import (
-    "bufio"
-    "bytes"
-    "fmt"
-    "os"
-    "os/exec"
-    "sort"
-    "strconv"
-    "strings"
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 type segment struct{ l, r int }
 
 type testCaseF struct {
-    segs []segment
+	segs []segment
 }
 
 func parseTestcasesF(path string) ([]testCaseF, error) {
-    f, err := os.Open(path)
-    if err != nil {
-        return nil, err
-    }
-    defer f.Close()
-    var cases []testCaseF
-    scanner := bufio.NewScanner(f)
-    for scanner.Scan() {
-        line := strings.TrimSpace(scanner.Text())
-        if line == "" {
-            continue
-        }
-        fields := strings.Fields(line)
-        if len(fields) < 1 {
-            return nil, fmt.Errorf("bad line")
-        }
-        n, _ := strconv.Atoi(fields[0])
-        if len(fields)-1 != 2*n {
-            return nil, fmt.Errorf("expected %d numbers", 2*n)
-        }
-        segs := make([]segment, n)
-        for i := 0; i < n; i++ {
-            l, _ := strconv.Atoi(fields[1+2*i])
-            r, _ := strconv.Atoi(fields[2+2*i])
-            segs[i] = segment{l, r}
-        }
-        cases = append(cases, testCaseF{segs})
-    }
-    if err := scanner.Err(); err != nil {
-        return nil, err
-    }
-    return cases, nil
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var cases []testCaseF
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 1 {
+			return nil, fmt.Errorf("bad line")
+		}
+		n, _ := strconv.Atoi(fields[0])
+		if len(fields)-1 != 2*n {
+			return nil, fmt.Errorf("expected %d numbers", 2*n)
+		}
+		segs := make([]segment, n)
+		for i := 0; i < n; i++ {
+			l, _ := strconv.Atoi(fields[1+2*i])
+			r, _ := strconv.Atoi(fields[2+2*i])
+			segs[i] = segment{l, r}
+		}
+		cases = append(cases, testCaseF{segs})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return cases, nil
 }
 
 func solveF(segs []segment) int {
-    n := len(segs)
-    xs := make([]int, 0, 2*n)
-    for _, s := range segs {
-        xs = append(xs, s.l, s.r)
-    }
-    sort.Ints(xs)
-    m := 0
-    last := -1
-    for _, v := range xs {
-        if v != last {
-            xs[m] = v
-            m++
-            last = v
-        }
-    }
-    xs = xs[:m]
-    idx := make(map[int]int, m)
-    for i, v := range xs {
-        idx[v] = i + 1
-    }
-    endsAt := make([][]int, m+2)
-    for _, s := range segs {
-        l := idx[s.l]
-        r := idx[s.r]
-        endsAt[r] = append(endsAt[r], l)
-    }
-    f := make([][]int16, m+2)
-    for i := 0; i <= m+1; i++ {
-        f[i] = make([]int16, m+2)
-    }
-    for width := 0; width < m; width++ {
-        for i := 1; i+width <= m; i++ {
-            j := i + width
-            var best int16
-            if j > i {
-                best = f[i][j-1]
-            }
-            for _, l0 := range endsAt[j] {
-                if l0 < i {
-                    continue
-                }
-                cur := int16(1)
-                if l0 > i {
-                    cur += f[i][l0-1]
-                }
-                if l0 < j {
-                    cur += f[l0+1][j-1]
-                }
-                if cur > best {
-                    best = cur
-                }
-            }
-            f[i][j] = best
-        }
-    }
-    if m > 0 {
-        return int(f[1][m])
-    }
-    return 0
+	sort.Slice(segs, func(i, j int) bool {
+		li := segs[i].r - segs[i].l
+		lj := segs[j].r - segs[j].l
+		if li != lj {
+			return li < lj
+		}
+		return segs[i].l < segs[j].l
+	})
+	type child struct{ l, r, w int }
+	n := len(segs)
+	dp := make([]int, n)
+	for i := 0; i < n; i++ {
+		var childs []child
+		for j := 0; j < i; j++ {
+			if segs[i].l <= segs[j].l && segs[j].r <= segs[i].r {
+				childs = append(childs, child{segs[j].l, segs[j].r, 1 + dp[j]})
+			}
+		}
+		if len(childs) == 0 {
+			dp[i] = 0
+			continue
+		}
+		sort.Slice(childs, func(a, b int) bool { return childs[a].r < childs[b].r })
+		ends := make([]int, len(childs))
+		for k := range childs {
+			ends[k] = childs[k].r
+		}
+		local := make([]int, len(childs)+1)
+		for k := 1; k <= len(childs); k++ {
+			lCur := childs[k-1].l
+			wCur := childs[k-1].w
+			q := sort.SearchInts(ends, lCur) - 1
+			prev := 0
+			if q >= 0 {
+				prev = local[q+1]
+			}
+			take := wCur + prev
+			if take > local[k-1] {
+				local[k] = take
+			} else {
+				local[k] = local[k-1]
+			}
+		}
+		dp[i] = local[len(childs)]
+	}
+	childs := make([]child, n)
+	for k := 0; k < n; k++ {
+		childs[k] = child{segs[k].l, segs[k].r, 1 + dp[k]}
+	}
+	sort.Slice(childs, func(a, b int) bool { return childs[a].r < childs[b].r })
+	ends := make([]int, n)
+	for k := range childs {
+		ends[k] = childs[k].r
+	}
+	local := make([]int, n+1)
+	for k := 1; k <= n; k++ {
+		lCur := childs[k-1].l
+		wCur := childs[k-1].w
+		q := sort.SearchInts(ends, lCur) - 1
+		prev := 0
+		if q >= 0 {
+			prev = local[q+1]
+		}
+		take := wCur + prev
+		if take > local[k-1] {
+			local[k] = take
+		} else {
+			local[k] = local[k-1]
+		}
+	}
+	return local[n]
 }
 
 func run(bin, input string) (string, error) {
-    var cmd *exec.Cmd
-    if strings.HasSuffix(bin, ".go") {
-        cmd = exec.Command("go", "run", bin)
-    } else {
-        cmd = exec.Command(bin)
-    }
-    cmd.Stdin = strings.NewReader(input)
-    var out bytes.Buffer
-    var errBuf bytes.Buffer
-    cmd.Stdout = &out
-    cmd.Stderr = &errBuf
-    if err := cmd.Run(); err != nil {
-        return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
-    }
-    return strings.TrimSpace(out.String()), nil
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
 }
 
 func main() {
-    if len(os.Args) != 2 {
-        fmt.Println("usage: go run verifierF.go /path/to/binary")
-        os.Exit(1)
-    }
-    bin := os.Args[1]
-    cases, err := parseTestcasesF("testcasesF.txt")
-    if err != nil {
-        fmt.Println("failed to parse testcases:", err)
-        os.Exit(1)
-    }
-    for idx, tc := range cases {
-        var sb strings.Builder
-        n := len(tc.segs)
-        sb.WriteString("1\n")
-        sb.WriteString(fmt.Sprintf("%d\n", n))
-        for _, s := range tc.segs {
-            sb.WriteString(fmt.Sprintf("%d %d\n", s.l, s.r))
-        }
-        expected := strconv.Itoa(solveF(tc.segs))
-        got, err := run(bin, sb.String())
-        if err != nil {
-            fmt.Printf("case %d failed: %v\n", idx+1, err)
-            os.Exit(1)
-        }
-        if strings.TrimSpace(got) != expected {
-            fmt.Printf("case %d failed: expected %s got %s\n", idx+1, expected, got)
-            os.Exit(1)
-        }
-    }
-    fmt.Printf("All %d tests passed\n", len(cases))
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases, err := parseTestcasesF("testcasesF.txt")
+	if err != nil {
+		fmt.Println("failed to parse testcases:", err)
+		os.Exit(1)
+	}
+	for idx, tc := range cases {
+		var sb strings.Builder
+		n := len(tc.segs)
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, s := range tc.segs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", s.l, s.r))
+		}
+		expected := strconv.Itoa(solveF(tc.segs))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Printf("case %d failed: expected %s got %s\n", idx+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
 }
-


### PR DESCRIPTION
## Summary
- replace 1399F solution with weighted interval scheduling to count nested/non-overlapping segments correctly
- rewrite verifierF to use the same correct algorithm for expected answers

## Testing
- `go run verifierF.go /tmp/solver`


------
https://chatgpt.com/codex/tasks/task_e_6899eeb8fe7c8324a84acc2dd4dbfa06