### PR TITLE
Fix 1006D verifier logic

### DIFF
--- a/1000-1999/1000-1099/1000-1009/1006/1006D.go
+++ b/1000-1999/1000-1099/1000-1009/1006/1006D.go
@@ -1,66 +1,61 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
-// get returns the minimum number of changes to make the four characters
-// form a palindrome under 180-degree rotation of the 2x2 block.
+// get returns the minimum number of changes required to make the four
+// characters form two equal pairs. Only the first and third characters
+// (belonging to the first string) may be changed.
 func get(a, b, c, d byte) int {
-   // frequency map of the four bytes
-   var cnt [256]int
-   cnt[a]++
-   cnt[b]++
-   cnt[c]++
-   cnt[d]++
-   // collect non-zero frequencies
-   freqs := make([]int, 0, 4)
-   for _, ch := range []byte{a, b, c, d} {
-       if f := cnt[ch]; f > 0 {
-           freqs = append(freqs, f)
-           cnt[ch] = 0 // avoid duplicates in freqs
-       }
-   }
-   distinct := len(freqs)
-   switch distinct {
-   case 1:
-       return 0
-   case 2:
-       // two cases: (2,2) => 0, (3,1) or (1,3) => 1
-       if freqs[0] == 2 && freqs[1] == 2 {
-           return 0
-       }
-       return 1
-   case 3:
-       return 1
-   case 4:
-       return 2
-   }
-   return 0
+	if b == d {
+		if a == c {
+			return 0
+		}
+		return 1
+	}
+	cost1 := 0
+	if a != b {
+		cost1++
+	}
+	if c != d {
+		cost1++
+	}
+	cost2 := 0
+	if a != d {
+		cost2++
+	}
+	if c != b {
+		cost2++
+	}
+	if cost1 < cost2 {
+		return cost1
+	}
+	return cost2
 }
 
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   var n int
-   // read n and two strings
-   fmt.Fscan(reader, &n)
-   s0 := make([]byte, 0, n)
-   s1 := make([]byte, 0, n)
-   // scan strings
-   var str0, str1 string
-   fmt.Fscan(reader, &str0, &str1)
-   s0 = []byte(str0)
-   s1 = []byte(str1)
-   ans := 0
-   // process pairs
-   for i := 0; i < n/2; i++ {
-       ans += get(s0[i], s1[i], s0[n-i-1], s1[n-i-1])
-   }
-   // middle column if odd
-   if n%2 == 1 && s0[n/2] != s1[n/2] {
-       ans++
-   }
-   fmt.Println(ans)
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	// read n and two strings
+	fmt.Fscan(reader, &n)
+	s0 := make([]byte, 0, n)
+	s1 := make([]byte, 0, n)
+	// scan strings
+	var str0, str1 string
+	fmt.Fscan(reader, &str0, &str1)
+	s0 = []byte(str0)
+	s1 = []byte(str1)
+	ans := 0
+	// process pairs
+	for i := 0; i < n/2; i++ {
+		ans += get(s0[i], s1[i], s0[n-i-1], s1[n-i-1])
+	}
+	// middle column if odd
+	if n%2 == 1 && s0[n/2] != s1[n/2] {
+		ans++
+	}
+	fmt.Println(ans)
 }

--- a/1000-1999/1000-1099/1000-1009/1006/verifierD.go
+++ b/1000-1999/1000-1099/1000-1009/1006/verifierD.go
@@ -28,33 +28,40 @@ func run(bin, input string) (string, error) {
 	return strings.TrimSpace(out.String()), nil
 }
 
+// get returns the minimum number of changes required to make the
+// four characters form two equal pairs. Only the first and third
+// characters (originally from string "a") can be changed.
 func get(a, b, c, d byte) int {
-	var cnt [256]int
-	cnt[a]++
-	cnt[b]++
-	cnt[c]++
-	cnt[d]++
-	freqs := make([]int, 0, 4)
-	for _, ch := range []byte{a, b, c, d} {
-		if f := cnt[ch]; f > 0 {
-			freqs = append(freqs, f)
-			cnt[ch] = 0
-		}
-	}
-	switch len(freqs) {
-	case 1:
-		return 0
-	case 2:
-		if freqs[0] == 2 && freqs[1] == 2 {
+	// If the characters from string "b" are the same, we only need to
+	// ensure the characters from string "a" match each other.
+	if b == d {
+		if a == c {
 			return 0
 		}
 		return 1
-	case 3:
-		return 1
-	case 4:
-		return 2
 	}
-	return 0
+	// Otherwise the characters of string "b" are different, so the final
+	// configuration must contain both b and d once in each string. We can
+	// choose which position gets which letter and minimise the number of
+	// modifications in "a".
+	cost1 := 0
+	if a != b {
+		cost1++
+	}
+	if c != d {
+		cost1++
+	}
+	cost2 := 0
+	if a != d {
+		cost2++
+	}
+	if c != b {
+		cost2++
+	}
+	if cost1 < cost2 {
+		return cost1
+	}
+	return cost2
 }
 
 func solve(s0, s1 string) int {


### PR DESCRIPTION
## Summary
- Correct minimum-change calculation for 1006D pairs.
- Update 1006D solver and verifier with new matching logic.

## Testing
- `go build 1000-1999/1000-1099/1000-1009/1006/1006D.go`
- `go build 1000-1999/1000-1099/1000-1009/1006/verifierD.go`
- `./1000-1999/1000-1099/1000-1009/1006/verifierD 1000-1999/1000-1099/1000-1009/1006/1006D.go`


------
https://chatgpt.com/codex/tasks/task_e_689da59a0fe483249fd7ea8de617de7f