### PR TITLE
Fix oracle path in 1346C verifier

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1346/verifierC.go
+++ b/1000-1999/1300-1399/1340-1349/1346/verifierC.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -16,7 +17,11 @@ func buildOracle() (string, error) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
 	}
-	return oracle, nil
+	abs, err := filepath.Abs(oracle)
+	if err != nil {
+		return "", fmt.Errorf("abs path: %v", err)
+	}
+	return abs, nil
 }
 
 func run(bin, input string) (string, error) {


### PR DESCRIPTION
## Summary
- ensure 1346C verifier uses an absolute path for the oracle binary

## Testing
- `go vet verifierC.go`
- `go build verifierC.go`
- `go run verifierC.go ./solbin`


------
https://chatgpt.com/codex/tasks/task_e_68a0fe54507c8324b3ff7ef23730d1d0