### PR TITLE
fix: accept any optimal index in 91E verifier

### DIFF
--- a/0-999/0-99/90-99/91/91E.go
+++ b/0-999/0-99/90-99/91/91E.go
@@ -61,10 +61,10 @@ func cmp(i, j int) bool {
 }
 
 func cmp3(x, y, t int) bool {
-	// return true if line x gives a value less than or equal to line y at time t
-	// this mirrors the behaviour of the original solution and ensures that when
-	// two lines produce the same value we advance to the later one in the hull.
-	return a[x]+b[x]*int64(t) <= a[y]+b[y]*int64(t)
+        // return true if line x gives a value strictly less than line y at time t.
+        // When two lines yield the same value we keep the earlier index as the
+        // answer, matching the problem's tie-breaking requirement.
+        return a[x]+b[x]*int64(t) < a[y]+b[y]*int64(t)
 }
 
 func cmps(i, j, k int) bool {

--- a/0-999/0-99/90-99/91/verifierE.go
+++ b/0-999/0-99/90-99/91/verifierE.go
@@ -6,17 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
-
-func buildOracle() (string, error) {
-	exe := "oracleE"
-	cmd := exec.Command("go", "build", "-o", exe, "91E.go")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
-	}
-	return exe, nil
-}
 
 func runProg(bin, input string) (string, error) {
 	cmd := exec.Command(bin)
@@ -31,19 +23,63 @@ func runProg(bin, input string) (string, error) {
 	return strings.TrimSpace(out.String()), nil
 }
 
+func checkCase(lines []string, idx int, bin string) error {
+	input := strings.Join(lines, "\n") + "\n"
+	got, err := runProg(bin, input)
+	if err != nil {
+		return fmt.Errorf("case %d failed: %v", idx, err)
+	}
+	// parse input
+	r := bufio.NewReader(strings.NewReader(input))
+	var n, q int
+	if _, err := fmt.Fscan(r, &n, &q); err != nil {
+		return fmt.Errorf("case %d: %v", idx, err)
+	}
+	a := make([]int64, n)
+	b := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &a[i], &b[i])
+	}
+	L := make([]int, q)
+	R := make([]int, q)
+	T := make([]int64, q)
+	for i := 0; i < q; i++ {
+		fmt.Fscan(r, &L[i], &R[i], &T[i])
+	}
+	// parse candidate output
+	outs := strings.Fields(got)
+	if len(outs) != q {
+		return fmt.Errorf("case %d: expected %d lines of output, got %d", idx, q, len(outs))
+	}
+	for i := 0; i < q; i++ {
+		ans, err := strconv.Atoi(outs[i])
+		if err != nil {
+			return fmt.Errorf("case %d line %d: %v", idx, i+1, err)
+		}
+		if ans < L[i] || ans > R[i] {
+			return fmt.Errorf("case %d line %d: answer %d out of range [%d,%d]", idx, i+1, ans, L[i], R[i])
+		}
+		maxH := a[L[i]-1] + b[L[i]-1]*T[i]
+		for j := L[i]; j <= R[i]; j++ {
+			h := a[j-1] + b[j-1]*T[i]
+			if h > maxH {
+				maxH = h
+			}
+		}
+		candH := a[ans-1] + b[ans-1]*T[i]
+		if candH != maxH {
+			return fmt.Errorf("case %d line %d: answer %d yields height %d, expected %d", idx, i+1, ans, candH, maxH)
+		}
+	}
+	return nil
+}
+
 func main() {
 	if len(os.Args) != 2 {
 		fmt.Println("usage: go run verifierE.go /path/to/binary")
 		os.Exit(1)
 	}
 	bin := os.Args[1]
-	oracle, err := buildOracle()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	defer os.Remove(oracle)
-
 	file, err := os.Open("testcasesE.txt")
 	if err != nil {
 		panic(err)
@@ -52,39 +88,30 @@ func main() {
 	scanner := bufio.NewScanner(file)
 	idx := 0
 	var lines []string
-	process := func() {
-		if len(lines) == 0 {
-			return
-		}
-		idx++
-		input := strings.Join(lines, "\n") + "\n"
-		exp, err := runProg("./"+oracle, input)
-		if err != nil {
-			fmt.Printf("oracle error on case %d: %v\n", idx, err)
-			os.Exit(1)
-		}
-		got, err := runProg(bin, input)
-		if err != nil {
-			fmt.Printf("case %d failed: %v\n", idx, err)
-			os.Exit(1)
-		}
-		if got != exp {
-			fmt.Printf("case %d mismatch\nexpected: %s\n got: %s\n", idx, exp, got)
-			os.Exit(1)
-		}
-	}
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.TrimSpace(line) == "" {
-			process()
-			lines = nil
+			if len(lines) > 0 {
+				idx++
+				if err := checkCase(lines, idx, bin); err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+				lines = nil
+			}
 			continue
 		}
 		lines = append(lines, line)
 	}
+	if len(lines) > 0 {
+		idx++
+		if err := checkCase(lines, idx, bin); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
 	if err := scanner.Err(); err != nil {
 		panic(err)
 	}
-	process()
 	fmt.Printf("All %d tests passed\n", idx)
 }


### PR DESCRIPTION
## Summary
- rewrite 91E verifier to check candidate answers by range and computed height
- allow any index with maximal height to pass verification

## Testing
- `cd 0-999/0-99/90-99/91 && go run verifierE.go ./solE`
- `cd 0-999/0-99/90-99/91 && go run verifierE.go ./candidate`


------
https://chatgpt.com/codex/tasks/task_e_689c803cb11c83248a794643b32ac7f3