### PR TITLE
Fix verifier for 1101C to validate arbitrary correct partitions

### DIFF
--- a/1000-1999/1100-1199/1100-1109/1101/verifierC.go
+++ b/1000-1999/1100-1199/1100-1109/1101/verifierC.go
@@ -11,62 +11,78 @@ import (
 	"strings"
 )
 
-type segment struct{ l, r, id int }
+type segment struct{ l, r int }
 
-func solveCase(segs []segment) string {
-	n := len(segs)
+type testCase struct {
+	segs     []segment
+	possible bool
+}
+
+func canSplit(segs []segment) bool {
 	sort.Slice(segs, func(i, j int) bool {
 		if segs[i].l != segs[j].l {
 			return segs[i].l < segs[j].l
 		}
 		return segs[i].r < segs[j].r
 	})
-	clusters := 1
 	curR := segs[0].r
-	for i := 1; i < n; i++ {
-		if segs[i].l <= curR {
-			if segs[i].r > curR {
-				curR = segs[i].r
-			}
+	for i := 1; i < len(segs); i++ {
+		if segs[i].l > curR {
+			return true
+		}
+		if segs[i].r > curR {
+			curR = segs[i].r
+		}
+	}
+	return false
+}
+
+func validate(line string, tc testCase) error {
+	line = strings.TrimSpace(line)
+	if line == "-1" {
+		if tc.possible {
+			return fmt.Errorf("partition exists but got -1")
+		}
+		return nil
+	}
+	if !tc.possible {
+		return fmt.Errorf("partition not possible but got result")
+	}
+	fields := strings.Fields(line)
+	if len(fields) != len(tc.segs) {
+		return fmt.Errorf("expected %d numbers, got %d", len(tc.segs), len(fields))
+	}
+	groups := make([]int, len(tc.segs))
+	has1, has2 := false, false
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", f)
+		}
+		if v != 1 && v != 2 {
+			return fmt.Errorf("invalid group %d", v)
+		}
+		groups[i] = v
+		if v == 1 {
+			has1 = true
 		} else {
-			clusters++
-			if segs[i].r > curR {
-				curR = segs[i].r
+			has2 = true
+		}
+	}
+	if !has1 || !has2 {
+		return fmt.Errorf("both groups must be non-empty")
+	}
+	segs := tc.segs
+	for i := 0; i < len(segs); i++ {
+		for j := i + 1; j < len(segs); j++ {
+			if groups[i] != groups[j] {
+				if !(segs[i].r < segs[j].l || segs[j].r < segs[i].l) {
+					return fmt.Errorf("segments %d and %d intersect but have different groups", i+1, j+1)
+				}
 			}
 		}
 	}
-	if clusters < 2 {
-		return "-1"
-	}
-	out := make([]int, n)
-	group := 1
-	curR = segs[0].r
-	out[segs[0].id] = group
-	for i := 1; i < n; i++ {
-		if segs[i].l <= curR {
-			out[segs[i].id] = group
-			if segs[i].r > curR {
-				curR = segs[i].r
-			}
-		} else {
-			group++
-			if group > 2 {
-				group = 2
-			}
-			out[segs[i].id] = group
-			if segs[i].r > curR {
-				curR = segs[i].r
-			}
-		}
-	}
-	var buf bytes.Buffer
-	for i, v := range out {
-		if i > 0 {
-			buf.WriteByte(' ')
-		}
-		fmt.Fprint(&buf, v)
-	}
-	return buf.String()
+	return nil
 }
 
 func main() {
@@ -90,7 +106,7 @@ func main() {
 		os.Exit(1)
 	}
 	t, _ := strconv.Atoi(scan.Text())
-	expected := make([]string, t)
+	cases := make([]testCase, t)
 	for i := 0; i < t; i++ {
 		if !scan.Scan() {
 			fmt.Println("bad file")
@@ -103,9 +119,11 @@ func main() {
 			l, _ := strconv.Atoi(scan.Text())
 			scan.Scan()
 			r, _ := strconv.Atoi(scan.Text())
-			segs[j] = segment{l: l, r: r, id: j}
+			segs[j] = segment{l: l, r: r}
 		}
-		expected[i] = solveCase(segs)
+		segCopy := make([]segment, n)
+		copy(segCopy, segs)
+		cases[i] = testCase{segs: segs, possible: canSplit(segCopy)}
 	}
 	cmd := exec.Command(bin)
 	cmd.Stdin = bytes.NewReader(data)
@@ -121,9 +139,9 @@ func main() {
 			fmt.Printf("missing output for test %d\n", i+1)
 			os.Exit(1)
 		}
-		got := strings.TrimSpace(outScan.Text())
-		if got != expected[i] {
-			fmt.Printf("test %d failed:\nexpected: %s\ngot: %s\n", i+1, expected[i], got)
+		line := outScan.Text()
+		if err := validate(line, cases[i]); err != nil {
+			fmt.Printf("test %d failed: %v\n", i+1, err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Summary
- update 1101C verifier to compute validity instead of expecting a single answer
- validate contestant output: two non-empty groups labeled 1 or 2 with no cross intersections

## Testing
- `go vet 1000-1999/1100-1199/1100-1109/1101/verifierC.go`
- `cd 1000-1999/1100-1199/1100-1109/1101 && go run verifierC.go ./solver`

------
https://chatgpt.com/codex/tasks/task_e_68a1e0a46f208324823bc91323a0f109