### PR TITLE
Fix 649B verifier case for same entrance

### DIFF
--- a/0-999/600-699/640-649/649/649B.go
+++ b/0-999/600-699/640-649/649/649B.go
@@ -40,6 +40,12 @@ func main() {
 
 	diff := abs(entranceA - entranceB)
 	walk := min(diff, n-diff) * 15
+	via := downA + walk + upB
 
-	fmt.Println(downA + walk + upB)
+	if entranceA == entranceB {
+		direct := min(abs(floorA-floorB)*5, 10+abs(floorA-floorB))
+		fmt.Println(min(direct, via))
+	} else {
+		fmt.Println(via)
+	}
 }

--- a/0-999/600-699/640-649/649/verifierB.go
+++ b/0-999/600-699/640-649/649/verifierB.go
@@ -46,8 +46,13 @@ func generateCase(rng *rand.Rand) (string, string) {
 	upB := min((floorB-1)*5, 10+(floorB-1))
 	diff := abs(entranceA - entranceB)
 	walk := min(diff, n-diff) * 15
-	exp := fmt.Sprintf("%d\n", downA+walk+upB)
-	return sb.String(), exp
+	via := downA + walk + upB
+	ans := via
+	if entranceA == entranceB {
+		direct := min(abs(floorA-floorB)*5, 10+abs(floorA-floorB))
+		ans = min(ans, direct)
+	}
+	return sb.String(), fmt.Sprintf("%d\n", ans)
 }
 
 func runCase(exe, input, expected string) error {


### PR DESCRIPTION
## Summary
- Handle same-entrance paths in problem 649B
- Update verifierB to compute expected answers correctly when apartments share an entrance

## Testing
- `go build 0-999/600-699/640-649/649/649B.go`
- `go build 0-999/600-699/640-649/649/verifierB.go`
- `go run 0-999/600-699/640-649/649/verifierB.go /tmp/sol`


------
https://chatgpt.com/codex/tasks/task_e_68a1c724c16083249d86eef16c229308