### PR TITLE
Fix 1572B verifier to match correct algorithm

### DIFF
--- a/1000-1999/1500-1599/1570-1579/1572/1572B.go
+++ b/1000-1999/1500-1599/1570-1579/1572/1572B.go
@@ -1,101 +1,53 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
 func main() {
-   in := bufio.NewReader(os.Stdin)
-   out := bufio.NewWriter(os.Stdout)
-   defer out.Flush()
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
 
-   var t int
-   fmt.Fscan(in, &t)
-   for ; t > 0; t-- {
-       var n int
-       fmt.Fscan(in, &n)
-       a := make([]int, n)
-       for i := 0; i < n; i++ {
-           fmt.Fscan(in, &a[i])
-       }
-       // Check feasibility: total XOR must be 0 and at least one zero
-       totalXor := 0
-       hasZero := false
-       for _, v := range a {
-           totalXor ^= v
-           if v == 0 {
-               hasZero = true
-           }
-       }
-       if totalXor != 0 || !hasZero {
-           fmt.Fprintln(out, "NO")
-           continue
-       }
-       // Prepare counts of ones in each triple
-       cnt := make([]int, n-2)
-       for i := 0; i < n-2; i++ {
-           cnt[i] = a[i] + a[i+1] + a[i+2]
-       }
-       // BFS queue for triples with 1 or 2 ones
-       queue := make([]int, 0, n)
-       inq := make([]bool, n-2)
-       for i := 0; i < n-2; i++ {
-           if cnt[i] == 1 || cnt[i] == 2 {
-               queue = append(queue, i)
-               inq[i] = true
-           }
-       }
-       ops := make([]int, 0, n)
-       head := 0
-       for head < len(queue) && len(ops) <= n {
-           i := queue[head]
-           head++
-           if i < 0 || i >= n-2 {
-               continue
-           }
-           c := cnt[i]
-           if c != 1 && c != 2 {
-               continue
-           }
-           // perform operation at i: set a[i..i+2] = parity
-           p := c & 1
-           ops = append(ops, i+1) // 1-based
-           for j := i; j < i+3; j++ {
-               a[j] = p
-           }
-           // update neighboring counts
-           for k := i - 2; k <= i+2; k++ {
-               if k >= 0 && k < n-2 {
-                   cnt[k] = a[k] + a[k+1] + a[k+2]
-                   if !inq[k] && (cnt[k] == 1 || cnt[k] == 2) {
-                       queue = append(queue, k)
-                       inq[k] = true
-                   }
-               }
-           }
-       }
-       // check all zeros
-       ok := true
-       for _, v := range a {
-           if v != 0 {
-               ok = false
-               break
-           }
-       }
-       if !ok || len(ops) > n {
-           fmt.Fprintln(out, "NO")
-       } else {
-           fmt.Fprintln(out, "YES")
-           fmt.Fprintln(out, len(ops))
-           for idx, v := range ops {
-               if idx > 0 {
-                   fmt.Fprint(out, ' ')
-               }
-               fmt.Fprint(out, v)
-           }
-           fmt.Fprintln(out)
-       }
-   }
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n+1)
+		pos := 0
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(in, &a[i])
+			a[i] ^= a[i-1]
+			if i%2 == 1 && a[i] == 0 {
+				pos = i
+			}
+		}
+		if pos != 0 && a[n] == 0 {
+			fmt.Fprintln(out, "YES")
+			m := n - 1
+			if n != pos {
+				m--
+			}
+			fmt.Fprintln(out, m)
+			for i := pos + 1; i+2 <= n; i += 2 {
+				fmt.Fprint(out, i, " ")
+			}
+			for i := pos; ; {
+				i -= 2
+				if i < 1 {
+					break
+				}
+				fmt.Fprint(out, i, " ")
+			}
+			for i := 1; i+2 <= n; i += 2 {
+				fmt.Fprint(out, i, " ")
+			}
+			fmt.Fprintln(out)
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
 }

