### PR TITLE
Fix 753A verifier to allow alternative valid outputs

### DIFF
--- a/0-999/700-799/750-759/753/verifierA.go
+++ b/0-999/700-799/750-759/753/verifierA.go
@@ -3,29 +3,16 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 )
 
-func buildOracle() (string, error) {
-	_, file, _, _ := runtime.Caller(0)
-	dir := filepath.Dir(file)
-	exe := filepath.Join(dir, "oracleA")
-	cmd := exec.Command("go", "build", "-o", exe, filepath.Join(dir, "753A.go"))
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
-	}
-	return exe, nil
-}
-
-func generateCase(rng *rand.Rand) string {
-	n := rng.Intn(1000) + 1
-	return fmt.Sprintf("%d\n", n)
+func generateCase(rng *rand.Rand) int {
+	return rng.Intn(1000) + 1
 }
 
 func runProg(exe, input string) (string, error) {
@@ -40,33 +27,73 @@ func runProg(exe, input string) (string, error) {
 	return strings.TrimSpace(out.String()), nil
 }
 
+func maxK(n int) int {
+	k := 0
+	for (k+1)*(k+2)/2 <= n {
+		k++
+	}
+	return k
+}
+
+func checkOutput(n int, out string, kExpected int) error {
+	r := strings.NewReader(out)
+	var k int
+	if _, err := fmt.Fscan(r, &k); err != nil {
+		return fmt.Errorf("failed to read k: %v", err)
+	}
+	var nums []int
+	for {
+		var x int
+		_, err := fmt.Fscan(r, &x)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("invalid number: %v", err)
+		}
+		nums = append(nums, x)
+	}
+	if len(nums) != k {
+		return fmt.Errorf("expected %d numbers, got %d", k, len(nums))
+	}
+	if k != kExpected {
+		return fmt.Errorf("expected k=%d, got %d", kExpected, k)
+	}
+	sum := 0
+	seen := make(map[int]bool)
+	for _, v := range nums {
+		if v <= 0 {
+			return fmt.Errorf("non-positive number %d", v)
+		}
+		if seen[v] {
+			return fmt.Errorf("number %d repeated", v)
+		}
+		seen[v] = true
+		sum += v
+	}
+	if sum != n {
+		return fmt.Errorf("sum mismatch: expected %d, got %d", n, sum)
+	}
+	return nil
+}
+
 func main() {
 	if len(os.Args) != 2 {
 		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
 		os.Exit(1)
 	}
 	candidate := os.Args[1]
-	oracle, err := buildOracle()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	defer os.Remove(oracle)
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < 100; i++ {
-		input := generateCase(rng)
-		exp, err := runProg(oracle, input)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:%s", i+1, err, input)
-			os.Exit(1)
-		}
+		n := generateCase(rng)
+		input := fmt.Sprintf("%d\n", n)
 		got, err := runProg(candidate, input)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
 			os.Exit(1)
 		}
-		if got != exp {
-			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\n got:\n%s\ninput:%s", i+1, exp, got, input)
+		if err := checkOutput(n, got, maxK(n)); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Summary
- Replace strict oracle comparison with validation logic that checks distinctness, sum and optimal `k`
- Compute expected `k` directly and verify candidate outputs match it

## Testing
- `go vet 0-999/700-799/750-759/753/verifierA.go`
- `go run 0-999/700-799/750-759/753/verifierA.go /tmp/user`


------
https://chatgpt.com/codex/tasks/task_e_689dc656d85c832488480dd51ea0f0a6