### PR TITLE
fix: allow equivalent 1187C outputs

### DIFF
--- a/1000-1999/1100-1199/1180-1189/1187/verifierC.go
+++ b/1000-1999/1100-1199/1180-1189/1187/verifierC.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -85,10 +86,108 @@ func main() {
 			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
 			os.Exit(1)
 		}
-		if out != exp {
-			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:%s", i+1, exp, out, input)
+		n, _, t, l, r, err := parseInput(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to parse input on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		expAns, _, err := parseOutput(exp, n)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference produced invalid output on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		outAns, arr, err := parseOutput(out, n)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if expAns == "NO" {
+			if outAns != "NO" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected NO, got %s\ninput:%s", i+1, outAns, input)
+				os.Exit(1)
+			}
+			continue
+		}
+		if outAns != "YES" {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected YES, got %s\ninput:%s", i+1, outAns, input)
+			os.Exit(1)
+		}
+		if err := checkConstraints(arr, t, l, r); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
 			os.Exit(1)
 		}
 	}
 	fmt.Println("All tests passed")
+}
+
+func parseInput(input string) (int, int, []int, []int, []int, error) {
+	reader := strings.NewReader(input)
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return 0, 0, nil, nil, nil, err
+	}
+	t := make([]int, m)
+	l := make([]int, m)
+	r := make([]int, m)
+	for i := 0; i < m; i++ {
+		if _, err := fmt.Fscan(reader, &t[i], &l[i], &r[i]); err != nil {
+			return 0, 0, nil, nil, nil, err
+		}
+		l[i]--
+		r[i]--
+	}
+	return n, m, t, l, r, nil
+}
+
+func parseOutput(out string, n int) (string, []int, error) {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return "", nil, fmt.Errorf("empty output")
+	}
+	res := strings.ToUpper(fields[0])
+	if res != "YES" && res != "NO" {
+		return "", nil, fmt.Errorf("first token must be YES or NO")
+	}
+	if res == "NO" {
+		return res, nil, nil
+	}
+	if len(fields) != n+1 {
+		return "", nil, fmt.Errorf("expected %d numbers, got %d", n, len(fields)-1)
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		v, err := strconv.Atoi(fields[i+1])
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid integer: %v", err)
+		}
+		if v < 1 || v > 1_000_000_000 {
+			return "", nil, fmt.Errorf("value out of range")
+		}
+		arr[i] = v
+	}
+	return res, arr, nil
+}
+
+func checkConstraints(a []int, t, l, r []int) error {
+	for i := 0; i < len(t); i++ {
+		if t[i] == 1 {
+			for j := l[i] + 1; j <= r[i]; j++ {
+				if a[j] < a[j-1] {
+					return fmt.Errorf("segment %d expected sorted", i+1)
+				}
+			}
+		} else {
+			ok := false
+			for j := l[i] + 1; j <= r[i]; j++ {
+				if a[j] < a[j-1] {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				return fmt.Errorf("segment %d expected not sorted", i+1)
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- relax 1187C verifier to validate candidate output instead of strict match
- add parsing and constraint checks for candidate arrays

## Testing
- `go build 1000-1999/1100-1199/1180-1189/1187/verifierC.go`
- `(cd 1000-1999/1100-1199/1180-1189/1187 && ../../../../verifierC 1187C.go)`

------
https://chatgpt.com/codex/tasks/task_e_68a17c1313708324a8c4f7924f88b5d8