### PR TITLE
Fix 593C verifier to allow missing trailing newline

### DIFF
--- a/0-999/500-599/590-599/593/verifierC.go
+++ b/0-999/500-599/590-599/593/verifierC.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -164,17 +165,21 @@ func main() {
 		}
 		outReader := bufio.NewReader(bytes.NewReader(out))
 		fLine, err := outReader.ReadString('\n')
-		if err != nil {
+		if err != nil && err != io.EOF {
 			fmt.Printf("missing output for test %d\n", idx+1)
 			os.Exit(1)
 		}
 		gLine, err := outReader.ReadString('\n')
-		if err != nil {
+		if err != nil && err != io.EOF {
 			fmt.Printf("missing output for test %d\n", idx+1)
 			os.Exit(1)
 		}
 		fLine = strings.TrimSpace(fLine)
 		gLine = strings.TrimSpace(gLine)
+		if fLine == "" || gLine == "" {
+			fmt.Printf("missing output for test %d\n", idx+1)
+			os.Exit(1)
+		}
 		fExpr, err := parseExpr(fLine)
 		if err != nil {
 			fmt.Printf("invalid function f in test %d: %v\n", idx+1, err)


### PR DESCRIPTION
## Summary
- handle EOF when reading competitor output so final line missing newline is accepted
- ensure output lines are non-empty and add required io import

## Testing
- `GO111MODULE=off go vet verifierC.go`
- `GO111MODULE=off go build verifierC.go`
- `GO111MODULE=off go run verifierC.go ./user_sol`


------
https://chatgpt.com/codex/tasks/task_e_689c56cff4e08324b3d29720cd0c29c9