### PR TITLE
Handle output case in 1379A verifier

### DIFF
--- a/1000-1999/1300-1399/1370-1379/1379/verifierA.go
+++ b/1000-1999/1300-1399/1370-1379/1379/verifierA.go
@@ -70,7 +70,7 @@ func runCase(bin, ref string, c Case) error {
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(got) != expect {
+	if !strings.EqualFold(strings.TrimSpace(got), expect) {
 		return fmt.Errorf("expected %q got %q", expect, got)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- make the 1379A verifier compare outputs case-insensitively so `Yes`/`No` responses pass

## Testing
- `go run verifierA.go /tmp/tmp1379`

------
https://chatgpt.com/codex/tasks/task_e_689dc1401c84832492b3167eab0c1402