### PR TITLE
Fix verifier for Codeforces 741C to allow alternative valid outputs

### DIFF
--- a/0-999/700-799/740-749/741/verifierC.go
+++ b/0-999/700-799/740-749/741/verifierC.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"math/rand"
@@ -52,6 +53,60 @@ func run(bin, input string) (string, error) {
 	return strings.TrimSpace(out.String()), nil
 }
 
+func check(input, output string) error {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return fmt.Errorf("invalid input format")
+	}
+	m := 2 * n
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		if _, err := fmt.Fscan(in, &a[i], &b[i]); err != nil {
+			return fmt.Errorf("invalid input format")
+		}
+		a[i]--
+		b[i]--
+	}
+
+	out := bufio.NewReader(strings.NewReader(output))
+	color := make([]int, m)
+	for i := range color {
+		color[i] = -1
+	}
+	for i := 0; i < n; i++ {
+		var ca, cb int
+		if _, err := fmt.Fscan(out, &ca, &cb); err != nil {
+			return fmt.Errorf("invalid output format")
+		}
+		if ca < 1 || ca > 2 || cb < 1 || cb > 2 {
+			return fmt.Errorf("invalid food type")
+		}
+		ca--
+		cb--
+		if ca == cb {
+			return fmt.Errorf("pair %d has same food", i+1)
+		}
+		color[a[i]] = ca
+		color[b[i]] = cb
+	}
+	for i := 0; i < m; i++ {
+		if color[i] == -1 {
+			return fmt.Errorf("seat %d has no food assigned", i+1)
+		}
+	}
+	for i := 0; i < m; i++ {
+		c1 := color[i]
+		c2 := color[(i+1)%m]
+		c3 := color[(i+2)%m]
+		if c1 == c2 && c2 == c3 {
+			return fmt.Errorf("three consecutive chairs starting at %d have same food", i+1)
+		}
+	}
+	return nil
+}
+
 func main() {
 	if len(os.Args) != 2 {
 		fmt.Println("usage: go run verifierC.go /path/to/binary")
@@ -78,8 +133,21 @@ func main() {
 			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
 			os.Exit(1)
 		}
-		if got != exp {
-			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i+1, exp, got)
+		exp = strings.TrimSpace(exp)
+		got = strings.TrimSpace(got)
+		if exp == "-1" {
+			if got != "-1" {
+				fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i+1, exp, got)
+				os.Exit(1)
+			}
+			continue
+		}
+		if got == "-1" {
+			fmt.Printf("case %d failed\nexpected a valid solution but got -1\ninput:\n%s", i+1, in)
+			os.Exit(1)
+		}
+		if err := check(in, got); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%soutput:\n%s\n", i+1, err, in, got)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Summary
- improve verifier for CF 741C to check solution validity instead of comparing with a single oracle output

## Testing
- `go vet 0-999/700-799/740-749/741/verifierC.go`
- `go build 0-999/700-799/740-749/741/verifierC.go`
- `cd codeforces/0-999/700-799/740-749/741 && go build -o candidate 741C.go && go run verifierC.go ./candidate`

------
https://chatgpt.com/codex/tasks/task_e_689c79da5d0c832489bade81539571b3