### PR TITLE
Fix verifier failing to execute reference solution for 1252L

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1252/verifierL.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierL.go
@@ -19,6 +19,9 @@ func buildRef() (string, error) {
 }
 
 func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
 	cmd := exec.Command(path)
 	cmd.Stdin = strings.NewReader(input)
 	var out bytes.Buffer


### PR DESCRIPTION
## Summary
- Ensure local binaries are executed with `./` prefix in `verifierL.go`

## Testing
- `go run verifierL.go ./candidate.bin` (inside 1000-1999/1200-1299/1250-1259/1252)


------
https://chatgpt.com/codex/tasks/task_e_68a106e13f5483249473bd820dfff41c