### PR TITLE
Fix 601C verifier float comparison

### DIFF
--- a/0-999/600-699/600-609/601/verifierC.go
+++ b/0-999/600-699/600-609/601/verifierC.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -70,7 +72,13 @@ func runCase(bin, ref string, c Case) error {
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+	e, err1 := strconv.ParseFloat(strings.TrimSpace(expected), 64)
+	g, err2 := strconv.ParseFloat(strings.TrimSpace(got), 64)
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("failed to parse output: expected %s got %s", expected, got)
+	}
+	const eps = 1e-6
+	if math.Abs(e-g) > eps {
 		return fmt.Errorf("expected %s got %s", expected, got)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- handle floating point outputs with a tolerance when verifying 601C

## Testing
- `go build 0-999/600-699/600-609/601/verifierC.go`
- `./verifierC 601C.go`

------
https://chatgpt.com/codex/tasks/task_e_689b168c7a108324a06565a148ee1ec3