### PR TITLE
Fix 981C verifier for path trees

### DIFF
--- a/0-999/900-999/980-989/981/981C.go
+++ b/0-999/900-999/980-989/981/981C.go
@@ -1,47 +1,66 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   var n int
-   if _, err := fmt.Fscan(reader, &n); err != nil {
-       return
-   }
-   deg := make([]int, n+1)
-   for i := 1; i < n; i++ {
-       var u, v int
-       fmt.Fscan(reader, &u, &v)
-       deg[u]++
-       deg[v]++
-   }
-   cnt := 0
-   for i := 1; i <= n; i++ {
-       if deg[i] > 2 {
-           cnt++
-           if cnt > 1 {
-               fmt.Println("No")
-               return
-           }
-       }
-   }
-   // find node with maximum degree
-   pre := 1
-   for i := 1; i <= n; i++ {
-       if deg[i] > deg[pre] {
-           pre = i
-       }
-   }
-   fmt.Println("Yes")
-   fmt.Println(deg[pre])
-   // connect center to all leaves
-   for i := 1; i <= n; i++ {
-       if i != pre && deg[i] == 1 {
-           fmt.Printf("%d %d\n", pre, i)
-       }
-   }
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	adj := make([][]int, n+1)
+	for i := 0; i < n-1; i++ {
+		var u, v int
+		fmt.Fscan(reader, &u, &v)
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+
+	if n == 1 {
+		fmt.Println("Yes")
+		fmt.Println(0)
+		return
+	}
+
+	deg := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		deg[i] = len(adj[i])
+	}
+
+	hub := -1
+	for i := 1; i <= n; i++ {
+		if deg[i] > 2 {
+			if hub == -1 {
+				hub = i
+			} else {
+				fmt.Println("No")
+				return
+			}
+		}
+	}
+
+	fmt.Println("Yes")
+	if hub == -1 {
+		// tree is a simple path
+		var ends []int
+		for i := 1; i <= n; i++ {
+			if deg[i] == 1 {
+				ends = append(ends, i)
+			}
+		}
+		fmt.Println(1)
+		fmt.Printf("%d %d\n", ends[0], ends[1])
+		return
+	}
+
+	fmt.Println(deg[hub])
+	for i := 1; i <= n; i++ {
+		if deg[i] == 1 {
+			fmt.Printf("%d %d\n", hub, i)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Correct 981C oracle to handle path-only trees
- Output single path between leaves when there is no high-degree node

## Testing
- `go build -o sol 0-999/900-999/980-989/981/981C.go`
- `cd 0-999/900-999/980-989/981 && go run verifierC.go ./sol`

------
https://chatgpt.com/codex/tasks/task_e_68a1e25142ac83249068f1662b32f268