### PR TITLE
Fix 1081D verifier edge generation loop

### DIFF
--- a/1000-1999/1000-1099/1080-1089/1081/verifierD.go
+++ b/1000-1999/1000-1099/1080-1089/1081/verifierD.go
@@ -43,7 +43,8 @@ func run(bin, input string) (string, error) {
 
 func genCase(r *rand.Rand) string {
 	n := r.Intn(6) + 2
-	m := n - 1 + r.Intn(n)
+	maxEdges := n * (n - 1) / 2
+	m := n - 1 + r.Intn(maxEdges-(n-1)+1)
 	k := r.Intn(n-1) + 1
 	// ensure k unique specials
 	specials := make([]int, k)


### PR DESCRIPTION
## Summary
- prevent verifier from generating impossible edge counts in 1081D
- random tests now run to completion without hanging

## Testing
- `go build -o verify ./verifierD.go`
- `./verify 1081D.go`


------
https://chatgpt.com/codex/tasks/task_e_68a1763abbcc832497be92df894e748f