### PR TITLE
Agent: For problem 999F this is a correct solution, but verifier ends…

### DIFF
--- a/0-999/900-999/990-999/999/verifierF.go
+++ b/0-999/900-999/990-999/999/verifierF.go
@@ -1,107 +1,111 @@
 package main
 
 import (
-	"bytes"
-	"fmt"
-	"math/rand"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
 )
 
 func buildRef() (string, error) {
-	ref := "./refF.bin"
-	cmd := exec.Command("go", "build", "-o", ref, "999F.go")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
-	}
-	return ref, nil
+    ref := "./refF.bin"
+    cmd := exec.Command("go", "build", "-o", ref, "999F.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+    }
+    return ref, nil
 }
 
 func runBinary(bin, input string) (string, string, error) {
-	var cmd *exec.Cmd
-	if strings.HasSuffix(bin, ".go") {
-		cmd = exec.Command("go", "run", bin)
-	} else {
-		cmd = exec.Command(bin)
-	}
-	cmd.Stdin = strings.NewReader(input)
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return strings.TrimSpace(out.String()), stderr.String(), err
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var stderr bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), stderr.String(), err
 }
 
 type testCase struct{ input string }
 
 func genCase(rng *rand.Rand) testCase {
-	n := rng.Intn(4) + 1
-	k := rng.Intn(4) + 1
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
-	total := n * k
-	for i := 0; i < total; i++ {
-		sb.WriteString(strconv.Itoa(rng.Intn(5) + 1))
-		if i+1 < total {
-			sb.WriteByte(' ')
-		}
-	}
-	sb.WriteByte('\n')
-	for i := 0; i < n; i++ {
-		if i > 0 {
-			sb.WriteByte(' ')
-		}
-		sb.WriteString(strconv.Itoa(rng.Intn(5) + 1))
-	}
-	sb.WriteByte('\n')
-	for i := 0; i < k; i++ {
-		sb.WriteString(strconv.Itoa(rng.Intn(7)))
-		if i+1 < k {
-			sb.WriteByte(' ')
-		}
-	}
-	sb.WriteByte('\n')
-	return testCase{sb.String()}
+    n := rng.Intn(4) + 1
+    k := rng.Intn(4) + 1
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+    total := n * k
+    for i := 0; i < total; i++ {
+        sb.WriteString(strconv.Itoa(rng.Intn(5) + 1))
+        if i+1 < total {
+            sb.WriteByte(' ')
+        }
+    }
+    sb.WriteByte('\n')
+    for i := 0; i < n; i++ {
+        if i > 0 {
+            sb.WriteByte(' ')
+        }
+        sb.WriteString(strconv.Itoa(rng.Intn(5) + 1))
+    }
+    sb.WriteByte('\n')
+    // Generate non-decreasing happiness values h[1..k] as per CF constraints
+    last := 0
+    for i := 0; i < k; i++ {
+        // increase by 0..3 to keep values reasonable but non-decreasing
+        last += rng.Intn(4)
+        sb.WriteString(strconv.Itoa(last))
+        if i+1 < k {
+            sb.WriteByte(' ')
+        }
+    }
+    sb.WriteByte('\n')
+    return testCase{sb.String()}
 }
 
 func runCase(bin, ref string, tc testCase, idx int) error {
-	expOut, expErr, err := runBinary(ref, tc.input)
-	if err != nil {
-		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
-	}
-	gotOut, gotErr, err := runBinary(bin, tc.input)
-	if err != nil {
-		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
-	}
-	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
-		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
-	}
-	return nil
+    expOut, expErr, err := runBinary(ref, tc.input)
+    if err != nil {
+        return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+    }
+    gotOut, gotErr, err := runBinary(bin, tc.input)
+    if err != nil {
+        return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+    }
+    if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+        return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+    }
+    return nil
 }
 
 func main() {
-	if len(os.Args) != 2 {
-		fmt.Println("usage: go run verifierF.go /path/to/binary")
-		os.Exit(1)
-	}
-	bin := os.Args[1]
-	ref, err := buildRef()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	defer os.Remove(ref)
+    if len(os.Args) != 2 {
+        fmt.Println("usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    ref, err := buildRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
 
-	rng := rand.New(rand.NewSource(99))
-	for i := 1; i <= 100; i++ {
-		tc := genCase(rng)
-		if err := runCase(bin, ref, tc, i); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-	}
-	fmt.Println("All tests passed")
+    rng := rand.New(rand.NewSource(99))
+    for i := 1; i <= 100; i++ {
+        tc := genCase(rng)
+        if err := runCase(bin, ref, tc, i); err != nil {
+            fmt.Fprintln(os.Stderr, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
 }


### PR DESCRIPTION
… with test 1 failedexpected: 12 got: 8exit status 1 can you fix the verifier? package mainimport (	"bufio"	"fmt"	"os"	"strconv")func max(a, b int) int {	if a > b {		return a	}	return b}func min(a, b int) int {	if a < b {		return a	}	return b}func main() {	scanner := bufio.NewScanner(os.Stdin)	scanner.Split(bufio.ScanWords)	readInt := func() int {		scanner.Scan()		i, _ := strconv.Atoi(scanner.Text())		return i	}	n := readInt()	k := readInt()	cardCounts := make(map[int]int)	for i := 0; i < n*k; i++ {		c := readInt()		cardCounts[c]++	}	playerFavs := make(map[int]int)	for i := 0; i < n; i++ {		f := readInt()		playerFavs[f]++	}	H := make([]int, k+1)	for i := 1; i <= k; i++ {		H[i] = readInt()	}	totalJoy := 0	for favNum, playerCount := range playerFavs {		cardCount, ok := cardCounts[favNum]		if !ok || cardCount == 0 {			continue		}		if playerCount == 1 {			t := min(k, cardCount)			totalJoy += H[t]		} else {			dp := make([]int, cardCount+1)			for i := 1; i <= playerCount; i++ {				for j := cardCount; j >= 0; j-- {					for t := 1; t <= k; t++ {						if j-t >= 0 {							dp[j] = max(dp[j], dp[j-t]+H[t])						} else {							break						}					}				}			}			totalJoy += dp[cardCount]		}	}	fmt.Println(totalJoy)}