--- a/1000-1999/1500-1599/1570-1579/1572/verifierB.go
+++ b/1000-1999/1500-1599/1570-1579/1572/verifierB.go
@@ -48,80 +48,38 @@ func solveB(reader *bufio.Reader) string {
 	for ; T > 0; T-- {
 		var n int
 		fmt.Fscan(reader, &n)
-		a := make([]int, n)
-		for i := 0; i < n; i++ {
+		a := make([]int, n+1)
+		pos := 0
+		for i := 1; i <= n; i++ {
 			fmt.Fscan(reader, &a[i])
-		}
-		totalXor := 0
-		hasZero := false
-		for _, v := range a {
-			totalXor ^= v
-			if v == 0 {
-				hasZero = true
+			a[i] ^= a[i-1]
+			if i%2 == 1 && a[i] == 0 {
+				pos = i
 			}
 		}
-		if totalXor != 0 || !hasZero {
-			out.WriteString("NO\n")
-			continue
-		}
-		cnt := make([]int, n-2)
-		for i := 0; i < n-2; i++ {
-			cnt[i] = a[i] + a[i+1] + a[i+2]
-		}
-		queue := make([]int, 0, n)
-		inq := make([]bool, n-2)
-		for i := 0; i < n-2; i++ {
-			if cnt[i] == 1 || cnt[i] == 2 {
-				queue = append(queue, i)
-				inq[i] = true
-			}
-		}
-		ops := make([]int, 0, n)
-		head := 0
-		for head < len(queue) && len(ops) <= n {
-			i := queue[head]
-			head++
-			if i < 0 || i >= n-2 {
-				continue
-			}
-			c := cnt[i]
-			if c != 1 && c != 2 {
-				continue
-			}
-			p := c & 1
-			ops = append(ops, i+1)
-			for j := i; j < i+3; j++ {
-				a[j] = p
-			}
-			for k := i - 2; k <= i+2; k++ {
-				if k >= 0 && k < n-2 {
-					cnt[k] = a[k] + a[k+1] + a[k+2]
-					if !inq[k] && (cnt[k] == 1 || cnt[k] == 2) {
-						queue = append(queue, k)
-						inq[k] = true
-					}
-				}
-			}
-		}
-		ok := true
-		for _, v := range a {
-			if v != 0 {
-				ok = false
-				break
-			}
-		}
-		if !ok || len(ops) > n {
-			out.WriteString("NO\n")
-		} else {
+		if pos != 0 && a[n] == 0 {
 			out.WriteString("YES\n")
-			out.WriteString(fmt.Sprintln(len(ops)))
-			for i, v := range ops {
-				if i > 0 {
-					out.WriteByte(' ')
+			m := n - 1
+			if n != pos {
+				m--
+			}
+			out.WriteString(fmt.Sprintln(m))
+			for i := pos + 1; i+2 <= n; i += 2 {
+				out.WriteString(fmt.Sprintf("%d ", i))
+			}
+			for i := pos; ; {
+				i -= 2
+				if i < 1 {
+					break
 				}
-				out.WriteString(fmt.Sprint(v))
+				out.WriteString(fmt.Sprintf("%d ", i))
+			}
+			for i := 1; i+2 <= n; i += 2 {
+				out.WriteString(fmt.Sprintf("%d ", i))
 			}
 			out.WriteByte('\n')
+		} else {
+			out.WriteString("NO\n")
 		}
 	}
 	return strings.TrimSpace(out.String())


### PR DESCRIPTION
## Summary
- Replace incorrect BFS approach with prefix-XOR based strategy in 1572B solution
- Align 1572B verifier with the corrected algorithm for reliable checks

## Testing
- `go run 1000-1999/1500-1599/1570-1579/1572/1572B.go < /tmp/test.in`
- `go run 1000-1999/1500-1599/1570-1579/1572/verifierB.go /tmp/sol`


------
https://chatgpt.com/codex/tasks/task_e_689c7bacae90832493757c442729aee6