### PR TITLE
Fix 1987D verifier and solution

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1987/1987D.go
+++ b/1000-1999/1900-1999/1980-1989/1987/1987D.go
@@ -2,10 +2,50 @@ package main
 
 import (
 	"bufio"
+	"container/heap"
 	"fmt"
 	"os"
-	"sort"
 )
+
+type maxHeap []int
+
+func (h maxHeap) Len() int           { return len(h) }
+func (h maxHeap) Less(i, j int) bool { return h[i] > h[j] }
+func (h maxHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *maxHeap) Push(x interface{}) {
+	*h = append(*h, x.(int))
+}
+func (h *maxHeap) Pop() interface{} {
+	old := *h
+	x := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return x
+}
+
+func solve(a []int) int {
+	n := len(a)
+	freq := make([]int, n+1)
+	for _, v := range a {
+		freq[v]++
+	}
+	h := &maxHeap{}
+	heap.Init(h)
+	s := 0
+	sum := 0
+	for v := 1; v <= n; v++ {
+		f := freq[v]
+		if f > 0 {
+			heap.Push(h, f)
+			sum += f
+			for sum > s {
+				big := heap.Pop(h).(int)
+				sum -= big
+				s++
+			}
+		}
+	}
+	return s
+}
 
 func main() {
 	reader := bufio.NewReader(os.Stdin)
@@ -13,34 +53,14 @@ func main() {
 	defer writer.Flush()
 
 	var t int
-	if _, err := fmt.Fscan(reader, &t); err != nil {
-		return
-	}
+	fmt.Fscan(reader, &t)
 	for ; t > 0; t-- {
 		var n int
 		fmt.Fscan(reader, &n)
 		a := make([]int, n)
-		for i := 0; i < n; i++ {
+		for i := range a {
 			fmt.Fscan(reader, &a[i])
 		}
-		sort.Ints(a)
-		prev := -1
-		left, right := 0, n-1
-		eaten := 0
-		for left <= right {
-			for left <= right && a[left] <= prev {
-				left++
-			}
-			if left > right {
-				break
-			}
-			prev = a[left]
-			left++
-			eaten++
-			if left <= right {
-				right--
-			}
-		}
-		fmt.Fprintln(writer, eaten)
+		fmt.Fprintln(writer, solve(a))
 	}
 }

--- a/1000-1999/1900-1999/1980-1989/1987/verifierD.go
+++ b/1000-1999/1900-1999/1980-1989/1987/verifierD.go
@@ -2,46 +2,53 @@ package main
 
 import (
 	"bytes"
+	"container/heap"
 	"fmt"
 	"math/rand"
 	"os"
 	"os/exec"
-	"sort"
 	"strings"
 	"time"
 )
 
+type maxHeap []int
+
+func (h maxHeap) Len() int           { return len(h) }
+func (h maxHeap) Less(i, j int) bool { return h[i] > h[j] }
+func (h maxHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *maxHeap) Push(x interface{}) {
+	*h = append(*h, x.(int))
+}
+func (h *maxHeap) Pop() interface{} {
+	old := *h
+	x := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return x
+}
+
 func expected(a []int) int {
-	sort.Ints(a)
-	prev := -1
-	left, right := 0, len(a)-1
-	eaten := 0
-	for left <= right {
-		idx := -1
-		for i := left; i <= right; i++ {
-			if a[i] > prev {
-				idx = i
-				break
+	n := len(a)
+	freq := make([]int, n+1)
+	for _, v := range a {
+		freq[v]++
+	}
+	h := &maxHeap{}
+	heap.Init(h)
+	s := 0
+	sum := 0
+	for v := 1; v <= n; v++ {
+		f := freq[v]
+		if f > 0 {
+			heap.Push(h, f)
+			sum += f
+			for sum > s {
+				big := heap.Pop(h).(int)
+				sum -= big
+				s++
 			}
 		}
-		if idx == -1 {
-			break
-		}
-		prev = a[idx]
-		eaten++
-		if idx == left {
-			left++
-		} else if idx == right {
-			right--
-		} else {
-			copy(a[idx:right], a[idx+1:right+1])
-			right--
-		}
-		if left <= right {
-			right--
-		}
 	}
-	return eaten
+	return s
 }
 
 func generateCase(rng *rand.Rand) (string, int) {


### PR DESCRIPTION
## Summary
- Correct 1987D solution using frequency counting with a max-heap
- Align 1987D verifier with optimal play logic using heap-based expected value

## Testing
- `go run 1000-1999/1900-1999/1980-1989/1987/verifierD.go ./1987D`


------
https://chatgpt.com/codex/tasks/task_e_68a179abd120832484dc38beab4b249f