### PR TITLE
fix: correct 475C oracle

### DIFF
--- a/0-999/400-499/470-479/475/475C.go
+++ b/0-999/400-499/470-479/475/475C.go
@@ -1,194 +1,116 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   var n, m int
-   if _, err := fmt.Fscan(reader, &n, &m); err != nil {
-       return
-   }
-   grid := make([][]byte, n)
-   for i := 0; i < n; i++ {
-       line := make([]byte, m)
-       fmt.Fscan(reader, &line)
-       grid[i] = line
-   }
-   // row segments
-   rowL := make([]int, n)
-   rowR := make([]int, n)
-   for i := 0; i < n; i++ {
-       rowL[i] = m
-       rowR[i] = -1
-       for j := 0; j < m; j++ {
-           if grid[i][j] == 'X' {
-               if j < rowL[i] {
-                   rowL[i] = j
-               }
-               if j > rowR[i] {
-                   rowR[i] = j
-               }
-           }
-       }
-   }
-   // find first/last row with X
-   firstRow, lastRow := -1, -1
-   for i := 0; i < n; i++ {
-       if rowR[i] >= 0 {
-           if firstRow < 0 {
-               firstRow = i
-           }
-           lastRow = i
-       }
-   }
-   // check no empty row inside
-   for i := firstRow; i <= lastRow; i++ {
-       if rowR[i] < 0 {
-           fmt.Println(-1)
-           return
-       }
-       // contiguous check
-       if rowR[i]-rowL[i]+1 != count(grid[i], 'X') {
-           fmt.Println(-1)
-           return
-       }
-   }
-   // minimal width y
-   y := m
-   for i := firstRow; i <= lastRow; i++ {
-       w := rowR[i] - rowL[i] + 1
-       if w < y {
-           y = w
-       }
-   }
-   // column segments
-   colL := make([]int, m)
-   colR := make([]int, m)
-   for j := 0; j < m; j++ {
-       colL[j] = n
-       colR[j] = -1
-       for i := 0; i < n; i++ {
-           if grid[i][j] == 'X' {
-               if i < colL[j] {
-                   colL[j] = i
-               }
-               if i > colR[j] {
-                   colR[j] = i
-               }
-           }
-       }
-   }
-   firstCol, lastCol := -1, -1
-   for j := 0; j < m; j++ {
-       if colR[j] >= 0 {
-           if firstCol < 0 {
-               firstCol = j
-           }
-           lastCol = j
-       }
-   }
-   for j := firstCol; j <= lastCol; j++ {
-       if colR[j] < 0 {
-           fmt.Println(-1)
-           return
-       }
-       // contiguous in column
-       if colR[j]-colL[j]+1 != countCol(grid, j, 'X') {
-           fmt.Println(-1)
-           return
-       }
-   }
-   // minimal height x
-   x := n
-   for j := firstCol; j <= lastCol; j++ {
-       h := colR[j] - colL[j] + 1
-       if h < x {
-           x = h
-       }
-   }
-   // prefix sum of grid
-   sum := make([][]int, n+1)
-   for i := range sum {
-       sum[i] = make([]int, m+1)
-   }
-   for i := 0; i < n; i++ {
-       for j := 0; j < m; j++ {
-           sum[i+1][j+1] = sum[i+1][j] + sum[i][j+1] - sum[i][j]
-           if grid[i][j] == 'X' {
-               sum[i+1][j+1]++
-           }
-       }
-   }
-   // erosion: find all brush top-left positions
-   A := make([][]bool, n)
-   for i := range A {
-       A[i] = make([]bool, m)
-   }
-   for i := 0; i+x <= n; i++ {
-       for j := 0; j+y <= m; j++ {
-           total := sum[i+x][j+y] - sum[i][j+y] - sum[i+x][j] + sum[i][j]
-           if total == x*y {
-               A[i][j] = true
-           }
-       }
-   }
-   // dilation via diff
-   diff := make([][]int, n+1)
-   for i := range diff {
-       diff[i] = make([]int, m+1)
-   }
-   for i := 0; i+x <= n; i++ {
-       for j := 0; j+y <= m; j++ {
-           if A[i][j] {
-               diff[i][j]++
-               diff[i+x][j]--
-               diff[i][j+y]--
-               diff[i+x][j+y]++
-           }
-       }
-   }
-   // prefix diff to cover
-   for i := 0; i < n; i++ {
-       for j := 0; j < m; j++ {
-           if i > 0 {
-               diff[i][j] += diff[i-1][j]
-           }
-           if j > 0 {
-               diff[i][j] += diff[i][j-1]
-           }
-           if i > 0 && j > 0 {
-               diff[i][j] -= diff[i-1][j-1]
-           }
-           // check coverage
-           if (grid[i][j] == 'X') != (diff[i][j] > 0) {
-               fmt.Println(-1)
-               return
-           }
-       }
-   }
-   fmt.Println(x * y)
-}
-
-func count(arr []byte, c byte) int {
-   cnt := 0
-   for _, v := range arr {
-       if v == c {
-           cnt++
-       }
-   }
-   return cnt
-}
-
-func countCol(grid [][]byte, col int, c byte) int {
-   cnt := 0
-   for i := range grid {
-       if grid[i][col] == c {
-           cnt++
-       }
-   }
-   return cnt
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]byte, m)
+		fmt.Fscan(in, &grid[i])
+	}
+	sum := make([][]int, n+2)
+	for i := range sum {
+		sum[i] = make([]int, m+2)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			val := 0
+			if grid[i][j] == 'X' {
+				val = 1
+			}
+			sum[i][j] = val + sum[i+1][j] + sum[i][j+1] - sum[i+1][j+1]
+		}
+	}
+	total := sum[0][0]
+	x, y := -1, -1
+	for i := 0; i < n && x == -1; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 'X' {
+				x, y = i, j
+				break
+			}
+		}
+	}
+	if x == -1 {
+		fmt.Println(0)
+		return
+	}
+	ans := n*m + 1
+	b := 0
+	for y+b < m && grid[x][y+b] == 'X' {
+		b++
+	}
+	for a := 1; x+a <= n && grid[x+a-1][y] == 'X'; a++ {
+		calc := func(i, j int) int {
+			return sum[i][j] - sum[i+a][j] - sum[i][j+b] + sum[i+a][j+b]
+		}
+		check := func(i, j int) int {
+			res := 0
+			for {
+				if calc(i+1, j) == a*b {
+					res += b
+					i++
+				} else if calc(i, j+1) == a*b {
+					res += a
+					j++
+				} else {
+					res += calc(i, j)
+					break
+				}
+			}
+			return res
+		}
+		if check(x, y) == total {
+			area := a * b
+			if area < ans {
+				ans = area
+			}
+			break
+		}
+	}
+	a := 0
+	for x+a < n && grid[x+a][y] == 'X' {
+		a++
+	}
+	for bb := 1; y+bb <= m && grid[x][y+bb-1] == 'X'; bb++ {
+		calc := func(i, j int) int {
+			return sum[i][j] - sum[i+a][j] - sum[i][j+bb] + sum[i+a][j+bb]
+		}
+		check := func(i, j int) int {
+			res := 0
+			for {
+				if calc(i+1, j) == a*bb {
+					res += bb
+					i++
+				} else if calc(i, j+1) == a*bb {
+					res += a
+					j++
+				} else {
+					res += calc(i, j)
+					break
+				}
+			}
+			return res
+		}
+		if check(x, y) == total {
+			area := a * bb
+			if area < ans {
+				ans = area
+			}
+		}
+	}
+	if ans == n*m+1 {
+		fmt.Println(-1)
+	} else {
+		fmt.Println(ans)
+	}
 }


### PR DESCRIPTION
## Summary
- replace incorrect oracle for problem 475C with algorithm that searches brush dimensions using prefix sums

## Testing
- `go vet 0-999/400-499/470-479/475/475C.go`
- `go build 0-999/400-499/470-479/475/475C.go`
- `go run 0-999/400-499/470-479/475/verifierC.go ./candidate`

------
https://chatgpt.com/codex/tasks/task_e_689dae7b70488324b8545303192d28b1