### PR TITLE
Fix verifierB to run reference binary using relative path

### DIFF
--- a/0-999/900-999/990-999/999/verifierB.go
+++ b/0-999/900-999/990-999/999/verifierB.go
@@ -11,7 +11,7 @@ import (
 )
 
 func buildRef() (string, error) {
-	ref := "refB.bin"
+	ref := "./refB.bin"
 	cmd := exec.Command("go", "build", "-o", ref, "999B.go")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)


### PR DESCRIPTION
## Summary
- ensure verifier builds and executes the reference solution via `./refB.bin`

## Testing
- `go build 0-999/900-999/990-999/999/verifierB.go`
- `go run verifierB.go ./sol`


------
https://chatgpt.com/codex/tasks/task_e_689dc62a15fc8324a24e317217829951