### PR TITLE
Fix 1931F verifier and reference solution

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1931/1931F.go
+++ b/1000-1999/1900-1999/1930-1939/1931/1931F.go
@@ -11,35 +11,43 @@ func main() {
 	out := bufio.NewWriter(os.Stdout)
 	defer out.Flush()
 
-	var t int
-	fmt.Fscan(in, &t)
-	for ; t > 0; t-- {
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
 		var n, k int
 		fmt.Fscan(in, &n, &k)
-
-		base := make([]int, n)
-		for i := 0; i < n; i++ {
-			fmt.Fscan(in, &base[i])
-		}
-		pos := make([]int, n+1)
-		for i, v := range base {
-			pos[v] = i
-		}
-
-		arr := make([]int, n)
-		ok := true
-		for s := 1; s < k; s++ {
-			for i := 0; i < n; i++ {
-				fmt.Fscan(in, &arr[i])
+		adj := make([][]int, n+1)
+		indeg := make([]int, n+1)
+		for i := 0; i < k; i++ {
+			arr := make([]int, n)
+			for j := 0; j < n; j++ {
+				fmt.Fscan(in, &arr[j])
 			}
-			start := pos[arr[0]]
-			for i := 0; i < n && ok; i++ {
-				if arr[i] != base[(start+i)%n] {
-					ok = false
+			for j := 1; j < n-1; j++ {
+				u, v := arr[j], arr[j+1]
+				adj[u] = append(adj[u], v)
+				indeg[v]++
+			}
+		}
+		q := make([]int, 0, n)
+		for i := 1; i <= n; i++ {
+			if indeg[i] == 0 {
+				q = append(q, i)
+			}
+		}
+		cnt := 0
+		for len(q) > 0 {
+			u := q[0]
+			q = q[1:]
+			cnt++
+			for _, v := range adj[u] {
+				indeg[v]--
+				if indeg[v] == 0 {
+					q = append(q, v)
 				}
 			}
 		}
-		if ok {
+		if cnt == n {
 			fmt.Fprintln(out, "YES")
 		} else {
 			fmt.Fprintln(out, "NO")

--- a/1000-1999/1900-1999/1930-1939/1931/verifierF.go
+++ b/1000-1999/1900-1999/1930-1939/1931/verifierF.go
@@ -74,16 +74,15 @@ func genCase(r *rand.Rand) string {
 		}
 
 		for idx, a := range authors {
-			start := 0
-			for i, v := range base {
-				if v == a {
-					start = i
-					break
-				}
-			}
 			arr := make([]int, n)
-			for i := 0; i < n; i++ {
-				arr[i] = base[(start+i)%n]
+			arr[0] = a
+			pos := 1
+			for _, v := range base {
+				if v == a {
+					continue
+				}
+				arr[pos] = v
+				pos++
 			}
 			if idx == bad {
 				i := 1 + r.Intn(n-1)


### PR DESCRIPTION
## Summary
- Generate screenshots by placing the author first and keeping remaining participants in activity order
- Rewrite 1931F reference to validate screenshot sets via topological sort

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1931/1931F.go`
- `go build 1000-1999/1900-1999/1930-1939/1931/verifierF.go`
- `go run 1000-1999/1900-1999/1930-1939/1931/verifierF.go ./candidate`


------
https://chatgpt.com/codex/tasks/task_e_689da4dbe980832484766b9ffb372ada