### PR TITLE
Handle empty output in 7B verifier

### DIFF
--- a/0-999/0-99/0-9/7/verifierB.go
+++ b/0-999/0-99/0-9/7/verifierB.go
@@ -138,7 +138,13 @@ func main() {
 			fmt.Printf("Test %d: runtime error: %v\n", idx, err)
 			os.Exit(1)
 		}
-		outLines := strings.Split(strings.TrimSpace(string(out)), "\n")
+		trimmed := strings.TrimSpace(string(out))
+		var outLines []string
+		if trimmed == "" {
+			outLines = []string{}
+		} else {
+			outLines = strings.Split(trimmed, "\n")
+		}
 		if len(outLines) != len(exp) {
 			fmt.Printf("Test %d failed: expected %d lines got %d\n", idx, len(exp), len(outLines))
 			os.Exit(1)


### PR DESCRIPTION
## Summary
- Avoid counting a blank line when the tested solution produces no output for a test case

## Testing
- `go run verifierB.go ../../../../7B.bin`

------
https://chatgpt.com/codex/tasks/task_e_68a1ccaccf408324a021a81477df17f2