### PR TITLE
Fix input format in 1988B verifier

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1988/verifierB.go
+++ b/1000-1999/1900-1999/1980-1989/1988/verifierB.go
@@ -30,13 +30,18 @@ func generate() (string, string) {
 				ones++
 			}
 		}
-		s := string(sb)
-		fmt.Fprintf(&in, "%d %s\n", n, s)
-		if ones > groups {
-			fmt.Fprintln(&out, "YES")
-		} else {
-			fmt.Fprintln(&out, "NO")
-		}
+               s := string(sb)
+               // According to the problem statement, the length and the string
+               // should be provided on separate lines. The previous implementation
+               // printed them on the same line, which caused solutions that
+               // expect the official format to fail with a parse error. Print
+               // `n` and `s` on individual lines to match the statement.
+               fmt.Fprintf(&in, "%d\n%s\n", n, s)
+               if ones > groups {
+                       fmt.Fprintln(&out, "YES")
+               } else {
+                       fmt.Fprintln(&out, "NO")
+               }
 	}
 	return in.String(), out.String()
 }


### PR DESCRIPTION
## Summary
- Correct 1988B verifier to print `n` and string on separate lines
- Document mismatch with problem statement to avoid parse errors

## Testing
- `go run verifierB.go ./1988B_bin`


------
https://chatgpt.com/codex/tasks/task_e_68a1c3048c6483249933ddbda7e5a001