### PR TITLE
Handle zero lower bound in 628D reference

### DIFF
--- a/0-999/600-699/620-629/628/628D.go
+++ b/0-999/600-699/620-629/628/628D.go
@@ -114,5 +114,14 @@ func main() {
 	if ans < 0 {
 		ans += MOD
 	}
+
+	// handle the case when the lower bound is 0
+	if a == "0" && L == 1 && d != 0 {
+		ans++
+		if ans >= MOD {
+			ans -= MOD
+		}
+	}
+
 	fmt.Fprintln(out, ans)
 }


### PR DESCRIPTION
## Summary
- ensure 0 is counted when range lower bound is 0 for CF 628D reference solution

## Testing
- `go build verifierD.go && ./verifierD 628D.go`

------
https://chatgpt.com/codex/tasks/task_e_68a1b439c75c8324ab8e5698d404e9fa