### PR TITLE
Fix 628D reference handling of zero lower bound

### DIFF
--- a/0-999/600-699/620-629/628/628D.go
+++ b/0-999/600-699/620-629/628/628D.go
@@ -115,13 +115,5 @@ func main() {
 		ans += MOD
 	}
 
-	// handle the case when the lower bound is 0
-	if a == "0" && L == 1 && d != 0 {
-		ans++
-		if ans >= MOD {
-			ans -= MOD
-		}
-	}
-
 	fmt.Fprintln(out, ans)
 }


### PR DESCRIPTION
## Summary
- Remove special-case that counted zero when lower bound is zero in problem 628D reference solution

## Testing
- `go run verifierD.go /tmp/628D_rust`

------
https://chatgpt.com/codex/tasks/task_e_68a1b679cc6083249a41c122e211c6a5