### PR TITLE
Fix 875B verifier input format

### DIFF
--- a/0-999/800-899/870-879/875/verifierB.go
+++ b/0-999/800-899/870-879/875/verifierB.go
@@ -50,7 +50,14 @@ func main() {
 			continue
 		}
 		idx++
-		input := line + "\n"
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		input := fields[0] + "\n"
+		if len(fields) > 1 {
+			input += strings.Join(fields[1:], " ") + "\n"
+		}
 		cmdO := exec.Command(oracle)
 		cmdO.Stdin = strings.NewReader(input)
 		var outO bytes.Buffer


### PR DESCRIPTION
## Summary
- Handle 875B test cases that contain all numbers on one line by splitting tokens into two-line input expected by some solutions

## Testing
- `go vet 0-999/800-899/870-879/875/verifierB.go`
- `go run verifierB.go ./oracleB`

------
https://chatgpt.com/codex/tasks/task_e_68a1c666c4108324bf2abf8aeec8bc11