### PR TITLE
Fix oracle execution path in 1183G verifier

### DIFF
--- a/1000-1999/1100-1199/1180-1189/1183/verifierG.go
+++ b/1000-1999/1100-1199/1180-1189/1183/verifierG.go
@@ -11,8 +11,8 @@ import (
 )
 
 func buildOracle() (string, error) {
-	oracle := "oracleG"
-	cmd := exec.Command("go", "build", "-o", oracle, "1183G.go")
+        oracle := "./oracleG"
+        cmd := exec.Command("go", "build", "-o", oracle, "1183G.go")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
 	}


### PR DESCRIPTION
## Summary
- ensure 1183G verifier builds oracle binary with a relative path so the executable can be found

## Testing
- `go vet 1000-1999/1100-1199/1180-1189/1183/verifierG.go`
- `go build 1000-1999/1100-1199/1180-1189/1183/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_689c3340c2f4832490f8151dd86ce320