### PR TITLE
Fix 838E verifier to allow float tolerance

### DIFF
--- a/0-999/800-899/830-839/838/verifierE.go
+++ b/0-999/800-899/830-839/838/verifierE.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -54,7 +55,12 @@ func runCase(exe, ref, input string) error {
 		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
 	}
 	got := strings.TrimSpace(out.String())
-	if got != expected {
+	expVal, err1 := strconv.ParseFloat(expected, 64)
+	gotVal, err2 := strconv.ParseFloat(got, 64)
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("parsing error: expected=%v got=%v", err1, err2)
+	}
+	if math.Abs(expVal-gotVal) > 1e-9 {
 		return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Allow numeric comparison with tolerance in verifier for problem 838E

## Testing
- `go build 0-999/800-899/830-839/838/verifierE.go`
- `(cd 0-999/800-899/830-839/838 && go run verifierE.go /tmp/refCandidate)`

------
https://chatgpt.com/codex/tasks/task_e_689a291211748324b1ae4cc501cc7e84