### PR TITLE
Make 1067B verifier case-insensitive

### DIFF
--- a/1000-1999/1000-1099/1060-1069/1067/verifierB.go
+++ b/1000-1999/1000-1099/1060-1069/1067/verifierB.go
@@ -83,7 +83,7 @@ func main() {
 			fmt.Printf("candidate runtime error on test %d: %v\n", caseNum+1, err)
 			os.Exit(1)
 		}
-		if want != got {
+		if !strings.EqualFold(want, got) {
 			fmt.Printf("test %d failed\nexpected: %s\ngot: %s\n", caseNum+1, want, got)
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary
- Allow `verifierB` for problem 1067B to compare outputs ignoring case differences.

## Testing
- `go build 1000-1999/1000-1099/1060-1069/1067/verifierB.go`


------
https://chatgpt.com/codex/tasks/task_e_689daf31f2c08324937b690342f76838