### PR TITLE
Fix verifier for 1737E by implementing correct oracle

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1737/1737E.go
+++ b/1000-1999/1700-1799/1730-1739/1737/1737E.go
@@ -6,49 +6,48 @@ import (
 	"os"
 )
 
-// TODO: implement the correct solution for problem E.
-// This placeholder outputs 0 for the first ant and assumes the rest have equal
-// probability to survive.
-
 const mod int64 = 1_000_000_007
+const iv2 int64 = (mod + 1) / 2
+const maxN = 1_000_007
+
+var pw2 [maxN]int64
+
+func solve(n int, out *bufio.Writer) {
+	r := make([]int64, n+2)
+
+	r[n] = pw2[(n-1)/2]
+
+	i := n - 1
+	for ; i > n-i; i-- {
+		r[i] = pw2[1+(i-1)/2]
+	}
+
+	tot := int64(1)
+	for ; i >= 1; i-- {
+		tot = (tot + mod - r[i*2] + mod - r[i*2+1]) % mod
+		r[i] = pw2[1+(i-1)/2] * tot % mod
+	}
+
+	for j := 1; j <= n; j++ {
+		fmt.Fprintln(out, r[j])
+	}
+}
 
 func main() {
 	in := bufio.NewReader(os.Stdin)
 	out := bufio.NewWriter(os.Stdout)
 	defer out.Flush()
 
-	var t int
-	if _, err := fmt.Fscan(in, &t); err != nil {
-		return
+	pw2[0] = 1
+	for i := 1; i < maxN; i++ {
+		pw2[i] = pw2[i-1] * iv2 % mod
 	}
 
+	var t int
+	fmt.Fscan(in, &t)
 	for ; t > 0; t-- {
 		var n int
 		fmt.Fscan(in, &n)
-		if n <= 1 {
-			fmt.Fprintln(out, 1)
-			continue
-		}
-		inv := modInv(int64(n - 1))
-		fmt.Fprintln(out, 0)
-		for i := 2; i <= n; i++ {
-			fmt.Fprintln(out, inv)
-		}
+		solve(n, out)
 	}
-}
-
-func modPow(a, b int64) int64 {
-	res := int64(1)
-	for b > 0 {
-		if b&1 == 1 {
-			res = res * a % mod
-		}
-		a = a * a % mod
-		b >>= 1
-	}
-	return res
-}
-
-func modInv(a int64) int64 {
-	return modPow(a%mod, mod-2)
 }


### PR DESCRIPTION
## Summary
- Implement correct oracle solution for problem 1737E, replacing placeholder logic with dynamic programming and inverse powers of two

## Testing
- `go vet 1000-1999/1700-1799/1730-1739/1737/1737E.go`
- `go build 1000-1999/1700-1799/1730-1739/1737/1737E.go`
- `./verifierE 1737E.go` in `1000-1999/1700-1799/1730-1739/1737` directory

------
https://chatgpt.com/codex/tasks/task_e_689c78a9c0908324ba1925f92c9607d0