### PR TITLE
Fix 1956E2 verifier to compute expected answers

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1956/verifierE2.go
+++ b/1000-1999/1900-1999/1950-1959/1956/verifierE2.go
@@ -6,12 +6,61 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 )
 
 func solveCase(n int, a []int) string {
-	return "0"
+	b := make([]int, n)
+	copy(b, a)
+	for i := 0; i < 2200; i++ {
+		for j := 0; j < n; j++ {
+			nxt := (j + 1) % n
+			diff := b[nxt] - b[j]
+			if diff < 0 {
+				diff = 0
+			}
+			b[nxt] = diff
+		}
+	}
+	ans := []int{}
+	for i := 0; i < n; i++ {
+		prev := (i - 1 + n) % n
+		if b[prev] != 0 || b[i] == 0 {
+			continue
+		}
+		ans = append(ans, i+1)
+		next := (i + 1) % n
+		next2 := (i + 2) % n
+		if b[next] > 0 && b[next2] > 0 {
+			x := b[i]
+			y := b[next]
+			z := b[next2]
+			xs := y / x
+			if i == n-1 {
+				xs++
+			}
+			delta := y
+			if i != n-1 {
+				delta -= x
+			}
+			delta += y % x
+			if int64(delta)*int64(xs)/2 < int64(z) {
+				ans = append(ans, next+1)
+			}
+		}
+	}
+	sort.Ints(ans)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(ans))
+	if len(ans) > 0 {
+		for _, v := range ans {
+			fmt.Fprintf(&sb, "%d ", v)
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
 }
 
 func genCase(rng *rand.Rand) (string, string) {
@@ -32,9 +81,6 @@ func genCase(rng *rand.Rand) (string, string) {
 		}
 		in.WriteByte('\n')
 		out.WriteString(solveCase(n, a))
-		if i+1 < t {
-			out.WriteByte('\n')
-		}
 	}
 	return in.String(), strings.TrimSpace(out.String())
 }


### PR DESCRIPTION
## Summary
- implement reference solution for 1956E2 verifier to simulate operations and collect answers
- adjust case generator to rely on solver formatting, matching contestant outputs

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1956/verifierE2.go`
- `go run 1000-1999/1900-1999/1950-1959/1956/verifierE2.go /tmp/solE2`
- `go vet 1000-1999/1900-1999/1950-1959/1956/verifierE2.go` *(failed: hung, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b820af9c83249f667ff120f74158