### PR TITLE
Fix 1822E verifier input formatting

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1822/verifierE.go
+++ b/1000-1999/1800-1899/1820-1829/1822/verifierE.go
@@ -95,7 +95,7 @@ func main() {
 			os.Exit(1)
 		}
 		s := scan.Text()
-		input := fmt.Sprintf("1\n%d %s\n", n, s)
+		input := fmt.Sprintf("1\n%d\n%s\n", n, s)
 		exp := solveCase(n, s)
 		got, err := runExe(bin, input)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Correct the verifier for problem 1822E to send `n` and `s` on separate lines when invoking the contestant program.

## Testing
- `go run verifierE.go /tmp/sol_rust`

------
https://chatgpt.com/codex/tasks/task_e_68a1eb14ce34832481805ebccbb95702