### PR TITLE
Fix reference binary path in 1391C verifier

### DIFF
--- a/1000-1999/1300-1399/1390-1399/1391/verifierC.go
+++ b/1000-1999/1300-1399/1390-1399/1391/verifierC.go
@@ -10,12 +10,12 @@ import (
 )
 
 func buildRef() (string, error) {
-	ref := "refC.bin"
-	cmd := exec.Command("go", "build", "-o", ref, "1391C.go")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
-	}
-	return ref, nil
+        ref := "./refC.bin"
+        cmd := exec.Command("go", "build", "-o", ref, "1391C.go")
+        if out, err := cmd.CombinedOutput(); err != nil {
+                return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+        }
+        return ref, nil
 }
 
 func runBinary(bin, input string) (string, string, error) {


### PR DESCRIPTION
## Summary
- ensure verifier for 1391C executes the built reference binary from the current directory

## Testing
- `go build verifierC.go && ./verifierC 1391C.go`

------
https://chatgpt.com/codex/tasks/task_e_68a1e86421ec8324b4a435d6d7f3ff0c