### PR TITLE
Fix oracle path in 753A verifier

### DIFF
--- a/0-999/700-799/750-759/753/verifierA.go
+++ b/0-999/700-799/750-759/753/verifierA.go
@@ -55,7 +55,7 @@ func main() {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < 100; i++ {
 		input := generateCase(rng)
-		exp, err := runProg("./"+oracle, input)
+		exp, err := runProg(oracle, input)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:%s", i+1, err, input)
 			os.Exit(1)


### PR DESCRIPTION
## Summary
- avoid prefixing oracle path with `./` so the built oracle can be executed

## Testing
- `go vet verifierA.go`
- `go run verifierA.go ./candidate_go`


------
https://chatgpt.com/codex/tasks/task_e_689dc47fcff48324952e281e9c461a09