### PR TITLE
fix: ensure 1987D verifier generates in-range values

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1987/verifierD.go
+++ b/1000-1999/1900-1999/1980-1989/1987/verifierD.go
@@ -48,7 +48,7 @@ func generateCase(rng *rand.Rand) (string, int) {
 	n := rng.Intn(6) + 1
 	arr := make([]int, n)
 	for i := range arr {
-		arr[i] = rng.Intn(10) + 1
+		arr[i] = rng.Intn(n) + 1
 	}
 	var sb strings.Builder
 	sb.WriteString("1\n")


### PR DESCRIPTION
## Summary
- constrain generated array values to `[1, n]` in the 1987D verifier to respect problem limits.

## Testing
- `go run 1000-1999/1900-1999/1980-1989/1987/verifierD.go /tmp/1987D_bin`

------
https://chatgpt.com/codex/tasks/task_e_68a177b66cb88324aa96f7bfb4bf4067