### PR TITLE
Fix oracle path in 475C verifier

### DIFF
--- a/0-999/400-499/470-479/475/verifierC.go
+++ b/0-999/400-499/470-479/475/verifierC.go
@@ -78,7 +78,7 @@ func main() {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < 100; i++ {
 		input := generateCase(rng)
-		exp, err := runProg("./"+oracle, input)
+		exp, err := runProg(oracle, input)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
 			os.Exit(1)


### PR DESCRIPTION
## Summary
- fix 475C verifier failing to locate oracle by executing built binary directly

## Testing
- `go build 0-999/400-499/470-479/475/verifierC.go`
- `go run 0-999/400-499/470-479/475/verifierC.go /tmp/475C`


------
https://chatgpt.com/codex/tasks/task_e_689dacf2f7fc83249f7c7767bd857355