### PR TITLE
Fix unused variable in 120C verifier

### DIFF
--- a/0-999/100-199/120-129/120/verifierC.go
+++ b/0-999/100-199/120-129/120/verifierC.go
@@ -95,7 +95,7 @@ func main() {
 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for t := 0; t < 100; t++ {
-		input, expect := generateCase(rng)
+		input, _ := generateCase(rng)
 		candOut, cErr := runBinary(candidate, input)
 		refOut, rErr := runBinary(ref, input)
 		if cErr != nil {


### PR DESCRIPTION
## Summary
- prevent unused variable error in 120C verifier by discarding second return value from `generateCase`

## Testing
- `go build -o /tmp/verifierc 0-999/100-199/120-129/120/verifierC.go`


------
https://chatgpt.com/codex/tasks/task_e_689dd97c40108324b41a157e3e1638c5