### PR TITLE
Fix 1707A oracle algorithm

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1707/1707A.go
+++ b/1000-1999/1700-1799/1700-1709/1707/1707A.go
@@ -22,13 +22,13 @@ func main() {
 			fmt.Fscan(in, &a[i])
 		}
 		res := make([]byte, n)
-		iq := q
+		cur := 0
 		for i := n - 1; i >= 0; i-- {
-			if a[i] <= iq {
+			if a[i] <= cur {
 				res[i] = '1'
-			} else if iq > 0 {
+			} else if cur < q {
+				cur++
 				res[i] = '1'
-				iq--
 			} else {
 				res[i] = '0'
 			}


### PR DESCRIPTION
## Summary
- Correct 1707A oracle to use forward IQ budget (`cur`) instead of decrementing `q`
- Greedy now tests contests from the end while only increasing `cur` when needed

## Testing
- `go build 1000-1999/1700-1799/1700-1709/1707/1707A.go`
- `go run 1000-1999/1700-1799/1700-1709/1707/verifierA.go /tmp/1707A_rs`


------
https://chatgpt.com/codex/tasks/task_e_68a1c57d5f308324b68a12ae55df8473