### PR TITLE
Allow case-insensitive output in 1242C verifier

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1242/verifierC.go
+++ b/1000-1999/1200-1299/1240-1249/1242/verifierC.go
@@ -257,7 +257,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
 			os.Exit(1)
 		}
-		if strings.TrimSpace(out) != exp {
+		if !strings.EqualFold(strings.TrimSpace(out), exp) {
 			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\n got:\n%s\ninput:\n%s", i+1, exp, out, in)
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary
- Ignore case when comparing solver output in 1242C verifier

## Testing
- `go build 1000-1999/1200-1299/1240-1249/1242/verifierC.go`
- `go run 1000-1999/1200-1299/1240-1249/1242/verifierC.go /tmp/const.sh` *(fails at case 2 because the sample script doesn't solve the problem, but case 1 now passes without case-sensitivity issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b14e92488324b1a90f4ad367c298