### PR TITLE
Fix 543B verifier extra edge generation

### DIFF
--- a/0-999/500-599/540-549/543/verifierB.go
+++ b/0-999/500-599/540-549/543/verifierB.go
@@ -84,7 +84,11 @@ func genTestB() (string, int) {
 		p := rand.Intn(i)
 		edges = append(edges, pair{i, p})
 	}
-	extra := rand.Intn(n)
+	// at this point graph has n-1 edges (tree). the maximum number of
+	// additional edges we can add without duplicates is the number of
+	// edges in a complete graph minus the existing n-1 edges
+	maxExtra := n*(n-1)/2 - (n - 1)
+	extra := rand.Intn(maxExtra + 1)
 	edgeSet := map[pair]bool{}
 	for _, e := range edges {
 		if e.a > e.b {


### PR DESCRIPTION
## Summary
- prevent infinite loop in 543B verifier by limiting randomly generated extra edges to maximum possible

## Testing
- `go build -o verifierB 0-999/500-599/540-549/543/verifierB.go`
- `./verifierB 0-999/500-599/540-549/543/sol`


------
https://chatgpt.com/codex/tasks/task_e_689c35250ac88324a6dbcdfc6a0d8a7f