### PR TITLE
Fix verifier for 479B

### DIFF
--- a/0-999/400-499/470-479/479/verifierB.go
+++ b/0-999/400-499/470-479/479/verifierB.go
@@ -62,12 +62,16 @@ func main() {
 			fmt.Printf("test %d: wrong number of values\n", idx)
 			os.Exit(1)
 		}
-		arr := make([]string, n)
+		arr := make([]int, n)
+		arrStr := make([]string, n)
 		for i := 0; i < n; i++ {
-			arr[i] = parts[2+i]
+			arrStr[i] = parts[2+i]
+			val, _ := strconv.Atoi(parts[2+i])
+			arr[i] = val
 		}
-		input := fmt.Sprintf("%d %d\n%s\n", n, k, strings.Join(arr, " "))
-		// run oracle
+		input := fmt.Sprintf("%d %d\n%s\n", n, k, strings.Join(arrStr, " "))
+
+		// run oracle to get minimal achievable difference
 		cmdO := exec.Command(oracle)
 		cmdO.Stdin = strings.NewReader(input)
 		var outO bytes.Buffer
@@ -76,8 +80,13 @@ func main() {
 			fmt.Fprintf(os.Stderr, "oracle run error: %v\n", err)
 			os.Exit(1)
 		}
-		expected := strings.TrimSpace(outO.String())
+		var expectedDiff, dummy int
+		if _, err := fmt.Fscan(bytes.NewReader(outO.Bytes()), &expectedDiff, &dummy); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to parse oracle output: %v\n", err)
+			os.Exit(1)
+		}
 
+		// run candidate solution
 		cmd := exec.Command(bin)
 		cmd.Stdin = strings.NewReader(input)
 		var out bytes.Buffer
@@ -89,9 +98,56 @@ func main() {
 			fmt.Printf("test %d: runtime error: %v\nstderr: %s\n", idx, err, stderr.String())
 			os.Exit(1)
 		}
-		got := strings.TrimSpace(out.String())
-		if got != expected {
-			fmt.Printf("test %d failed. Expected\n%s\nGot\n%s\n", idx, expected, got)
+
+		reader := bufio.NewReader(bytes.NewReader(out.Bytes()))
+		var s, t int
+		if _, err := fmt.Fscan(reader, &s, &t); err != nil {
+			fmt.Printf("test %d: failed to read s and t: %v\n", idx, err)
+			os.Exit(1)
+		}
+		if t < 0 || t > k {
+			fmt.Printf("test %d: invalid number of operations %d\n", idx, t)
+			os.Exit(1)
+		}
+
+		// apply operations
+		h := make([]int, n)
+		copy(h, arr)
+		for op := 0; op < t; op++ {
+			var i, j int
+			if _, err := fmt.Fscan(reader, &i, &j); err != nil {
+				fmt.Printf("test %d: failed to read operation %d: %v\n", idx, op+1, err)
+				os.Exit(1)
+			}
+			if i < 1 || i > n || j < 1 || j > n {
+				fmt.Printf("test %d: operation %d has invalid indices %d %d\n", idx, op+1, i, j)
+				os.Exit(1)
+			}
+			if h[i-1] <= h[j-1] {
+				fmt.Printf("test %d: operation %d moves from non-taller tower %d to %d\n", idx, op+1, i, j)
+				os.Exit(1)
+			}
+			h[i-1]--
+			h[j-1]++
+		}
+
+		// compute resulting difference
+		minH, maxH := h[0], h[0]
+		for i := 1; i < n; i++ {
+			if h[i] < minH {
+				minH = h[i]
+			}
+			if h[i] > maxH {
+				maxH = h[i]
+			}
+		}
+		diff := maxH - minH
+		if diff != s {
+			fmt.Printf("test %d: reported diff %d but got %d\n", idx, s, diff)
+			os.Exit(1)
+		}
+		if s != expectedDiff {
+			fmt.Printf("test %d: expected minimal diff %d, but got %d\n", idx, expectedDiff, s)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Summary
- Update 479B verifier to parse candidate output and validate operations instead of exact string comparison
- Ensure final tower heights match reported and optimal differences

## Testing
- `go vet 0-999/400-499/470-479/479/verifierB.go`
- `go build 0-999/400-499/470-479/479/verifierB.go`
- `cd 0-999/400-499/470-479/479 && go build -o sol 479B.go && go run verifierB.go ./sol`


------
https://chatgpt.com/codex/tasks/task_e_68a1c7b17bd083248022551613c3560a