### PR TITLE
fix: allow any order in 1325D verifier

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1325/verifierD.go
+++ b/1000-1999/1300-1399/1320-1329/1325/verifierD.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -55,16 +56,35 @@ func verifyCase(bin string, u, v int64) error {
 	}
 	fields := strings.Fields(out)
 	expected := solveD(u, v)
-	if int64(len(fields)) != int64(len(expected)) {
+	if len(fields) != len(expected) {
 		return fmt.Errorf("expected %d numbers got %d", len(expected), len(fields))
 	}
+
+	got := make([]int64, len(fields))
 	for i, f := range fields {
-		got, err := strconv.ParseInt(f, 10, 64)
+		v, err := strconv.ParseInt(f, 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid number %q", f)
 		}
-		if got != expected[i] {
-			return fmt.Errorf("expected %v got %v", expected, fields)
+		got[i] = v
+	}
+
+	if len(got) == 1 {
+		if got[0] != expected[0] {
+			return fmt.Errorf("expected %v got %v", expected, got)
+		}
+		return nil
+	}
+
+	if got[0] != expected[0] {
+		return fmt.Errorf("expected %v got %v", expected, got)
+	}
+
+	sort.Slice(got[1:], func(i, j int) bool { return got[i+1] < got[j+1] })
+	sort.Slice(expected[1:], func(i, j int) bool { return expected[i+1] < expected[j+1] })
+	for i := 1; i < len(expected); i++ {
+		if got[i] != expected[i] {
+			return fmt.Errorf("expected %v got %v", expected, got)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- accept any permutation of numbers in 1325D verifier by sorting actual and expected outputs before comparison

## Testing
- `go vet 1000-1999/1300-1399/1320-1329/1325/verifierD.go`
- `go build 1000-1999/1300-1399/1320-1329/1325/verifierD.go`
- `/tmp/verifier 1000-1999/1300-1399/1320-1329/1325/1325D.go`


------
https://chatgpt.com/codex/tasks/task_e_689db9949a4c8324b426ac806c215bd2