### PR TITLE
Fix verifier for 243D reference path

### DIFF
--- a/0-999/200-299/240-249/243/243D.go
+++ b/0-999/200-299/240-249/243/243D.go
@@ -1,63 +1,144 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
-   "sort"
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
 )
 
-type entry struct {
-   c, t int64
-   h    int64
+// record represents a tower projected onto the plane orthogonal to the
+// viewing direction. The segment [l, r] describes all rays intersecting the
+// unit square of the tower, k is the order of the tower along the viewing
+// direction and h is its height.
+type record struct {
+	k, l, r, h int64
+}
+
+const inf = int64(1e8)
+
+type node struct {
+	s, tag int64
+	lc, rc int
+}
+
+var tree []node
+
+func max(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func ensure(idx *int) {
+	if *idx == 0 {
+		*idx = len(tree)
+		tree = append(tree, node{})
+	}
+}
+
+func change(idx int, l, r, ll, rr, v int64) int {
+	ensure(&idx)
+	nd := &tree[idx]
+	if ll <= l && r <= rr {
+		nd.s = max(nd.s, v)
+		nd.tag = max(nd.tag, v)
+		return idx
+	}
+	mid := (l + r) >> 1
+	if ll <= mid {
+		nd.lc = change(nd.lc, l, mid, ll, rr, v)
+	}
+	if rr > mid {
+		nd.rc = change(nd.rc, mid+1, r, ll, rr, v)
+	}
+	left := int64(0)
+	if nd.lc != 0 {
+		left = tree[nd.lc].s
+	}
+	right := int64(0)
+	if nd.rc != 0 {
+		right = tree[nd.rc].s
+	}
+	nd.s = max(nd.tag, min(left, right))
+	return idx
+}
+
+func query(idx int, l, r, ll, rr int64) int64 {
+	if idx == 0 {
+		return 0
+	}
+	nd := tree[idx]
+	if ll <= l && r <= rr {
+		return nd.s
+	}
+	mid := (l + r) >> 1
+	res := inf * 20
+	if ll <= mid {
+		res = min(res, query(nd.lc, l, mid, ll, rr))
+	}
+	if rr > mid {
+		res = min(res, query(nd.rc, mid+1, r, ll, rr))
+	}
+	return max(res, nd.tag)
+}
+
+func add(records *[]record, i, j int64, vx, vy, h int64) {
+	k := int64(1 << 60)
+	l := int64(1 << 60)
+	r := int64(-1 << 60)
+	for p := i - 1; p <= i; p++ {
+		for q := j - 1; q <= j; q++ {
+			k = min(k, vx*p+vy*q)
+			t := vy*p - vx*q
+			l = min(l, t)
+			r = max(r, t)
+		}
+	}
+	*records = append(*records, record{k: k, l: l, r: r - 1, h: h})
 }
 
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   writer := bufio.NewWriter(os.Stdout)
-   defer writer.Flush()
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
 
-   var n int
-   var vx, vy int64
-   if _, err := fmt.Fscan(reader, &n, &vx, &vy); err != nil {
-       return
-   }
-   total := n * n
-   entries := make([]entry, 0, total)
-   for i := 0; i < n; i++ {
-       for j := 0; j < n; j++ {
-           var h int64
-           fmt.Fscan(reader, &h)
-           // compute line key c and projection t
-           ii := int64(i)
-           jj := int64(j)
-           c := ii*vy - jj*vx
-           t := ii*vx + jj*vy
-           if h > 0 {
-               entries = append(entries, entry{c: c, t: t, h: h})
-           }
-           // zero-height towers have no cubes
-       }
-   }
-   // sort by c asc, then t desc
-   sort.Slice(entries, func(i, j int) bool {
-       if entries[i].c != entries[j].c {
-           return entries[i].c < entries[j].c
-       }
-       return entries[i].t > entries[j].t
-   })
-   var ans int64
-   var curC int64 = 1<<63 - 1
-   var maxH int64
-   for _, e := range entries {
-       if e.c != curC {
-           curC = e.c
-           maxH = 0
-       }
-       if e.h > maxH {
-           ans += e.h - maxH
-           maxH = e.h
-       }
-   }
-   fmt.Fprint(writer, ans)
+	var n int64
+	var vx, vy int64
+	if _, err := fmt.Fscan(reader, &n, &vx, &vy); err != nil {
+		return
+	}
+	records := make([]record, 0, n*n)
+	for i := int64(1); i <= n; i++ {
+		for j := int64(1); j <= n; j++ {
+			var h int64
+			fmt.Fscan(reader, &h)
+			add(&records, i, j, vx, vy, h)
+		}
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].k < records[j].k
+	})
+
+	tree = make([]node, 2, 1<<20) // index 0 unused, 1 is root
+	root := 1
+	var ans int64
+	for _, rec := range records {
+		ll := rec.l + inf
+		rr := rec.r + inf
+		cur := query(root, 1, inf*2, ll, rr)
+		if rec.h > cur {
+			ans += rec.h - cur
+		}
+		root = change(root, 1, inf*2, ll, rr, rec.h)
+	}
+	fmt.Fprint(writer, ans)
 }

--- a/0-999/200-299/240-249/243/verifierD.go
+++ b/0-999/200-299/240-249/243/verifierD.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -27,7 +28,12 @@ func compileRef(src string) (string, error) {
 }
 
 func runBinary(bin, input string) (string, error) {
-	cmd := exec.Command(bin)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
 	cmd.Stdin = strings.NewReader(input)
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -64,7 +70,9 @@ func main() {
 	}
 	candidate, _ := filepath.Abs(os.Args[1])
 	rand.Seed(time.Now().UnixNano())
-	refBin, err := compileRef("243D.go")
+	_, file, _, _ := runtime.Caller(0)
+	refSrc := filepath.Join(filepath.Dir(file), "243D.go")
+	refBin, err := compileRef(refSrc)
 	if err != nil {
 		fmt.Println("failed to compile reference:", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- implement accurate sweep-line reference solver for 243D based on dynamic segment tree

## Testing
- `go build 0-999/200-299/240-249/243/243D.go`
- `go run 0-999/200-299/240-249/243/verifierD.go /tmp/candidate`


------
https://chatgpt.com/codex/tasks/task_e_689decd2f89c8324bd6b4d7d0997eedd