### PR TITLE
Fix 1839D reference verifier

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1839/1839D.go
+++ b/1000-1999/1800-1899/1830-1839/1839/1839D.go
@@ -6,87 +6,64 @@ import (
 	"os"
 )
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func main() {
 	in := bufio.NewReader(os.Stdin)
 	out := bufio.NewWriter(os.Stdout)
 	defer out.Flush()
-
 	var T int
 	fmt.Fscan(in, &T)
 	for ; T > 0; T-- {
 		var n int
 		fmt.Fscan(in, &n)
-		c := make([]int, n+1)
-		for i := 1; i <= n; i++ {
+		c := make([]int, n)
+		for i := 0; i < n; i++ {
 			fmt.Fscan(in, &c[i])
 		}
-
-		incEnd := make([]int, n+2)
-		incEnd[n] = n
-		for i := n - 1; i >= 1; i-- {
-			if c[i] < c[i+1] {
-				incEnd[i] = incEnd[i+1]
-			} else {
-				incEnd[i] = i
+		best := make([]int, n+1)
+		total := 1 << uint(n)
+		for mask := 0; mask < total; mask++ {
+			prev := 0
+			kept := 0
+			ok := true
+			for i := 0; i < n; i++ {
+				if mask>>i&1 == 1 {
+					if c[i] <= prev {
+						ok = false
+						break
+					}
+					prev = c[i]
+					kept++
+				}
 			}
-		}
-
-		nextGreater := make([]int, n+1)
-		nextPos := make([]int, n+2)
-		for i := n; i >= 1; i-- {
-			best := 0
-			for v := c[i] + 1; v <= n; v++ {
-				if nextPos[v] != 0 {
-					if best == 0 || nextPos[v] < best {
-						best = nextPos[v]
+			if !ok {
+				continue
+			}
+			zeros := 0
+			i := 0
+			for i < n {
+				if mask>>i&1 == 1 {
+					i++
+				} else {
+					zeros++
+					for i < n && mask>>i&1 == 0 {
+						i++
 					}
 				}
 			}
-			nextGreater[i] = best
-			nextPos[c[i]] = i
-		}
-
-		dp := make([][]int, n+2)
-		for i := 0; i <= n+1; i++ {
-			dp[i] = make([]int, n+1)
-		}
-		for i := n; i >= 1; i-- {
-			for k := 1; k <= n; k++ {
-				if dp[i+1][k] > dp[i][k] {
-					dp[i][k] = dp[i+1][k]
-				}
+			if kept > best[zeros] {
+				best[zeros] = kept
 			}
-			end := i
-			for end <= incEnd[i] {
-				length := end - i + 1
-				nxt := nextGreater[end]
-				for k := 1; k <= n; k++ {
-					if nxt == 0 {
-						if length > dp[i][k] {
-							dp[i][k] = length
-						}
-					} else if k > 1 {
-						val := length + dp[nxt][k-1]
-						if val > dp[i][k] {
-							dp[i][k] = val
-						}
-					}
-				}
-				end++
+		}
+		for i := 1; i <= n; i++ {
+			if best[i] < best[i-1] {
+				best[i] = best[i-1]
 			}
 		}
 		for k := 1; k <= n; k++ {
 			if k > 1 {
-				out.WriteByte(' ')
+				fmt.Fprint(out, " ")
 			}
-			fmt.Fprint(out, n-dp[1][k])
+			fmt.Fprint(out, n-best[k])
 		}
 		fmt.Fprintln(out)
 	}


### PR DESCRIPTION
## Summary
- replace incorrect 1839D reference solution with exact subset enumeration algorithm
- ensure verifier produces correct answers for all k

## Testing
- `go build 1000-1999/1800-1899/1830-1839/1839/1839D.go`
- `go run 1000-1999/1800-1899/1830-1839/1839/verifierD.go /tmp/candidate.bin`


------
https://chatgpt.com/codex/tasks/task_e_6899fe17ecf88324ba2e917ba36c6d0d