### PR TITLE
Fix 1746C verifier to accept multiple valid answers

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1746/verifierC.go
+++ b/1000-1999/1700-1799/1740-1749/1746/verifierC.go
@@ -1,13 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"math/rand"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -17,18 +16,6 @@ func runBinary(bin string, input []byte) (string, error) {
 	cmd.Stdin = bytes.NewReader(input)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
-}
-
-func buildRef() (string, error) {
-	_, cur, _, _ := runtime.Caller(0)
-	dir := filepath.Dir(cur)
-	src := filepath.Join(dir, "1746C.go")
-	refBin := filepath.Join(os.TempDir(), "1746C_ref.bin")
-	cmd := exec.Command("go", "build", "-o", refBin, src)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
-	}
-	return refBin, nil
 }
 
 func genTest() []byte {
@@ -50,6 +37,47 @@ func genTest() []byte {
 	return []byte(sb.String())
 }
 
+func verify(in []byte, out string) error {
+	inReader := bufio.NewReader(bytes.NewReader(in))
+	outReader := bufio.NewReader(strings.NewReader(out))
+	var t int
+	if _, err := fmt.Fscan(inReader, &t); err != nil {
+		return fmt.Errorf("failed to read t: %v", err)
+	}
+	for tc := 1; tc <= t; tc++ {
+		var n int
+		if _, err := fmt.Fscan(inReader, &n); err != nil {
+			return fmt.Errorf("failed to read n: %v", err)
+		}
+		a := make([]int, n)
+		for i := range a {
+			if _, err := fmt.Fscan(inReader, &a[i]); err != nil {
+				return fmt.Errorf("failed to read permutation: %v", err)
+			}
+		}
+		x := make([]int, n)
+		for i := range x {
+			if _, err := fmt.Fscan(outReader, &x[i]); err != nil {
+				return fmt.Errorf("not enough output for test case %d", tc)
+			}
+			if x[i] < 1 || x[i] > n {
+				return fmt.Errorf("x[%d]=%d out of range", i+1, x[i])
+			}
+		}
+		for i := 0; i < n; i++ {
+			for j := x[i] - 1; j < n; j++ {
+				a[j] += i + 1
+			}
+		}
+		for i := 0; i < n-1; i++ {
+			if a[i] > a[i+1] {
+				return fmt.Errorf("array not sorted after operations")
+			}
+		}
+	}
+	return nil
+}
+
 func main() {
 	rand.Seed(time.Now().UnixNano())
 	if len(os.Args) < 2 {
@@ -57,27 +85,15 @@ func main() {
 		return
 	}
 	cand := os.Args[1]
-	ref, err := buildRef()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	defer os.Remove(ref)
-
 	for i := 1; i <= 100; i++ {
 		in := genTest()
-		expected, err := runBinary(ref, in)
-		if err != nil {
-			fmt.Printf("reference failed on test %d: %v\n", i, err)
-			os.Exit(1)
-		}
 		got, err := runBinary(cand, in)
 		if err != nil {
 			fmt.Printf("runtime error on test %d: %v\n", i, err)
 			os.Exit(1)
 		}
-		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
-			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+		if err := verify(in, got); err != nil {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sreason: %v\noutput:%s\n", i, string(in), err, got)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Summary
- allow multiple valid outputs for 1746C by simulating suffix operations
- verify candidate output produces nondecreasing array instead of comparing to a reference program

## Testing
- `go run verifierC.go ./candidate`

------
https://chatgpt.com/codex/tasks/task_e_689c96ec77c48324b9378fe829e64088